### PR TITLE
fix(ci): add missing plex user selection utility

### DIFF
--- a/apps/api/src/plex/plex-user-selection.utils.spec.ts
+++ b/apps/api/src/plex/plex-user-selection.utils.spec.ts
@@ -1,0 +1,86 @@
+import {
+  buildExcludedPlexUserIdsFromSelected,
+  isPlexUserExcludedFromMonitoring,
+  readConfiguredExcludedPlexUserIds,
+  resolvePlexUserMonitoringSelection,
+  sanitizePlexUserIds,
+} from './plex-user-selection.utils';
+
+describe('plex-user-selection.utils', () => {
+  describe('sanitizePlexUserIds', () => {
+    it('trims and de-duplicates values', () => {
+      expect(sanitizePlexUserIds([' u1 ', 'u2', 'u1', null, 3])).toEqual([
+        'u1',
+        'u2',
+      ]);
+    });
+  });
+
+  describe('readConfiguredExcludedPlexUserIds', () => {
+    it('reads configured key list and sanitizes it', () => {
+      expect(
+        readConfiguredExcludedPlexUserIds({
+          plex: {
+            userMonitoring: {
+              excludedPlexUserIds: [' u3 ', 'u3', 'u2'],
+            },
+          },
+        }),
+      ).toEqual(['u3', 'u2']);
+    });
+  });
+
+  describe('resolvePlexUserMonitoringSelection', () => {
+    it('defaults to all selected when config is missing', () => {
+      const selection = resolvePlexUserMonitoringSelection({
+        settings: {},
+        users: [{ id: 'a' }, { id: 'b' }],
+      });
+      expect(selection.selectedPlexUserIds).toEqual(['a', 'b']);
+      expect(selection.excludedPlexUserIds).toEqual([]);
+    });
+
+    it('applies configured exclusions limited to known users', () => {
+      const selection = resolvePlexUserMonitoringSelection({
+        settings: {
+          plex: {
+            userMonitoring: {
+              excludedPlexUserIds: ['b', 'missing'],
+            },
+          },
+        },
+        users: [{ id: 'a' }, { id: 'b' }],
+      });
+      expect(selection.selectedPlexUserIds).toEqual(['a']);
+      expect(selection.excludedPlexUserIds).toEqual(['b']);
+    });
+  });
+
+  describe('buildExcludedPlexUserIdsFromSelected', () => {
+    it('computes complement of selected ids', () => {
+      const excluded = buildExcludedPlexUserIdsFromSelected({
+        users: [{ id: 'u1' }, { id: 'u2' }, { id: 'u3' }],
+        selectedPlexUserIds: ['u1', 'u3'],
+      });
+      expect(excluded).toEqual(['u2']);
+    });
+  });
+
+  describe('isPlexUserExcludedFromMonitoring', () => {
+    it('returns true only for configured excluded users', () => {
+      const settings = {
+        plex: {
+          userMonitoring: {
+            excludedPlexUserIds: ['u10'],
+          },
+        },
+      };
+      expect(
+        isPlexUserExcludedFromMonitoring({ settings, plexUserId: 'u10' }),
+      ).toBe(true);
+      expect(
+        isPlexUserExcludedFromMonitoring({ settings, plexUserId: 'u11' }),
+      ).toBe(false);
+    });
+  });
+});

--- a/apps/api/src/plex/plex-user-selection.utils.ts
+++ b/apps/api/src/plex/plex-user-selection.utils.ts
@@ -1,0 +1,85 @@
+type PlexUserLike = {
+  id: string;
+};
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function pick(obj: Record<string, unknown>, path: string): unknown {
+  const parts = path.split('.');
+  let cur: unknown = obj;
+  for (const part of parts) {
+    if (!isPlainObject(cur)) return undefined;
+    cur = cur[part];
+  }
+  return cur;
+}
+
+function normalizePlexUserId(value: unknown): string {
+  if (typeof value === 'string') return value.trim();
+  return '';
+}
+
+export function sanitizePlexUserIds(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const raw of value) {
+    const id = normalizePlexUserId(raw);
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+  }
+  return out;
+}
+
+export function readConfiguredExcludedPlexUserIds(
+  settings: Record<string, unknown>,
+): string[] {
+  return sanitizePlexUserIds(
+    pick(settings, 'plex.userMonitoring.excludedPlexUserIds'),
+  );
+}
+
+export function resolvePlexUserMonitoringSelection(params: {
+  settings: Record<string, unknown>;
+  users: PlexUserLike[];
+}) {
+  const knownIds = new Set(
+    params.users
+      .map((u) => String(u.id ?? '').trim())
+      .filter(Boolean),
+  );
+  const excludedPlexUserIds = readConfiguredExcludedPlexUserIds(
+    params.settings,
+  ).filter((id) => knownIds.has(id));
+  const excludedSet = new Set(excludedPlexUserIds);
+  const selectedPlexUserIds = params.users
+    .map((u) => String(u.id ?? '').trim())
+    .filter((id) => id && !excludedSet.has(id));
+
+  return {
+    excludedPlexUserIds,
+    selectedPlexUserIds,
+  };
+}
+
+export function buildExcludedPlexUserIdsFromSelected(params: {
+  users: PlexUserLike[];
+  selectedPlexUserIds: unknown;
+}) {
+  const selected = new Set(sanitizePlexUserIds(params.selectedPlexUserIds));
+  return params.users
+    .map((u) => String(u.id ?? '').trim())
+    .filter((id) => id && !selected.has(id));
+}
+
+export function isPlexUserExcludedFromMonitoring(params: {
+  settings: Record<string, unknown>;
+  plexUserId: unknown;
+}): boolean {
+  const plexUserId = normalizePlexUserId(params.plexUserId);
+  if (!plexUserId) return false;
+  return readConfiguredExcludedPlexUserIds(params.settings).includes(plexUserId);
+}


### PR DESCRIPTION
## Summary
- Add the missing plex-user-selection utility module referenced by API imports.
- Add unit coverage for the new utility.

## Why
- Master build was failing in Docker/CI with TS2307 module-not-found errors during API compile.
- This PR restores a complete source tree so the container build succeeds.