### PR TITLE
Docker: build from source (remove GHCR image reference)

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -40,8 +40,7 @@ Getting Started (Docker)
 Immaculaterr is designed to run as a single container.
 
 ```bash
-docker compose -f docker/immaculaterr/docker-compose.yml pull
-docker compose -f docker/immaculaterr/docker-compose.yml up -d
+docker compose -f docker/immaculaterr/docker-compose.yml up -d --build
 ```
 
 Then open `http://<server-ip>:3210/` and configure integrations in the UI (Plex/Radarr/Sonarr/TMDB/OpenAI/Google as desired).

--- a/docker/immaculaterr/docker-compose.yml
+++ b/docker/immaculaterr/docker-compose.yml
@@ -3,8 +3,6 @@ name: immaculaterr
 services:
   immaculaterr:
     container_name: immaculaterr
-    # Default: pull from GitHub Container Registry (GHCR). Override for forks via IMM_IMAGE/IMM_TAG.
-    image: ${IMM_IMAGE:-ghcr.io/ohmz/immaculaterr}:${IMM_TAG:-latest}
     build:
       context: ../..
       dockerfile: docker/immaculaterr/Dockerfile


### PR DESCRIPTION
Removes the default GHCR image reference from docker-compose so the repo doesn't point at a prebuilt image. Updates docs to use Usage:  docker compose [OPTIONS] COMMAND

Define and run multi-container applications with Docker

Options:
      --all-resources              Include all resources, even those not
                                   used by services
      --ansi string                Control when to print ANSI control
                                   characters ("never"|"always"|"auto")
                                   (default "auto")
      --compatibility              Run compose in backward compatibility mode
      --dry-run                    Execute command in dry run mode
      --env-file stringArray       Specify an alternate environment file
  -f, --file stringArray           Compose configuration files
      --parallel int               Control max parallelism, -1 for
                                   unlimited (default -1)
      --profile stringArray        Specify a profile to enable
      --progress string            Set type of progress output (auto,
                                   tty, plain, json, quiet) (default "auto")
      --project-directory string   Specify an alternate working directory
                                   (default: the path of the, first
                                   specified, Compose file)
  -p, --project-name string        Project name

Commands:
  attach      Attach local standard input, output, and error streams to a service's running container
  build       Build or rebuild services
  commit      Create a new image from a service container's changes
  config      Parse, resolve and render compose file in canonical format
  cp          Copy files/folders between a service container and the local filesystem
  create      Creates containers for a service
  down        Stop and remove containers, networks
  events      Receive real time events from containers
  exec        Execute a command in a running container
  export      Export a service container's filesystem as a tar archive
  images      List images used by the created containers
  kill        Force stop service containers
  logs        View output from containers
  ls          List running compose projects
  pause       Pause services
  port        Print the public port for a port binding
  ps          List containers
  publish     Publish compose application
  pull        Pull service images
  push        Push service images
  restart     Restart service containers
  rm          Removes stopped service containers
  run         Run a one-off command on a service
  scale       Scale services 
  start       Start services
  stats       Display a live stream of container(s) resource usage statistics
  stop        Stop services
  top         Display the running processes
  unpause     Unpause services
  up          Create and start containers
  version     Show the Docker Compose version information
  wait        Block until containers of all (or specified) services stop.
  watch       Watch build context for service and rebuild/refresh containers when files are updated

Run 'docker compose COMMAND --help' for more information on a command..

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches Docker usage to build the image locally instead of pulling from GHCR.
> 
> - Updates `docker/immaculaterr/docker-compose.yml` to remove the `image` reference and rely solely on `build` (local Dockerfile context)
> - Updates `doc/README.md` Docker quickstart to `docker compose -f docker/immaculaterr/docker-compose.yml up -d --build` (removes separate `pull` step)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2575abb75cb360bd49fc2383cfcf48a3dae91cbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->