### PR TITLE
ci: fix concurrency group expressions

### DIFF
--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -10,7 +10,7 @@ permissions:
   packages: write
 
 concurrency:
-  group: containers-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -10,7 +10,7 @@ permissions:
   packages: write
 
 concurrency:
-  group: ghcr-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Fix concurrency.group to use valid GitHub expression syntax so workflows no longer fail before creating jobs.