### PR TITLE
ci: add publish-containers workflow

### DIFF
--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -1,0 +1,94 @@
+name: Publish containers (GHCR + Docker Hub)
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: containers-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub (optional)
+        if: ${{ secrets.DOCKERHUB_TOKEN }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Compute tags
+        id: vars
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          VERSION="$(
+            node -e "const fs=require('fs');const s=fs.readFileSync('apps/api/src/app.meta.ts','utf8');const m=s.match(/DEFAULT_APP_VERSION\\s*=\\s*'([^']+)'/);process.stdout.write((m&&m[1]?m[1].trim():'')||'0.0.0.0')"
+          )"
+
+          OWNER_LC="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
+          GHCR_IMAGE="ghcr.io/${OWNER_LC}/immaculaterr"
+          DOCKERHUB_IMAGE="docker.io/ohmzii/immaculaterr"
+          BUILD_TIME="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "ghcr_image=${GHCR_IMAGE}" >> "${GITHUB_OUTPUT}"
+          echo "dockerhub_image=${DOCKERHUB_IMAGE}" >> "${GITHUB_OUTPUT}"
+          echo "build_time=${BUILD_TIME}" >> "${GITHUB_OUTPUT}"
+
+          echo "tags<<EOF" >> "${GITHUB_OUTPUT}"
+          echo "${GHCR_IMAGE}:latest" >> "${GITHUB_OUTPUT}"
+          echo "${GHCR_IMAGE}:${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "${GHCR_IMAGE}:v${VERSION}" >> "${GITHUB_OUTPUT}"
+          if [[ -n "${DOCKERHUB_TOKEN:-}" ]]; then
+            echo "${DOCKERHUB_IMAGE}:latest" >> "${GITHUB_OUTPUT}"
+            echo "${DOCKERHUB_IMAGE}:${VERSION}" >> "${GITHUB_OUTPUT}"
+            echo "${DOCKERHUB_IMAGE}:v${VERSION}" >> "${GITHUB_OUTPUT}"
+          fi
+          echo "EOF" >> "${GITHUB_OUTPUT}"
+        env:
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push (multi-arch)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/immaculaterr/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.vars.outputs.tags }}
+          labels: |
+            org.opencontainers.image.title=Immaculaterr
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.vars.outputs.version }}
+            org.opencontainers.image.created=${{ steps.vars.outputs.build_time }}
+          build-args: |
+            APP_VERSION=${{ steps.vars.outputs.version }}
+            APP_BUILD_SHA=${{ github.sha }}
+            APP_BUILD_TIME=${{ steps.vars.outputs.build_time }}
+


### PR DESCRIPTION
Add a minimal publish workflow that pushes multi-arch images to GHCR (and optionally Docker Hub if secrets exist). This unblocks package publishing.