### PR TITLE
v1.0.0.504

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,33 @@
+changelog:
+  categories:
+    - title: "Changes"
+      labels:
+        - "*"
+  template: |
+    ## What's Changed
+
+    $CHANGES
+
+    ## Update
+
+    **Portainer**: Recreate -> Re-Pull Image -> Recreate
+
+    **Or by script**:
+
+    ```bash
+    docker pull ohmzii/immaculaterr:latest
+
+    docker rm -f Immaculaterr 2>/dev/null || true
+
+    docker run -d \
+      --name Immaculaterr \
+      --network host \
+      -e HOST=0.0.0.0 \
+      -e PORT=5454 \
+      -e APP_DATA_DIR=/data \
+      -e DATABASE_URL=file:/data/tcp.sqlite \
+      -v immaculaterr-data:/data \
+      --restart unless-stopped \
+      ohmzii/immaculaterr:latest
+    ```
+

--- a/apps/api/src/app.dto.ts
+++ b/apps/api/src/app.dto.ts
@@ -12,7 +12,7 @@ export class AppMetaResponseDto {
   @ApiProperty({ example: 'immaculaterr' })
   name!: string;
 
-  @ApiProperty({ example: '1.0.0.503' })
+  @ApiProperty({ example: '1.0.0.504' })
   version!: string;
 
   @ApiProperty({ example: '41fb2cb', nullable: true })

--- a/apps/api/src/app.meta.ts
+++ b/apps/api/src/app.meta.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_APP_VERSION = '1.0.0.503';
+export const DEFAULT_APP_VERSION = '1.0.0.504';
 
 export type AppMeta = {
   name: string;

--- a/apps/api/src/updates/updates.dto.ts
+++ b/apps/api/src/updates/updates.dto.ts
@@ -1,10 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 export class UpdatesResponseDto {
-  @ApiProperty({ example: '1.0.0.503' })
+  @ApiProperty({ example: '1.0.0.504' })
   currentVersion!: string;
 
-  @ApiProperty({ example: '1.0.0.503', nullable: true })
+  @ApiProperty({ example: '1.0.0.504', nullable: true })
   latestVersion!: string | null;
 
   @ApiProperty({ example: true })
@@ -17,7 +17,7 @@ export class UpdatesResponseDto {
   repo!: string | null;
 
   @ApiProperty({
-    example: 'https://github.com/ohmz/Immaculaterr/releases/tag/v1.0.0.503',
+    example: 'https://github.com/ohmz/Immaculaterr/releases/tag/v1.0.0.504',
     nullable: true,
   })
   latestUrl!: string | null;

--- a/apps/web/src/components/Navigation.tsx
+++ b/apps/web/src/components/Navigation.tsx
@@ -74,8 +74,7 @@ export function Navigation() {
     didToastUpdateRef.current = true;
 
     toast.info(`${updateLabel} available`, {
-      description:
-        'Pull the latest image and redeploy the container. Portainer: Duplicate/Edit → set image to :latest or :vX.Y.Z.NNN → remove APP_VERSION env var → enable “Always pull image” → Deploy.',
+      // Keep this short; full update instructions live in the GitHub release notes.
     });
   }, [updateAvailable, updateLabel]);
 


### PR DESCRIPTION
- Add release notes template with update instructions (Portainer + docker run)
- Simplify update toast to only show version available
- Bump to 1.0.0.504