### PR TITLE
Revert Observatory UI changes (back to 52b98ca)

### DIFF
--- a/apps/web/src/pages/ObservatoryPage.tsx
+++ b/apps/web/src/pages/ObservatoryPage.tsx
@@ -883,7 +883,7 @@ export function ObservatoryPage() {
                           if (mediaTab === 'movie') setMovieLibrary(e.target.value);
                           else setTvLibrary(e.target.value);
                         }}
-                        className="rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white/95 outline-none focus:ring-2 focus:ring-[#facc15]/40 focus:border-[#facc15]/40"
+                        className="rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white/90 outline-none focus:ring-2 focus:ring-white/20"
                       >
                         {(mediaTab === 'movie' ? movieLibraries : tvLibraries).map(
                           (l) => (
@@ -1109,7 +1109,7 @@ export function ObservatoryPage() {
                           if (mediaTab === 'movie') setMovieLibrary(e.target.value);
                           else setTvLibrary(e.target.value);
                         }}
-                        className="rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white/95 outline-none focus:ring-2 focus:ring-[#facc15]/40 focus:border-[#facc15]/40"
+                        className="rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white/90 outline-none focus:ring-2 focus:ring-white/20"
                       >
                         {(mediaTab === 'movie' ? movieLibraries : tvLibraries).map(
                           (l) => (


### PR DESCRIPTION
This PR reverts Observatory UI tweaks made after commit 52b98ca, returning the page to that state.\n\nReverted commits:\n- 36954fc (misty tab tint)\n- 1ce370a (tab readability + subtitle)\n- cd82274 (yellow library selector)