### PR TITLE
docs(readme): add Plex UI screenshots below showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@
   <img src="doc/assets/screenshots/showcase.gif" alt="Immaculaterr desktop UI showcase" width="900" />
   <br/>
   <br/>
+  <p><b>Plex UI examples</b></p>
+  <img src="doc/assets/screenshots/plex-immaculate-taste-mobile.png" alt="Plex mobile screenshot showing Immaculaterr recommendations" width="320" />
+  <br/>
+  <br/>
+  <img src="doc/assets/screenshots/plex-immaculate-taste-desktop.png" alt="Plex desktop screenshot showing Immaculaterr recommendations" width="900" />
+  <br/>
+  <br/>
   <p><b>Mobile UI (full mobile support)</b></p>
   <img src="doc/assets/screenshots/showcase-mobile.gif" alt="Immaculaterr mobile UI showcase" width="320" />
 </div>

--- a/doc/README.md
+++ b/doc/README.md
@@ -46,6 +46,15 @@ Screenshots
   <img src="assets/screenshots/showcase.gif" alt="Immaculaterr desktop UI showcase" width="900" />
 </div>
 
+**Plex UI examples**
+
+<div align="center">
+  <img src="assets/screenshots/plex-immaculate-taste-mobile.png" alt="Plex mobile screenshot showing Immaculaterr recommendations" width="320" />
+  <br/>
+  <br/>
+  <img src="assets/screenshots/plex-immaculate-taste-desktop.png" alt="Plex desktop screenshot showing Immaculaterr recommendations" width="900" />
+</div>
+
 **Mobile UI (full mobile support)**
 
 <div align="center">


### PR DESCRIPTION
Adds two Plex UI screenshot placeholders below the desktop showcase GIF in both README.md and doc/README.md.

Note: the README now references:
- doc/assets/screenshots/plex-immaculate-taste-mobile.png
- doc/assets/screenshots/plex-immaculate-taste-desktop.png

Please ensure those files are present in the repo so images render correctly.