### PR TITLE
ci: fix badge-ghcr-package-downloads workflow

### DIFF
--- a/.github/workflows/badge-ghcr-package-downloads.yml
+++ b/.github/workflows/badge-ghcr-package-downloads.yml
@@ -1,6 +1,6 @@
 name: Badge: GHCR package downloads
 
-on:
+"on":
   schedule:
     # Update periodically (GitHub schedules may be delayed)
     - cron: '17 * * * *'


### PR DESCRIPTION
Fix workflow YAML parsing by quoting the top-level "on" key (prevents YAML 1.1 boolean parsing issues that can cause GitHub to reject the workflow).