### PR TITLE
v1.0.0.102

### DIFF
--- a/apps/api/src/app.dto.ts
+++ b/apps/api/src/app.dto.ts
@@ -12,7 +12,7 @@ export class AppMetaResponseDto {
   @ApiProperty({ example: 'immaculaterr' })
   name!: string;
 
-  @ApiProperty({ example: '1.0.0.101' })
+  @ApiProperty({ example: '1.0.0.102' })
   version!: string;
 
   @ApiProperty({ example: '41fb2cb', nullable: true })

--- a/apps/api/src/app.meta.ts
+++ b/apps/api/src/app.meta.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_APP_VERSION = '1.0.0.101';
+export const DEFAULT_APP_VERSION = '1.0.0.102';
 
 export type AppMeta = {
   name: string;

--- a/apps/api/src/updates/updates.dto.ts
+++ b/apps/api/src/updates/updates.dto.ts
@@ -1,10 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 export class UpdatesResponseDto {
-  @ApiProperty({ example: '1.0.0.101' })
+  @ApiProperty({ example: '1.0.0.102' })
   currentVersion!: string;
 
-  @ApiProperty({ example: '1.0.0.101', nullable: true })
+  @ApiProperty({ example: '1.0.0.102', nullable: true })
   latestVersion!: string | null;
 
   @ApiProperty({ example: true })

--- a/apps/web/src/components/HeroSection.tsx
+++ b/apps/web/src/components/HeroSection.tsx
@@ -23,12 +23,19 @@ const TIME_RANGE_OPTIONS: Array<{
 ];
 
 function formatMonthLabel(value: string) {
-  const [y, m] = value.split('-');
+  const [y, m, d] = value.split('-');
   const year = Number.parseInt(y ?? '', 10);
   const month = Number.parseInt(m ?? '', 10);
   if (!Number.isFinite(year) || !Number.isFinite(month)) return value;
-  const d = new Date(Date.UTC(year, month - 1, 1));
-  return d.toLocaleString(undefined, { month: 'short', year: '2-digit' });
+  const day = d ? Number.parseInt(d, 10) : 1;
+  const date = new Date(Date.UTC(year, month - 1, Number.isFinite(day) ? day : 1));
+
+  // If this point is a real "day" point (the server appends "today"),
+  // show a date label. Otherwise keep the compact month+year label.
+  if (d && Number.isFinite(day) && day !== 1) {
+    return date.toLocaleString(undefined, { month: 'short', day: 'numeric' });
+  }
+  return date.toLocaleString(undefined, { month: 'short', year: '2-digit' });
 }
 
 function parseUtcMonthStart(value: string): Date | null {


### PR DESCRIPTION
### What’s changed\n- Dashboard analytics graph now always ends on **today’s date** (adds a "today" point on the backend; UI formats day labels).\n- Plex analytics growth cache/version refresh is time-bucketed so the chart stays current even if webhooks miss.\n\n### Version\n- Bumped to **1.0.0.102**\n