### PR TITLE
chore: add CODEOWNERS for owner approval

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Require repository owner approval for all changes.
+* @ohmzi
+


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Establishes repository-wide code ownership to enforce owner review on all changes.
> 
> - Adds `.github/CODEOWNERS` mapping `*` to `@ohmzi`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91210e35c20fc91625fc31122fb8a0bf8bd9c031. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->