### PR TITLE
ci: fix GHCR downloads badge workflow

### DIFF
--- a/.github/workflows/badge-ghcr-package-downloads.yml
+++ b/.github/workflows/badge-ghcr-package-downloads.yml
@@ -1,4 +1,4 @@
-name: Badge: GHCR package downloads
+name: "Badge: GHCR package downloads"
 
 "on":
   schedule:


### PR DESCRIPTION
Fix invalid YAML in badge workflow (quote name containing a colon) and keep "on" as a string key. This unblocks the workflow so download counts can update.