### PR TITLE
Release v1.0.0.512

### DIFF
--- a/apps/api/src/version.ts
+++ b/apps/api/src/version.ts
@@ -1,6 +1,6 @@
 // Single source of truth for the app version.
 // Bump this constant only.
-export const APP_VERSION = '1.0.0.511' as const;
+export const APP_VERSION = '1.0.0.512' as const;
 
 export const APP_VERSION_TAG = `v${APP_VERSION}` as const;
 


### PR DESCRIPTION
Make Cleanup After Adding New Content report cards drill-downable: include per-item lists for deleted Plex duplicates, Radarr/Sonarr unmonitor actions, and watchlist removals (capped).\n\nBumps version to v1.0.0.512.