### PR TITLE
Potential fix for code scanning alert no. 2: Server-side request forgery

### DIFF
--- a/apps/api/src/plex/plex-server.service.ts
+++ b/apps/api/src/plex/plex-server.service.ts
@@ -1032,6 +1032,16 @@ export class PlexServerService {
     const q = title.trim();
     if (!q) return null;
 
+    // Ensure librarySectionKey is in the expected safe format (numeric ID) to
+    // prevent path manipulation or SSRF-style issues when constructing URLs.
+    // Plex library section IDs are numeric, so reject anything else.
+    if (!/^[1-9]\d*$/.test(librarySectionKey.trim())) {
+      this.logger.warn(
+        `Ignoring invalid Plex librarySectionKey: ${librarySectionKey}`,
+      );
+      return null;
+    }
+
     const url = new URL(
       `library/sections/${librarySectionKey}/search?type=1&query=${encodeURIComponent(q)}`,
       normalizeBaseUrl(baseUrl),


### PR DESCRIPTION
Potential fix for [https://github.com/ohmzi/Immaculaterr/security/code-scanning/2](https://github.com/ohmzi/Immaculaterr/security/code-scanning/2)

In general, the fix is to constrain user-controlled values before including them in any portion of an outgoing request URL. Here, the risky value is `librarySectionKey`, which is derived from user input (`seedLibrarySectionIdRaw`) and used as a path segment in `findMovieRatingKeyByTitle`. We want to enforce that this value matches the expected format of a Plex library section key (e.g., a positive integer or some conservative pattern) before using it, and reject or sanitize anything that does not conform. This removes the ability to inject arbitrary sequences like `../` into the path and makes the CodeQL dataflow safe.

The most direct, minimal-impact change is to validate `librarySectionKey` **inside `findMovieRatingKeyByTitle`**, since that is the function that actually uses it to construct the URL. That centralizes the protection even if other callers are added later. We can add a small guard that checks `librarySectionKey` against a strict regular expression (for example, `/^[1-9]\d*$/` which allows only non‑zero positive integers) and immediately returns `null` (or throws) if the input is invalid. Returning `null` aligns with the method’s existing “no match” result, avoiding functional changes for valid values while preventing use of unexpected ones. This guard happens before the `new URL(...)` call, so the URL passed into `fetchXml` is no longer tainted with arbitrary user input.

Concretely, in `apps/api/src/plex/plex-server.service.ts`, in `findMovieRatingKeyByTitle`, add a simple validation right after destructuring `params` and before building `url`. No other files need changes. The change will be: after `const { baseUrl, token, librarySectionKey, title } = params;`, insert something like:

```ts
// Ensure librarySectionKey is a simple positive integer to prevent path manipulation.
if (!/^[1-9]\d*$/.test(librarySectionKey)) {
  this.logger.warn(`Ignoring invalid Plex librarySectionKey: ${librarySectionKey}`);
  return null;
}
```

This uses only standard RegExp and the already-imported `Logger` via `this.logger`, so no new imports are necessary. It maintains existing behavior for legitimate keys and prevents malformed user input from influencing the request path.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
