### PR TITLE
Release v1.0.0.513

### DIFF
--- a/apps/api/src/version.ts
+++ b/apps/api/src/version.ts
@@ -1,6 +1,6 @@
 // Single source of truth for the app version.
 // Bump this constant only.
-export const APP_VERSION = '1.0.0.512' as const;
+export const APP_VERSION = '1.0.0.513' as const;
 
 export const APP_VERSION_TAG = `v${APP_VERSION}` as const;
 


### PR DESCRIPTION
Adds detailed troubleshooting logs for mediaAddedCleanup: which duplicates were found, what was deleted, and unmonitor attempts/results (including failures).\n\nBumps version to v1.0.0.513.