### PR TITLE
Release v1.0.0.519

### DIFF
--- a/apps/api/src/version.ts
+++ b/apps/api/src/version.ts
@@ -1,6 +1,6 @@
 // Single source of truth for the app version.
 // Bump this constant only.
-export const APP_VERSION = '1.0.0.518' as const;
+export const APP_VERSION = '1.0.0.519' as const;
 
 export const APP_VERSION_TAG = `v${APP_VERSION}` as const;
 

--- a/apps/web/src/app/AppShell.tsx
+++ b/apps/web/src/app/AppShell.tsx
@@ -54,7 +54,10 @@ export function AppShell() {
 
       {/* Main Content */}
       <main className={isHomePage ? 'pb-24 lg:pb-0' : 'pt-24 pb-24 lg:pb-8'}>
-        <Outlet />
+        {/* Force route content to remount on path change.
+            This avoids rare cases where a previous page's state/overlays prevent the next page from rendering,
+            even though the URL changes (observed leaving Observatory). */}
+        <Outlet key={location.pathname} />
       </main>
 
       {/* Mobile app navigation */}


### PR DESCRIPTION
Fix routing stuck after leaving Observatory: force routed content (<Outlet/>) to remount on pathname changes.\n\nBumps version to v1.0.0.519.