### PR TITLE
Meta: issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Report something that isn’t working
+title: "[Bug]: "
+labels: bug
+assignees: ''
+---
+
+## App version
+
+Found in Help → Version:
+
+## Deployment
+
+- [ ] Docker
+- [ ] Local (node)
+- [ ] Other
+
+## What happened?
+
+What did you expect to happen?
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Logs / screenshots (optional)
+
+Paste relevant logs (redact tokens) or attach screenshots.
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature request
+about: Suggest an idea or improvement
+title: "[Feature]: "
+labels: enhancement
+assignees: ''
+---
+
+## What problem are you trying to solve?
+
+## What would you like to see?
+
+## Alternatives you’ve considered (optional)
+
+## Additional context (optional)
+


### PR DESCRIPTION
Adds markdown issue templates so GitHub community profile recognizes issue templates (in addition to the YAML issue forms already present).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces GitHub-friendly markdown issue templates to structure incoming issues and improve community profile recognition.
> 
> - Add `.github/ISSUE_TEMPLATE/bug_report.md` with sections for `App version`, `Deployment`, what happened/expected, `Steps to reproduce`, and `Logs/screenshots`
> - Add `.github/ISSUE_TEMPLATE/feature_request.md` with sections for problem statement, desired outcome, alternatives, and additional context
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aea34525f858620b6df57dec1bf580c72cb199e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->