### PR TITLE
v1.0.0.502

### DIFF
--- a/apps/api/src/app.dto.ts
+++ b/apps/api/src/app.dto.ts
@@ -12,7 +12,7 @@ export class AppMetaResponseDto {
   @ApiProperty({ example: 'immaculaterr' })
   name!: string;
 
-  @ApiProperty({ example: '1.0.0.501' })
+  @ApiProperty({ example: '1.0.0.502' })
   version!: string;
 
   @ApiProperty({ example: '41fb2cb', nullable: true })

--- a/apps/api/src/app.meta.ts
+++ b/apps/api/src/app.meta.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_APP_VERSION = '1.0.0.501';
+export const DEFAULT_APP_VERSION = '1.0.0.502';
 
 export type AppMeta = {
   name: string;
@@ -8,7 +8,16 @@ export type AppMeta = {
 };
 
 export function readAppMeta(): AppMeta {
-  const version = (process.env.APP_VERSION ?? '').trim() || DEFAULT_APP_VERSION;
+  // IMPORTANT:
+  // - For packaged builds (Docker/Portainer), the version is already baked into the codebase
+  //   via DEFAULT_APP_VERSION.
+  // - Allowing APP_VERSION to override causes confusing "stuck on old version" situations
+  //   when users duplicate/recreate containers and Portainer preserves env vars.
+  // If you really need to override for local/dev, set ALLOW_APP_VERSION_OVERRIDE=true.
+  const allowOverride = (process.env.ALLOW_APP_VERSION_OVERRIDE ?? '').trim() === 'true';
+  const envVersion = (process.env.APP_VERSION ?? '').trim();
+  const version =
+    allowOverride && envVersion ? envVersion : DEFAULT_APP_VERSION;
   const buildSha = (process.env.APP_BUILD_SHA ?? '').trim() || null;
   const buildTime = (process.env.APP_BUILD_TIME ?? '').trim() || null;
 

--- a/apps/api/src/updates/updates.dto.ts
+++ b/apps/api/src/updates/updates.dto.ts
@@ -1,10 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 export class UpdatesResponseDto {
-  @ApiProperty({ example: '1.0.0.501' })
+  @ApiProperty({ example: '1.0.0.502' })
   currentVersion!: string;
 
-  @ApiProperty({ example: '1.0.0.501', nullable: true })
+  @ApiProperty({ example: '1.0.0.502', nullable: true })
   latestVersion!: string | null;
 
   @ApiProperty({ example: true })
@@ -17,7 +17,7 @@ export class UpdatesResponseDto {
   repo!: string | null;
 
   @ApiProperty({
-    example: 'https://github.com/ohmz/Immaculaterr/releases/tag/v1.0.0.501',
+    example: 'https://github.com/ohmz/Immaculaterr/releases/tag/v1.0.0.502',
     nullable: true,
   })
   latestUrl!: string | null;

--- a/apps/web/src/components/Navigation.tsx
+++ b/apps/web/src/components/Navigation.tsx
@@ -74,7 +74,8 @@ export function Navigation() {
     didToastUpdateRef.current = true;
 
     toast.info(`${updateLabel} available`, {
-      description: 'Pull the latest image and recreate/redeploy the container (Portainer: Recreate / Pull latest image).',
+      description:
+        'Pull the latest image and redeploy the container. Portainer: Duplicate/Edit → set image to :latest or :vX.Y.Z.NNN → remove APP_VERSION env var → enable “Always pull image” → Deploy.',
     });
   }, [updateAvailable, updateLabel]);
 

--- a/docker/immaculaterr/Dockerfile
+++ b/docker/immaculaterr/Dockerfile
@@ -26,9 +26,9 @@ RUN npm run build
 FROM node:20-bookworm-slim AS runner
 
 # Source of truth for the app's version is `apps/api/src/app.meta.ts`.
-# CI (GHCR publish workflow) passes APP_VERSION explicitly; local builds can omit it
-# and the app will fall back to DEFAULT_APP_VERSION.
-ARG APP_VERSION
+# (We do not inject APP_VERSION into the runtime container env; allowing APP_VERSION
+# overrides causes confusing "stuck on old version" situations in Portainer when
+# env vars are preserved across recreates.)
 ARG APP_BUILD_SHA=
 ARG APP_BUILD_TIME=
 
@@ -37,7 +37,6 @@ ENV HOST=0.0.0.0
 ENV PORT=5454
 ENV APP_DATA_DIR=/data
 ENV DATABASE_URL=file:/data/tcp.sqlite
-ENV APP_VERSION=$APP_VERSION
 ENV APP_BUILD_SHA=$APP_BUILD_SHA
 ENV APP_BUILD_TIME=$APP_BUILD_TIME
 


### PR DESCRIPTION
Fix Portainer upgrade confusion by ignoring APP_VERSION override, stop injecting APP_VERSION into runtime env, and improve the update toast instructions. Bump to 1.0.0.502.