### PR TITLE
Release v1.0.0.515

### DIFF
--- a/apps/api/src/version.ts
+++ b/apps/api/src/version.ts
@@ -1,6 +1,6 @@
 // Single source of truth for the app version.
 // Bump this constant only.
-export const APP_VERSION = '1.0.0.514' as const;
+export const APP_VERSION = '1.0.0.515' as const;
 
 export const APP_VERSION_TAG = `v${APP_VERSION}` as const;
 

--- a/apps/web/src/pages/VersionHistoryPage.tsx
+++ b/apps/web/src/pages/VersionHistoryPage.tsx
@@ -89,7 +89,7 @@ export function VersionHistoryPage() {
           <div className="space-y-6">
             <div className={cardClass}>
               <div className="text-white font-black text-2xl tracking-tight">
-                1.0.0.0
+                V1.0.0
               </div>
 
               <div className="mt-4 space-y-3 text-sm text-white/75 leading-relaxed">


### PR DESCRIPTION
Fix Version History label formatting: display V1.0.0 (instead of 1.0.0.0).\n\nBumps version to v1.0.0.515.