### PR TITLE
ci: Docker Hub tags use v-prefixed versions

### DIFF
--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -70,7 +70,6 @@ jobs:
           echo "${GHCR_IMAGE}:v${VERSION}" >> "${GITHUB_OUTPUT}"
           if [[ -n "${DOCKERHUB_TOKEN:-}" ]]; then
             echo "${DOCKERHUB_IMAGE}:latest" >> "${GITHUB_OUTPUT}"
-            echo "${DOCKERHUB_IMAGE}:${VERSION}" >> "${GITHUB_OUTPUT}"
             echo "${DOCKERHUB_IMAGE}:v${VERSION}" >> "${GITHUB_OUTPUT}"
           fi
           echo "EOF" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -78,7 +78,6 @@ jobs:
             echo "${GHCR_IMAGE}:v${VERSION}"
             if [[ "${DOCKERHUB_ENABLED}" == "true" ]]; then
               echo "${DOCKERHUB_IMAGE}:latest"
-              echo "${DOCKERHUB_IMAGE}:${VERSION}"
               echo "${DOCKERHUB_IMAGE}:v${VERSION}"
             fi
             echo "EOF"


### PR DESCRIPTION
Stop publishing duplicate Docker Hub tags. Docker Hub will now publish only:\n- :latest\n- :v<version>\n\nGHCR keeps both :<version> and :v<version>.