### PR TITLE
Actions build task failure

### DIFF
--- a/docker/immaculaterr/Dockerfile
+++ b/docker/immaculaterr/Dockerfile
@@ -68,8 +68,10 @@ COPY apps/web/package.json apps/web/package.json
 COPY apps/api/prisma apps/api/prisma
 RUN npm ci --omit=dev && npm cache clean --force
 
-# Ensure Prisma client exists at runtime (the Nest app imports @prisma/client).
-RUN npm -w apps/api run db:generate
+# Reuse Prisma client generated in builder. A second generation here is flaky on
+# linux/arm64 under emulation (Prisma getDmmf JSON parse errors).
+COPY --from=builder /app/apps/api/node_modules/.prisma /app/apps/api/node_modules/.prisma
+COPY --from=builder /app/apps/api/node_modules/@prisma/client /app/apps/api/node_modules/@prisma/client
 
 # Copy built artifacts
 COPY --from=builder /app/apps/api/dist /app/apps/api/dist


### PR DESCRIPTION
## Summary

This PR fixes a failing GitHub Actions build for `arm64` architecture. The build was failing during the `npm -w apps/api run db:generate` step in the runtime stage due to an `Unable to parse JSON` error from Prisma. The fix prevents redundant Prisma generation in the runtime stage by copying pre-generated client artifacts from the builder stage.

## Changes

- Removed `RUN npm -w apps/api run db:generate` from the runtime stage in `docker/immaculaterr/Dockerfile`.
- Added `COPY --from=builder` commands to copy the `.prisma` and `@prisma/client` directories from the builder stage to the runtime stage in `docker/immaculaterr/Dockerfile`.

## How to test

- Trigger a GitHub Actions build, specifically verifying the `arm64` build job.
- Ensure the application deploys and functions correctly.

## UI screenshots (if applicable)

- N/A

## Checklist

- [ ] I tested this change locally (or in Docker).
- [ ] I added/updated docs where needed.
- [ ] I kept this PR focused (no unrelated changes).

---
<p><a href="https://cursor.com/background-agent?bcId=bc-4dc76894-00dc-4c54-a7c7-0aee9da0f5fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4dc76894-00dc-4c54-a7c7-0aee9da0f5fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

