### PR TITLE
Release 1.7.7-beta-1 to master

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -1,42 +1,42 @@
-## What's Changed
+## What's New
 
 - <!-- Describe the most important user-facing changes here. -->
 
-**Full Changelog**: https://github.com/ohmzi/Immaculaterr/compare/<previous-tag>..<new-tag>
+Full Changelog: https://github.com/ohmzi/Immaculaterr/compare/<previous-tag>..<new-tag>
+
+If you are running NAS or Unraid please check their specific documentation for update
+[NAS](https://github.com/ohmzi/Immaculaterr/blob/master/doc/setup-truenas.md)
+[Unraid](https://github.com/ohmzi/Immaculaterr/blob/master/doc/setup-unraid.md)
 
 ## Updating
 
 ### Docker
 
-HTTP-only update (required)
+HTTPS update which includes sidecar
 
 ```bash
-docker pull ohmzii/immaculaterr:latest
+set -euo pipefail
 
-docker rm -f Immaculaterr 2>/dev/null || true
+IMM_IMAGE="ghcr.io/ohmzi/immaculaterr:latest"
 
-docker run -d \
-  --name Immaculaterr \
-  --network host \
-  -e HOST=0.0.0.0 \
-  -e PORT=5454 \
-  -e APP_DATA_DIR=/data \
-  -e DATABASE_URL=file:/data/tcp.sqlite \
-  -v immaculaterr-data:/data \
-  --restart unless-stopped \
-  ohmzii/immaculaterr:latest
-```
-
-Optional HTTPS sidecar (can run anytime later)
-
-```bash
 mkdir -p ~/immaculaterr
 curl -fsSL -o ~/immaculaterr/caddy-entrypoint.sh \
   "https://raw.githubusercontent.com/ohmzi/Immaculaterr/<release-tag>/docker/immaculaterr/caddy-entrypoint.sh"
-chmod +x ~/immaculaterr/caddy-entrypoint.sh
+curl -fsSL -o ~/immaculaterr/install-local-ca.sh \
+  "https://raw.githubusercontent.com/ohmzi/Immaculaterr/<release-tag>/docker/immaculaterr/install-local-ca.sh"
+chmod +x ~/immaculaterr/caddy-entrypoint.sh ~/immaculaterr/install-local-ca.sh
 
+if ! command -v certutil >/dev/null 2>&1; then
+  sudo apt-get update
+  sudo apt-get install -y libnss3-tools
+fi
+
+docker pull "$IMM_IMAGE"
 docker pull caddy:2.8.4-alpine
 docker rm -f ImmaculaterrHttps 2>/dev/null || true
+docker rm -f Immaculaterr 2>/dev/null || true
+docker volume create immaculaterr-caddy-data >/dev/null 2>&1 || true
+docker volume create immaculaterr-caddy-config >/dev/null 2>&1 || true
 
 docker run -d \
   --name ImmaculaterrHttps \
@@ -53,11 +53,50 @@ docker run -d \
   --restart unless-stopped \
   caddy:2.8.4-alpine \
   /bin/sh /etc/caddy/caddy-entrypoint.sh
+
+docker run -d \
+  --name Immaculaterr \
+  -p 5454:5454 \
+  -e HOST=0.0.0.0 \
+  -e PORT=5454 \
+  -e TRUST_PROXY=1 \
+  -e APP_DATA_DIR=/data \
+  -e DATABASE_URL=file:/data/tcp.sqlite \
+  -v immaculaterr-data:/data \
+  --restart unless-stopped \
+  "$IMM_IMAGE"
+
+"$HOME/immaculaterr/install-local-ca.sh"
+
+curl -I https://localhost:5464
+```
+
+HTTP-only update
+
+```bash
+IMM_IMAGE="ghcr.io/ohmzi/immaculaterr:latest"
+APP_PORT=5454
+
+docker pull "$IMM_IMAGE"
+docker rm -f ImmaculaterrHttps 2>/dev/null || true
+docker rm -f Immaculaterr 2>/dev/null || true
+
+docker run -d \
+  --name Immaculaterr \
+  -p ${APP_PORT}:${APP_PORT} \
+  -e HOST=0.0.0.0 \
+  -e PORT=${APP_PORT} \
+  -e TRUST_PROXY=1 \
+  -e APP_DATA_DIR=/data \
+  -e DATABASE_URL=file:/data/tcp.sqlite \
+  -v immaculaterr-data:/data \
+  --restart unless-stopped \
+  "$IMM_IMAGE"
 ```
 
 ### Portainer
 
-1. In Portainer: **Containers** → select **Immaculaterr**
+1. In Portainer: **Containers** -> select **Immaculaterr**
 2. Click **Recreate**
 3. Enable **Re-pull image**
 4. Click **Recreate**

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,45 +4,45 @@ changelog:
       labels:
         - "*"
   template: |
-    ## What's Changed
+    ## What's New
 
     $CHANGES
 
-    **Full Changelog**: https://github.com/ohmzi/Immaculaterr/compare/<previous-tag>..<new-tag>
+    Full Changelog: https://github.com/ohmzi/Immaculaterr/compare/<previous-tag>..<new-tag>
+
+    If you are running NAS or Unraid please check their specific documentation for update
+    [NAS](https://github.com/ohmzi/Immaculaterr/blob/master/doc/setup-truenas.md)
+    [Unraid](https://github.com/ohmzi/Immaculaterr/blob/master/doc/setup-unraid.md)
 
     ## Updating
 
     ### Docker
 
-    HTTP-only update (required)
+    HTTPS update which includes sidecar
 
     ```bash
-    docker pull ohmzii/immaculaterr:latest
+    set -euo pipefail
 
-    docker rm -f Immaculaterr 2>/dev/null || true
+    IMM_IMAGE="ghcr.io/ohmzi/immaculaterr:latest"
 
-    docker run -d \
-      --name Immaculaterr \
-      --network host \
-      -e HOST=0.0.0.0 \
-      -e PORT=5454 \
-      -e APP_DATA_DIR=/data \
-      -e DATABASE_URL=file:/data/tcp.sqlite \
-      -v immaculaterr-data:/data \
-      --restart unless-stopped \
-      ohmzii/immaculaterr:latest
-    ```
-
-    Optional HTTPS sidecar (can run anytime later)
-
-    ```bash
     mkdir -p ~/immaculaterr
     curl -fsSL -o ~/immaculaterr/caddy-entrypoint.sh \
       "https://raw.githubusercontent.com/ohmzi/Immaculaterr/master/docker/immaculaterr/caddy-entrypoint.sh"
-    chmod +x ~/immaculaterr/caddy-entrypoint.sh
+    curl -fsSL -o ~/immaculaterr/install-local-ca.sh \
+      "https://raw.githubusercontent.com/ohmzi/Immaculaterr/master/docker/immaculaterr/install-local-ca.sh"
+    chmod +x ~/immaculaterr/caddy-entrypoint.sh ~/immaculaterr/install-local-ca.sh
 
+    if ! command -v certutil >/dev/null 2>&1; then
+      sudo apt-get update
+      sudo apt-get install -y libnss3-tools
+    fi
+
+    docker pull "$IMM_IMAGE"
     docker pull caddy:2.8.4-alpine
     docker rm -f ImmaculaterrHttps 2>/dev/null || true
+    docker rm -f Immaculaterr 2>/dev/null || true
+    docker volume create immaculaterr-caddy-data >/dev/null 2>&1 || true
+    docker volume create immaculaterr-caddy-config >/dev/null 2>&1 || true
 
     docker run -d \
       --name ImmaculaterrHttps \
@@ -59,11 +59,50 @@ changelog:
       --restart unless-stopped \
       caddy:2.8.4-alpine \
       /bin/sh /etc/caddy/caddy-entrypoint.sh
+
+    docker run -d \
+      --name Immaculaterr \
+      -p 5454:5454 \
+      -e HOST=0.0.0.0 \
+      -e PORT=5454 \
+      -e TRUST_PROXY=1 \
+      -e APP_DATA_DIR=/data \
+      -e DATABASE_URL=file:/data/tcp.sqlite \
+      -v immaculaterr-data:/data \
+      --restart unless-stopped \
+      "$IMM_IMAGE"
+
+    "$HOME/immaculaterr/install-local-ca.sh"
+
+    curl -I https://localhost:5464
+    ```
+
+    HTTP-only update
+
+    ```bash
+    IMM_IMAGE="ghcr.io/ohmzi/immaculaterr:latest"
+    APP_PORT=5454
+
+    docker pull "$IMM_IMAGE"
+    docker rm -f ImmaculaterrHttps 2>/dev/null || true
+    docker rm -f Immaculaterr 2>/dev/null || true
+
+    docker run -d \
+      --name Immaculaterr \
+      -p ${APP_PORT}:${APP_PORT} \
+      -e HOST=0.0.0.0 \
+      -e PORT=${APP_PORT} \
+      -e TRUST_PROXY=1 \
+      -e APP_DATA_DIR=/data \
+      -e DATABASE_URL=file:/data/tcp.sqlite \
+      -v immaculaterr-data:/data \
+      --restart unless-stopped \
+      "$IMM_IMAGE"
     ```
 
     ### Portainer
 
-    1. In Portainer: **Containers** → select **Immaculaterr**
+    1. In Portainer: **Containers** -> select **Immaculaterr**
     2. Click **Recreate**
     3. Enable **Re-pull image**
     4. Click **Recreate**

--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -339,38 +339,22 @@ jobs:
 
           $(cat "${FEATURE_LINES_FILE}")
 
-          **Full Changelog**: ${CHANGELOG_URL}
+          Full Changelog: ${CHANGELOG_URL}
+
+          If you are running NAS or Unraid please check their specific documentation for update
+          [NAS](https://github.com/ohmzi/Immaculaterr/blob/master/doc/setup-truenas.md)
+          [Unraid](https://github.com/ohmzi/Immaculaterr/blob/master/doc/setup-unraid.md)
 
           ## Updating
 
           ### Docker
 
-          #### HTTP-only update (required)
-
-          \`\`\`bash
-          IMM_IMAGE="ghcr.io/ohmzi/immaculaterr:latest"
-          APP_PORT=5454
-
-          docker pull "\$IMM_IMAGE"
-          docker rm -f Immaculaterr 2>/dev/null || true
-
-          docker run -d \
-            --name Immaculaterr \
-            -p \${APP_PORT}:\${APP_PORT} \
-            -e HOST=0.0.0.0 \
-            -e PORT=\${APP_PORT} \
-            -e TRUST_PROXY=1 \
-            -e APP_DATA_DIR=/data \
-            -e DATABASE_URL=file:/data/tcp.sqlite \
-            -v immaculaterr-data:/data \
-            --restart unless-stopped \
-            "\$IMM_IMAGE"
-          \`\`\`
-
-          #### Optional HTTPS sidecar (can run anytime later)
+          #### HTTPS update which includes sidecar
 
           \`\`\`bash
           set -euo pipefail
+
+          IMM_IMAGE="ghcr.io/ohmzi/immaculaterr:latest"
 
           mkdir -p "\$HOME/immaculaterr"
 
@@ -386,12 +370,14 @@ jobs:
             sudo apt-get install -y libnss3-tools
           fi
 
+          docker pull "\$IMM_IMAGE"
           docker pull caddy:2.8.4-alpine
           docker rm -f ImmaculaterrHttps 2>/dev/null || true
+          docker rm -f Immaculaterr 2>/dev/null || true
 
           # Keep named volumes stable so certs persist across restarts
-          docker volume create immaculaterr-caddy-data >/dev/null
-          docker volume create immaculaterr-caddy-config >/dev/null
+          docker volume create immaculaterr-caddy-data >/dev/null 2>&1 || true
+          docker volume create immaculaterr-caddy-config >/dev/null 2>&1 || true
 
           docker run -d \
             --name ImmaculaterrHttps \
@@ -409,6 +395,18 @@ jobs:
             caddy:2.8.4-alpine \
             /bin/sh /etc/caddy/caddy-entrypoint.sh
 
+          docker run -d \
+            --name Immaculaterr \
+            -p 5454:5454 \
+            -e HOST=0.0.0.0 \
+            -e PORT=5454 \
+            -e TRUST_PROXY=1 \
+            -e APP_DATA_DIR=/data \
+            -e DATABASE_URL=file:/data/tcp.sqlite \
+            -v immaculaterr-data:/data \
+            --restart unless-stopped \
+            "\$IMM_IMAGE"
+
           # CRITICAL: trust the current Caddy local CA
           "\$HOME/immaculaterr/install-local-ca.sh"
 
@@ -416,9 +414,32 @@ jobs:
           curl -I https://localhost:5464
           \`\`\`
 
+          #### HTTP-only update
+
+          \`\`\`bash
+          IMM_IMAGE="ghcr.io/ohmzi/immaculaterr:latest"
+          APP_PORT=5454
+
+          docker pull "\$IMM_IMAGE"
+          docker rm -f ImmaculaterrHttps 2>/dev/null || true
+          docker rm -f Immaculaterr 2>/dev/null || true
+
+          docker run -d \
+            --name Immaculaterr \
+            -p \${APP_PORT}:\${APP_PORT} \
+            -e HOST=0.0.0.0 \
+            -e PORT=\${APP_PORT} \
+            -e TRUST_PROXY=1 \
+            -e APP_DATA_DIR=/data \
+            -e DATABASE_URL=file:/data/tcp.sqlite \
+            -v immaculaterr-data:/data \
+            --restart unless-stopped \
+            "\$IMM_IMAGE"
+          \`\`\`
+
           ### Portainer
 
-          1. In Portainer: **Containers** → select **Immaculaterr**
+          1. In Portainer: **Containers** -> select **Immaculaterr**
           2. Click **Recreate**
           3. Enable **Re-pull image**
           4. Click **Recreate**

--- a/apps/api/prisma/migrations/20260405092958_add_imported_watch_entry/migration.sql
+++ b/apps/api/prisma/migrations/20260405092958_add_imported_watch_entry/migration.sql
@@ -5,8 +5,9 @@
   - The primary key for the `ImmaculateTasteShowLibrary` table will be changed. If it partially fails, the table could be left without primary key constraint.
 
 */
--- CreateTable
-CREATE TABLE "ArrInstance" (
+-- CreateTable (idempotent: existing SQLite installs may already have
+-- ArrInstance provisioned by migrate-with-repair before this migration runs)
+CREATE TABLE IF NOT EXISTS "ArrInstance" (
     "id" TEXT NOT NULL PRIMARY KEY,
     "userId" TEXT NOT NULL,
     "type" TEXT NOT NULL,
@@ -23,8 +24,8 @@ CREATE TABLE "ArrInstance" (
     CONSTRAINT "ArrInstance_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
 );
 
--- CreateTable
-CREATE TABLE "ImportedWatchEntry" (
+-- CreateTable (idempotent: supports reruns after partial SQLite recovery)
+CREATE TABLE IF NOT EXISTS "ImportedWatchEntry" (
     "id" TEXT NOT NULL PRIMARY KEY,
     "userId" TEXT NOT NULL,
     "source" TEXT NOT NULL,
@@ -111,17 +112,12 @@ CREATE INDEX "ImmaculateTasteShowLibrary_firstAirDate_idx" ON "ImmaculateTasteSh
 PRAGMA foreign_keys=ON;
 PRAGMA defer_foreign_keys=OFF;
 
--- CreateIndex
-CREATE INDEX "ArrInstance_userId_type_idx" ON "ArrInstance"("userId", "type");
+CREATE INDEX IF NOT EXISTS "ArrInstance_userId_type_idx" ON "ArrInstance"("userId", "type");
 
--- CreateIndex
-CREATE UNIQUE INDEX "ArrInstance_userId_type_name_key" ON "ArrInstance"("userId", "type", "name");
+CREATE UNIQUE INDEX IF NOT EXISTS "ArrInstance_userId_type_name_key" ON "ArrInstance"("userId", "type", "name");
 
--- CreateIndex
-CREATE INDEX "ImportedWatchEntry_userId_source_idx" ON "ImportedWatchEntry"("userId", "source");
+CREATE INDEX IF NOT EXISTS "ImportedWatchEntry_userId_source_idx" ON "ImportedWatchEntry"("userId", "source");
 
--- CreateIndex
-CREATE INDEX "ImportedWatchEntry_userId_status_idx" ON "ImportedWatchEntry"("userId", "status");
+CREATE INDEX IF NOT EXISTS "ImportedWatchEntry_userId_status_idx" ON "ImportedWatchEntry"("userId", "status");
 
--- CreateIndex
-CREATE UNIQUE INDEX "ImportedWatchEntry_userId_source_parsedTitle_key" ON "ImportedWatchEntry"("userId", "source", "parsedTitle");
+CREATE UNIQUE INDEX IF NOT EXISTS "ImportedWatchEntry_userId_source_parsedTitle_key" ON "ImportedWatchEntry"("userId", "source", "parsedTitle");

--- a/apps/api/prisma/migrations/20260411120000_add_auto_run_media_history/migration.sql
+++ b/apps/api/prisma/migrations/20260411120000_add_auto_run_media_history/migration.sql
@@ -1,5 +1,5 @@
--- CreateTable
-CREATE TABLE "AutoRunMediaHistory" (
+-- CreateTable (idempotent: supports reruns after partial SQLite recovery)
+CREATE TABLE IF NOT EXISTS "AutoRunMediaHistory" (
     "id" TEXT NOT NULL PRIMARY KEY,
     "jobId" TEXT NOT NULL,
     "mediaFingerprint" TEXT NOT NULL,
@@ -17,8 +17,6 @@ CREATE TABLE "AutoRunMediaHistory" (
     "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
--- CreateIndex
-CREATE UNIQUE INDEX "AutoRunMediaHistory_jobId_mediaFingerprint_key" ON "AutoRunMediaHistory"("jobId", "mediaFingerprint");
+CREATE UNIQUE INDEX IF NOT EXISTS "AutoRunMediaHistory_jobId_mediaFingerprint_key" ON "AutoRunMediaHistory"("jobId", "mediaFingerprint");
 
--- CreateIndex
-CREATE INDEX "AutoRunMediaHistory_jobId_plexUserId_librarySectionKey_createdAt_idx" ON "AutoRunMediaHistory"("jobId", "plexUserId", "librarySectionKey", "createdAt");
+CREATE INDEX IF NOT EXISTS "AutoRunMediaHistory_jobId_plexUserId_librarySectionKey_createdAt_idx" ON "AutoRunMediaHistory"("jobId", "plexUserId", "librarySectionKey", "createdAt");

--- a/apps/api/prisma/migrations/20260411120000_add_auto_run_media_history/migration.sql
+++ b/apps/api/prisma/migrations/20260411120000_add_auto_run_media_history/migration.sql
@@ -1,0 +1,24 @@
+-- CreateTable
+CREATE TABLE "AutoRunMediaHistory" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "jobId" TEXT NOT NULL,
+    "mediaFingerprint" TEXT NOT NULL,
+    "plexUserId" TEXT NOT NULL,
+    "mediaType" TEXT NOT NULL,
+    "librarySectionKey" TEXT NOT NULL,
+    "seedRatingKey" TEXT,
+    "showRatingKey" TEXT,
+    "seedTitle" TEXT,
+    "seedYear" INTEGER,
+    "seasonNumber" INTEGER,
+    "episodeNumber" INTEGER,
+    "source" TEXT NOT NULL,
+    "firstRunId" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AutoRunMediaHistory_jobId_mediaFingerprint_key" ON "AutoRunMediaHistory"("jobId", "mediaFingerprint");
+
+-- CreateIndex
+CREATE INDEX "AutoRunMediaHistory_jobId_plexUserId_librarySectionKey_createdAt_idx" ON "AutoRunMediaHistory"("jobId", "plexUserId", "librarySectionKey", "createdAt");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -17,33 +17,33 @@ model Setting {
 }
 
 model User {
-  id           String   @id @default(cuid())
-  username     String   @unique
-  passwordHash String
-  tokenVersion Int      @default(0)
+  id                      String   @id @default(cuid())
+  username                String   @unique
+  passwordHash            String
+  tokenVersion            Int      @default(0)
   passwordProofSalt       String?
   passwordProofIterations Int?
   passwordProofKeyEnc     String?
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  createdAt               DateTime @default(now())
+  updatedAt               DateTime @updatedAt
 
-  sessions            Session[]
-  settings            UserSettings?
-  secrets             UserSecrets?
-  recovery            UserRecovery?
-  rejectedSuggestions RejectedSuggestion[]
-  arrInstances        ArrInstance[]
+  sessions                Session[]
+  settings                UserSettings?
+  secrets                 UserSecrets?
+  recovery                UserRecovery?
+  rejectedSuggestions     RejectedSuggestion[]
+  arrInstances            ArrInstance[]
   immaculateTasteProfiles ImmaculateTasteProfile[]
-  importedWatchEntries ImportedWatchEntry[]
+  importedWatchEntries    ImportedWatchEntry[]
 }
 
 model Session {
-  id         String   @id
-  userId     String
+  id           String   @id
+  userId       String
   tokenVersion Int
-  createdAt  DateTime @default(now())
-  lastSeenAt DateTime @updatedAt
-  expiresAt  DateTime
+  createdAt    DateTime @default(now())
+  lastSeenAt   DateTime @updatedAt
+  expiresAt    DateTime
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -70,15 +70,15 @@ model UserSecrets {
 }
 
 model UserRecovery {
-  userId String @id
-  questionOneKey String
-  questionOneAnswerHash String
-  questionTwoKey String
-  questionTwoAnswerHash String
-  questionThreeKey String
+  userId                  String   @id
+  questionOneKey          String
+  questionOneAnswerHash   String
+  questionTwoKey          String
+  questionTwoAnswerHash   String
+  questionThreeKey        String
   questionThreeAnswerHash String
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  createdAt               DateTime @default(now())
+  updatedAt               DateTime @updatedAt
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
@@ -93,17 +93,17 @@ model LoginThrottle {
 }
 
 model PlexUser {
-  id               String   @id @default(cuid())
+  id               String    @id @default(cuid())
   plexAccountId    Int?
   plexAccountTitle String
-  isAdmin          Boolean  @default(false)
+  isAdmin          Boolean   @default(false)
   lastSeenAt       DateTime?
-  createdAt        DateTime @default(now())
-  updatedAt        DateTime @updatedAt
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
 
-  immaculateTasteMovieLibraries      ImmaculateTasteMovieLibrary[]
-  immaculateTasteShowLibraries       ImmaculateTasteShowLibrary[]
-  immaculateTasteProfileOverrides    ImmaculateTasteProfileUserOverride[]
+  immaculateTasteMovieLibraries       ImmaculateTasteMovieLibrary[]
+  immaculateTasteShowLibraries        ImmaculateTasteShowLibrary[]
+  immaculateTasteProfileOverrides     ImmaculateTasteProfileUserOverride[]
   watchedMovieRecommendationLibraries WatchedMovieRecommendationLibrary[]
   watchedShowRecommendationLibraries  WatchedShowRecommendationLibrary[]
 
@@ -113,14 +113,14 @@ model PlexUser {
 }
 
 model ArrInstance {
-  id        String   @id @default(cuid())
+  id        String  @id @default(cuid())
   userId    String
   type      String
   name      String
   baseUrl   String
   apiKey    String
-  enabled   Boolean  @default(true)
-  sortOrder Int      @default(0)
+  enabled   Boolean @default(true)
+  sortOrder Int     @default(0)
 
   rootFolderPath   String?
   qualityProfileId Int?
@@ -144,11 +144,11 @@ model ImmaculateTasteProfile {
   sortOrder     Int     @default(0)
   scopeAllUsers Boolean @default(true)
 
-  mediaType      String @default("both")
-  matchMode      String @default("all")
-  genres         String @default("[]")
-  audioLanguages String @default("[]")
-  excludedGenres String @default("[]")
+  mediaType              String @default("both")
+  matchMode              String @default("all")
+  genres                 String @default("[]")
+  audioLanguages         String @default("[]")
+  excludedGenres         String @default("[]")
   excludedAudioLanguages String @default("[]")
 
   radarrInstanceId String?
@@ -160,7 +160,7 @@ model ImmaculateTasteProfile {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  user          User                               @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user          User                                 @relation(fields: [userId], references: [id], onDelete: Cascade)
   userOverrides ImmaculateTasteProfileUserOverride[]
 
   @@unique([userId, name])
@@ -172,11 +172,11 @@ model ImmaculateTasteProfileUserOverride {
   profileId  String
   plexUserId String
 
-  mediaType      String @default("both")
-  matchMode      String @default("all")
-  genres         String @default("[]")
-  audioLanguages String @default("[]")
-  excludedGenres String @default("[]")
+  mediaType              String @default("both")
+  matchMode              String @default("all")
+  genres                 String @default("[]")
+  audioLanguages         String @default("[]")
+  excludedGenres         String @default("[]")
   excludedAudioLanguages String @default("[]")
 
   radarrInstanceId String?
@@ -220,23 +220,23 @@ model JobSchedule {
 }
 
 model JobRun {
-  id           String        @id @default(cuid())
-  jobId        String
-  userId       String?
-  trigger      JobRunTrigger
-  dryRun       Boolean       @default(false)
-  status       JobRunStatus
-  startedAt    DateTime      @default(now())
-  queuedAt     DateTime      @default(now())
+  id                 String        @id @default(cuid())
+  jobId              String
+  userId             String?
+  trigger            JobRunTrigger
+  dryRun             Boolean       @default(false)
+  status             JobRunStatus
+  startedAt          DateTime      @default(now())
+  queuedAt           DateTime      @default(now())
   executionStartedAt DateTime?
-  finishedAt   DateTime?
-  input        Json?
-  summary      Json?
-  queueFingerprint String?
-  claimedAt    DateTime?
-  heartbeatAt  DateTime?
-  workerId     String?
-  errorMessage String?
+  finishedAt         DateTime?
+  input              Json?
+  summary            Json?
+  queueFingerprint   String?
+  claimedAt          DateTime?
+  heartbeatAt        DateTime?
+  workerId           String?
+  errorMessage       String?
 
   logs JobLogLine[]
 
@@ -248,14 +248,35 @@ model JobRun {
   @@index([userId, status, queuedAt])
 }
 
+model AutoRunMediaHistory {
+  id                String   @id @default(cuid())
+  jobId             String
+  mediaFingerprint  String
+  plexUserId        String
+  mediaType         String
+  librarySectionKey String
+  seedRatingKey     String?
+  showRatingKey     String?
+  seedTitle         String?
+  seedYear          Int?
+  seasonNumber      Int?
+  episodeNumber     Int?
+  source            String
+  firstRunId        String
+  createdAt         DateTime @default(now())
+
+  @@unique([jobId, mediaFingerprint])
+  @@index([jobId, plexUserId, librarySectionKey, createdAt])
+}
+
 model JobQueueState {
-  id            String   @id
-  activeRunId    String?
-  cooldownUntil  DateTime?
-  paused         Boolean  @default(false)
-  pauseReason    String?
-  version        Int      @default(0)
-  updatedAt      DateTime @updatedAt
+  id            String    @id
+  activeRunId   String?
+  cooldownUntil DateTime?
+  paused        Boolean   @default(false)
+  pauseReason   String?
+  version       Int       @default(0)
+  updatedAt     DateTime  @updatedAt
 }
 
 model JobLogLine {
@@ -383,7 +404,7 @@ model WatchedMovieRecommendation {
 model ImmaculateTasteMovieLibrary {
   plexUserId        String
   librarySectionKey String
-  profileId         String   @default("default")
+  profileId         String  @default("default")
   tmdbId            Int
   title             String?
 
@@ -464,9 +485,9 @@ model FreshReleaseMovieLibrary {
   tmdbPosterPath    String?
   tmdbVoteAvg       Float?
   tmdbVoteCount     Int?
-  lastCheckedAt     DateTime @default(now())
-  createdAt         DateTime @default(now())
-  updatedAt         DateTime @updatedAt
+  lastCheckedAt     DateTime  @default(now())
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
 
   @@id([librarySectionKey, tmdbId])
   @@index([librarySectionKey, releaseDate])
@@ -498,7 +519,7 @@ model ImmaculateTasteShow {
 model ImmaculateTasteShowLibrary {
   plexUserId        String
   librarySectionKey String
-  profileId         String   @default("default")
+  profileId         String  @default("default")
   // TV collections are keyed by tvdbId because Plex/Sonarr mapping is TVDB-first.
   tvdbId            Int
   tmdbId            Int?
@@ -611,7 +632,7 @@ model ImportedWatchEntry {
   tmdbId       Int?
   tvdbId       Int?
   matchedTitle String?
-  status       String   @default("pending")
+  status       String  @default("pending")
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/apps/api/src/jobs/auto-run-media.ts
+++ b/apps/api/src/jobs/auto-run-media.ts
@@ -1,0 +1,190 @@
+import { normalizeTitleForMatching } from '../lib/title-normalize';
+
+const DURABLE_AUTO_RUN_JOB_IDS = [
+  'immaculateTastePoints',
+  'watchedMovieRecommendations',
+] as const;
+
+export const DURABLE_AUTO_RUN_JOB_ID_SET = new Set<string>(
+  DURABLE_AUTO_RUN_JOB_IDS,
+);
+
+type AutoRunMediaInput = Record<string, unknown> | null | undefined;
+
+export type AutoRunMediaHistoryPayload = {
+  mediaFingerprint: string;
+  plexUserId: string;
+  mediaType: 'movie' | 'episode';
+  librarySectionKey: string;
+  seedRatingKey: string | null;
+  showRatingKey: string | null;
+  seedTitle: string | null;
+  seedYear: number | null;
+  seasonNumber: number | null;
+  episodeNumber: number | null;
+  source: string;
+};
+
+function pickString(input: AutoRunMediaInput, keys: string | string[]): string {
+  if (!input) return '';
+  const keyList = Array.isArray(keys) ? keys : [keys];
+  for (const key of keyList) {
+    const value = input[key];
+    if (typeof value !== 'string') continue;
+    const trimmed = value.trim();
+    if (trimmed) return trimmed;
+  }
+  return '';
+}
+
+function pickInteger(
+  input: AutoRunMediaInput,
+  keys: string | string[],
+): number | null {
+  if (!input) return null;
+  const keyList = Array.isArray(keys) ? keys : [keys];
+  for (const key of keyList) {
+    const value = input[key];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return Math.trunc(value);
+    }
+    if (typeof value === 'string' && value.trim()) {
+      const parsed = Number.parseInt(value.trim(), 10);
+      if (Number.isFinite(parsed)) return parsed;
+    }
+  }
+  return null;
+}
+
+function normalizeFingerprintTitle(title: string): string {
+  return normalizeTitleForMatching(title).trim().toLowerCase();
+}
+
+function normalizeDebugTitle(title: string): string {
+  return normalizeTitleForMatching(title).trim();
+}
+
+function pickLibrarySectionKey(input: AutoRunMediaInput): string {
+  return (
+    pickString(input, ['seedLibrarySectionKey', 'librarySectionKey']) ||
+    (() => {
+      const librarySectionId = pickInteger(input, 'seedLibrarySectionId');
+      return librarySectionId === null ? '' : String(librarySectionId);
+    })()
+  );
+}
+
+export function buildAutoRunMediaFingerprint(
+  input: AutoRunMediaInput,
+): string | null {
+  const plexUserId = pickString(input, 'plexUserId');
+  const mediaType = pickString(input, 'mediaType').toLowerCase();
+  const librarySectionKey = pickLibrarySectionKey(input);
+  if (!plexUserId || !librarySectionKey) return null;
+
+  if (mediaType === 'movie') {
+    const seedRatingKey = pickString(input, ['seedRatingKey', 'ratingKey']);
+    if (seedRatingKey) {
+      return [
+        'movie',
+        `plexUser:${plexUserId}`,
+        `library:${librarySectionKey}`,
+        `ratingKey:${seedRatingKey}`,
+      ].join('|');
+    }
+
+    const seedTitle = normalizeFingerprintTitle(
+      pickString(input, ['seedTitle', 'title']),
+    );
+    const seedYear = pickInteger(input, 'seedYear');
+    if (!seedTitle || seedYear === null) return null;
+
+    return [
+      'movie',
+      `plexUser:${plexUserId}`,
+      `library:${librarySectionKey}`,
+      `title:${seedTitle}`,
+      `year:${seedYear}`,
+    ].join('|');
+  }
+
+  if (mediaType === 'episode') {
+    const episodeRatingKey = pickString(input, ['seedRatingKey', 'ratingKey']);
+    if (episodeRatingKey) {
+      return [
+        'episode',
+        `plexUser:${plexUserId}`,
+        `library:${librarySectionKey}`,
+        `ratingKey:${episodeRatingKey}`,
+      ].join('|');
+    }
+
+    const showRatingKey = pickString(input, 'showRatingKey');
+    const seasonNumber = pickInteger(input, 'seasonNumber');
+    const episodeNumber = pickInteger(input, 'episodeNumber');
+    if (showRatingKey && seasonNumber !== null && episodeNumber !== null) {
+      return [
+        'episode',
+        `plexUser:${plexUserId}`,
+        `library:${librarySectionKey}`,
+        `showRatingKey:${showRatingKey}`,
+        `season:${seasonNumber}`,
+        `episode:${episodeNumber}`,
+      ].join('|');
+    }
+
+    const showTitle = normalizeFingerprintTitle(
+      pickString(input, ['showTitle', 'grandparentTitle', 'seedTitle']),
+    );
+    if (!showTitle || seasonNumber === null || episodeNumber === null) {
+      return null;
+    }
+
+    return [
+      'episode',
+      `plexUser:${plexUserId}`,
+      `library:${librarySectionKey}`,
+      `showTitle:${showTitle}`,
+      `season:${seasonNumber}`,
+      `episode:${episodeNumber}`,
+    ].join('|');
+  }
+
+  return null;
+}
+
+export function buildAutoRunMediaHistoryPayload(
+  input: AutoRunMediaInput,
+): AutoRunMediaHistoryPayload | null {
+  const mediaFingerprint = buildAutoRunMediaFingerprint(input);
+  if (!mediaFingerprint) return null;
+
+  const plexUserId = pickString(input, 'plexUserId');
+  const mediaType = pickString(input, 'mediaType').toLowerCase();
+  const librarySectionKey = pickLibrarySectionKey(input);
+  if (
+    !plexUserId ||
+    !librarySectionKey ||
+    (mediaType !== 'movie' && mediaType !== 'episode')
+  ) {
+    return null;
+  }
+
+  const seedTitle = normalizeDebugTitle(
+    pickString(input, ['seedTitle', 'title', 'showTitle']),
+  );
+
+  return {
+    mediaFingerprint,
+    plexUserId,
+    mediaType,
+    librarySectionKey,
+    seedRatingKey: pickString(input, ['seedRatingKey', 'ratingKey']) || null,
+    showRatingKey: pickString(input, 'showRatingKey') || null,
+    seedTitle: seedTitle || null,
+    seedYear: pickInteger(input, 'seedYear'),
+    seasonNumber: pickInteger(input, 'seasonNumber'),
+    episodeNumber: pickInteger(input, 'episodeNumber'),
+    source: pickString(input, 'source') || 'unknown',
+  };
+}

--- a/apps/api/src/jobs/job-registry.ts
+++ b/apps/api/src/jobs/job-registry.ts
@@ -115,6 +115,11 @@ function buildWebhookFingerprint(
   const input = params.input ?? null;
   if (!input) return null;
 
+  const autoRunMediaFingerprint = pickString(input, 'autoRunMediaFingerprint');
+  if (autoRunMediaFingerprint) {
+    return `${params.jobId}|media:${autoRunMediaFingerprint}|dryRun:${params.dryRun ? '1' : '0'}`;
+  }
+
   const sessionAutomationId = pickString(input, 'sessionAutomationId');
   if (sessionAutomationId) {
     return `${params.jobId}|session:${sessionAutomationId}|dryRun:${params.dryRun ? '1' : '0'}`;
@@ -279,7 +284,7 @@ export const JOB_DEFINITIONS: JobDefinitionInfo[] = [
     id: 'immaculateTastePoints',
     name: 'Immaculate Taste Collection',
     description:
-      'Triggered by Plex webhooks when a movie is finished. Updates the Immaculate Taste points dataset and optionally sends missing movies to Radarr.',
+      'Triggered by Plex watch activity for newly completed movies or episodes. Updates the Immaculate Taste points dataset and optionally sends missing titles to Radarr, Sonarr, or Seerr.',
     defaultScheduleCron: undefined,
     defaultEstimatedRuntimeMs: 12 * 60_000,
     dedupePolicy: 'queue_fingerprint',
@@ -300,7 +305,7 @@ export const JOB_DEFINITIONS: JobDefinitionInfo[] = [
     id: 'watchedMovieRecommendations',
     name: 'Based on Latest Watched Collection',
     description:
-      'Triggered by Plex webhooks when a movie is finished. Generates recommendations and rebuilds curated Plex collections in the same Plex movie library you watched from.',
+      'Triggered by Plex watch activity for newly completed movies or episodes. Generates recommendations and rebuilds curated Plex collections in the same Plex library you watched from.',
     defaultScheduleCron: undefined,
     defaultEstimatedRuntimeMs: 12 * 60_000,
     dedupePolicy: 'queue_fingerprint',

--- a/apps/api/src/jobs/job-registry.ts
+++ b/apps/api/src/jobs/job-registry.ts
@@ -266,6 +266,16 @@ export const JOB_DEFINITIONS: JobDefinitionInfo[] = [
     estimateKeyBuilder: buildDefaultEstimateKey,
   }),
   defineJob({
+    id: 'rottenTomatoesUpcomingMovies',
+    name: 'Rotten Tomatoes Upcoming Movies',
+    description:
+      'Scrapes fixed Rotten Tomatoes upcoming and newest movie pages, deduplicates safe matches, and routes them to Radarr or Seerr.',
+    defaultScheduleCron: '0 5 * * 0',
+    defaultEstimatedRuntimeMs: 14 * 60_000,
+    dedupePolicy: 'schedule_singleton',
+    estimateKeyBuilder: buildDefaultEstimateKey,
+  }),
+  defineJob({
     id: 'immaculateTastePoints',
     name: 'Immaculate Taste Collection',
     description:

--- a/apps/api/src/jobs/jobs.handlers.ts
+++ b/apps/api/src/jobs/jobs.handlers.ts
@@ -11,6 +11,7 @@ import { BasedonLatestWatchedCollectionJob } from './basedon-latest-watched-coll
 import { CollectionResyncUpgradeJob } from './collection-resync-upgrade.job';
 import { FreshOutOfTheOvenJob } from './fresh-out-of-the-oven.job';
 import { TmdbUpcomingMoviesJob } from './tmdb-upcoming-movies.job';
+import { RottenTomatoesUpcomingMoviesJob } from './rotten-tomatoes-upcoming-movies.job';
 import { ImportNetflixHistoryJob } from './import-netflix-history.job';
 import { ImportPlexHistoryJob } from './import-plex-history.job';
 
@@ -28,6 +29,7 @@ export class JobsHandlers {
     private readonly collectionResyncUpgradeJob: CollectionResyncUpgradeJob,
     private readonly freshOutOfTheOvenJob: FreshOutOfTheOvenJob,
     private readonly tmdbUpcomingMoviesJob: TmdbUpcomingMoviesJob,
+    private readonly rottenTomatoesUpcomingMoviesJob: RottenTomatoesUpcomingMoviesJob,
     private readonly importNetflixHistoryJob: ImportNetflixHistoryJob,
     private readonly importPlexHistoryJob: ImportPlexHistoryJob,
   ) {}
@@ -42,6 +44,8 @@ export class JobsHandlers {
         return await this.arrMonitoredSearchJob.run(ctx);
       case 'tmdbUpcomingMovies':
         return await this.tmdbUpcomingMoviesJob.run(ctx);
+      case 'rottenTomatoesUpcomingMovies':
+        return await this.rottenTomatoesUpcomingMoviesJob.run(ctx);
       case 'mediaAddedCleanup':
         return await this.cleanupAfterAddingNewContentJob.run(ctx);
       case 'immaculateTastePoints':

--- a/apps/api/src/jobs/jobs.module.ts
+++ b/apps/api/src/jobs/jobs.module.ts
@@ -30,6 +30,7 @@ import { ArrInstanceModule } from '../arr-instances/arr-instance.module';
 import { ImmaculateTasteProfileModule } from '../immaculate-taste-profiles/immaculate-taste-profile.module';
 import { FreshOutOfTheOvenJob } from './fresh-out-of-the-oven.job';
 import { TmdbUpcomingMoviesJob } from './tmdb-upcoming-movies.job';
+import { RottenTomatoesUpcomingMoviesJob } from './rotten-tomatoes-upcoming-movies.job';
 import { ImportNetflixHistoryJob } from './import-netflix-history.job';
 import { ImportPlexHistoryJob } from './import-plex-history.job';
 import { ImportModule } from '../import/import.module';
@@ -71,6 +72,7 @@ import { AuthModule } from '../auth/auth.module';
     FreshOutOfTheOvenJob,
     CollectionResyncUpgradeJob,
     TmdbUpcomingMoviesJob,
+    RottenTomatoesUpcomingMoviesJob,
     ImportNetflixHistoryJob,
     ImportPlexHistoryJob,
     CollectionResyncUpgradeService,

--- a/apps/api/src/jobs/jobs.service.spec.ts
+++ b/apps/api/src/jobs/jobs.service.spec.ts
@@ -1,0 +1,360 @@
+import { ConflictException } from '@nestjs/common';
+import type { JobRunTrigger } from '@prisma/client';
+import { buildAutoRunMediaFingerprint } from './auto-run-media';
+import { JobsService } from './jobs.service';
+
+type RunInput = ReturnType<typeof makeRunInput>;
+
+type JobsServiceForSpies = {
+  ensureQueueState: () => Promise<unknown>;
+  scheduleQueuePump: (reason: string) => Promise<void>;
+};
+
+type FinalizeRunningRun = (params: {
+  runId: string;
+  status: 'SUCCESS' | 'FAILED' | 'CANCELLED';
+  finishedAt: Date;
+  summary?: Record<string, unknown> | null;
+  errorMessage?: string | null;
+  runContext?: {
+    jobId: string;
+    trigger: JobRunTrigger;
+    dryRun: boolean;
+    input?: RunInput | null;
+  };
+}) => Promise<boolean>;
+
+type FinalizeRunningRunParams = Parameters<FinalizeRunningRun>[0];
+
+function callFinalizeRunningRun(
+  service: JobsService,
+  params: FinalizeRunningRunParams,
+) {
+  const finalizeRunningRun = (
+    service as unknown as { finalizeRunningRun: FinalizeRunningRun }
+  ).finalizeRunningRun;
+  return finalizeRunningRun.call(service, params);
+}
+
+type JobsServicePrivate = JobsServiceForSpies & {
+  finalizeRunningRun: (params: {
+    runId: string;
+    status: 'SUCCESS' | 'FAILED' | 'CANCELLED';
+    finishedAt: Date;
+    summary?: Record<string, unknown> | null;
+    errorMessage?: string | null;
+    runContext?: {
+      jobId: string;
+      trigger: JobRunTrigger;
+      dryRun: boolean;
+      input?: RunInput | null;
+    };
+  }) => Promise<boolean>;
+};
+
+function makeQueueState() {
+  return {
+    id: 'global',
+    activeRunId: null,
+    cooldownUntil: null,
+    paused: false,
+    pauseReason: null,
+    version: 0,
+    updatedAt: new Date('2026-04-11T00:00:00.000Z'),
+  };
+}
+
+function makeRunInput() {
+  const input = {
+    source: 'plexPolling',
+    plexUserId: 'plex-user-2',
+    plexUserTitle: 'Alice',
+    mediaType: 'movie',
+    seedTitle: 'Inception',
+    seedYear: 2010,
+    seedRatingKey: 'movie-1',
+    seedLibrarySectionId: 1,
+    seedLibrarySectionTitle: 'Movies',
+  };
+  const autoRunMediaFingerprint = buildAutoRunMediaFingerprint(input);
+  if (!autoRunMediaFingerprint) {
+    throw new Error('Expected a stable auto-run media fingerprint');
+  }
+
+  return {
+    ...input,
+    autoRunMediaFingerprint,
+  };
+}
+
+function makeCreatedRun(params: {
+  jobId: string;
+  trigger: JobRunTrigger;
+  input: RunInput;
+}) {
+  const now = new Date('2026-04-11T00:00:00.000Z');
+  return {
+    id: 'run-1',
+    jobId: params.jobId,
+    userId: 'admin-user',
+    trigger: params.trigger,
+    dryRun: false,
+    status: 'PENDING',
+    startedAt: now,
+    queuedAt: now,
+    executionStartedAt: null,
+    finishedAt: null,
+    summary: { phase: 'queued' },
+    errorMessage: null,
+    input: params.input,
+    queueFingerprint: `${params.jobId}|media:${params.input.autoRunMediaFingerprint}|dryRun:0`,
+    claimedAt: null,
+    heartbeatAt: null,
+    workerId: null,
+  };
+}
+
+function makeSuccessReport(skipped = false) {
+  return {
+    template: 'jobReportV1' as const,
+    version: 1 as const,
+    jobId: 'watchedMovieRecommendations',
+    dryRun: false,
+    trigger: 'auto' as const,
+    headline: skipped ? 'Skipped.' : 'Completed.',
+    sections: [],
+    tasks: [],
+    issues: [],
+    raw: skipped ? { skipped: true, reason: 'library_excluded' } : { ok: true },
+  };
+}
+
+function readConflictReason(error: unknown): string | null {
+  if (!(error instanceof ConflictException)) return null;
+  const response = error.getResponse();
+  if (!response || typeof response !== 'object' || Array.isArray(response)) {
+    return null;
+  }
+  const reason = (response as Record<string, unknown>)['reason'];
+  return typeof reason === 'string' ? reason : null;
+}
+
+function getAutoRunHistoryUpsertArg(tx: ReturnType<typeof makeService>['tx']) {
+  const firstCall = tx.autoRunMediaHistory.upsert.mock.calls[0] as
+    | [unknown]
+    | undefined;
+  return firstCall?.[0] as
+    | {
+        where: {
+          jobId_mediaFingerprint: {
+            jobId: string;
+            mediaFingerprint: string;
+          };
+        };
+        update: Record<string, never>;
+        create: Record<string, unknown>;
+      }
+    | undefined;
+}
+
+function makeService() {
+  const tx = {
+    jobRun: {
+      count: jest.fn(),
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      updateMany: jest.fn(),
+    },
+    jobQueueState: {
+      update: jest.fn(),
+    },
+    jobLogLine: {
+      create: jest.fn(),
+    },
+    autoRunMediaHistory: {
+      findUnique: jest.fn(),
+      upsert: jest.fn(),
+    },
+  };
+
+  const prisma = {
+    $transaction: jest.fn(async (callback: (client: typeof tx) => unknown) => {
+      return await callback(tx);
+    }),
+  };
+
+  const handlers = {
+    run: jest.fn(),
+  };
+
+  const service = new JobsService(prisma as never, handlers as never);
+  const privateService = service as unknown as JobsServicePrivate;
+  tx.jobRun.count.mockResolvedValue(0);
+  tx.jobRun.findFirst.mockResolvedValue(null);
+  tx.jobQueueState.update.mockResolvedValue(makeQueueState());
+  tx.jobLogLine.create.mockResolvedValue({});
+  tx.autoRunMediaHistory.findUnique.mockResolvedValue(null);
+  tx.autoRunMediaHistory.upsert.mockResolvedValue({ id: 'history-1' });
+  jest
+    .spyOn(privateService, 'ensureQueueState')
+    .mockResolvedValue(makeQueueState());
+  jest.spyOn(privateService, 'scheduleQueuePump').mockResolvedValue(undefined);
+
+  return {
+    service,
+    tx,
+  };
+}
+
+describe('JobsService durable auto-run media dedupe', () => {
+  it('blocks auto enqueue when a durable media history record already exists', async () => {
+    const { service, tx } = makeService();
+    const input = makeRunInput();
+    tx.autoRunMediaHistory.findUnique.mockResolvedValue({ id: 'history-1' });
+
+    await service
+      .runJob({
+        jobId: 'watchedMovieRecommendations',
+        trigger: 'auto',
+        dryRun: false,
+        userId: 'admin-user',
+        input,
+      })
+      .catch((error) => {
+        expect(error).toBeInstanceOf(ConflictException);
+        expect(readConflictReason(error)).toBe('already_processed');
+      });
+
+    expect(tx.autoRunMediaHistory.findUnique).toHaveBeenCalledWith({
+      where: {
+        jobId_mediaFingerprint: {
+          jobId: 'watchedMovieRecommendations',
+          mediaFingerprint: input.autoRunMediaFingerprint,
+        },
+      },
+      select: { id: true },
+    });
+    expect(tx.jobRun.create).not.toHaveBeenCalled();
+  });
+
+  it('writes a durable history record only after a successful non-skipped auto run', async () => {
+    const { service, tx } = makeService();
+    const input = makeRunInput();
+    tx.jobRun.updateMany.mockResolvedValue({ count: 1 });
+
+    const finalized = await callFinalizeRunningRun(service, {
+      runId: 'run-1',
+      status: 'SUCCESS',
+      finishedAt: new Date('2026-04-11T00:05:00.000Z'),
+      summary: makeSuccessReport(false),
+      errorMessage: null,
+      runContext: {
+        jobId: 'watchedMovieRecommendations',
+        trigger: 'auto',
+        dryRun: false,
+        input,
+      },
+    });
+
+    expect(finalized).toBe(true);
+    const upsertArg = getAutoRunHistoryUpsertArg(tx);
+    expect(upsertArg).toMatchObject({
+      where: {
+        jobId_mediaFingerprint: {
+          jobId: 'watchedMovieRecommendations',
+          mediaFingerprint: input.autoRunMediaFingerprint,
+        },
+      },
+      update: {},
+    });
+    expect(upsertArg?.create['jobId']).toBe('watchedMovieRecommendations');
+    expect(upsertArg?.create['mediaFingerprint']).toBe(
+      input.autoRunMediaFingerprint,
+    );
+    expect(upsertArg?.create['plexUserId']).toBe('plex-user-2');
+    expect(upsertArg?.create['mediaType']).toBe('movie');
+    expect(upsertArg?.create['librarySectionKey']).toBe('1');
+    expect(upsertArg?.create['seedRatingKey']).toBe('movie-1');
+    expect(upsertArg?.create['seedTitle']).toBe('Inception');
+    expect(upsertArg?.create['seedYear']).toBe(2010);
+    expect(upsertArg?.create['source']).toBe('plexPolling');
+    expect(upsertArg?.create['firstRunId']).toBe('run-1');
+  });
+
+  it('does not write a durable history record for failed or skipped auto runs', async () => {
+    const { service, tx } = makeService();
+    const input = makeRunInput();
+    tx.jobRun.updateMany.mockResolvedValue({ count: 1 });
+
+    await callFinalizeRunningRun(service, {
+      runId: 'run-failed',
+      status: 'FAILED',
+      finishedAt: new Date('2026-04-11T00:05:00.000Z'),
+      summary: makeSuccessReport(false),
+      errorMessage: 'boom',
+      runContext: {
+        jobId: 'watchedMovieRecommendations',
+        trigger: 'auto',
+        dryRun: false,
+        input,
+      },
+    });
+    await callFinalizeRunningRun(service, {
+      runId: 'run-skipped',
+      status: 'SUCCESS',
+      finishedAt: new Date('2026-04-11T00:06:00.000Z'),
+      summary: makeSuccessReport(true),
+      errorMessage: null,
+      runContext: {
+        jobId: 'watchedMovieRecommendations',
+        trigger: 'auto',
+        dryRun: false,
+        input,
+      },
+    });
+
+    expect(tx.autoRunMediaHistory.upsert).not.toHaveBeenCalled();
+  });
+
+  it('still returns already_queued_or_running for pending or running duplicates', async () => {
+    const { service, tx } = makeService();
+    const input = makeRunInput();
+    tx.jobRun.findFirst.mockResolvedValue({ id: 'existing-run' });
+
+    await service
+      .runJob({
+        jobId: 'watchedMovieRecommendations',
+        trigger: 'auto',
+        dryRun: false,
+        userId: 'admin-user',
+        input,
+      })
+      .catch((error) => {
+        expect(readConflictReason(error)).toBe('already_queued_or_running');
+      });
+  });
+
+  it('ignores the durable history record for manual runs', async () => {
+    const { service, tx } = makeService();
+    const input = makeRunInput();
+    tx.jobRun.create.mockResolvedValue(
+      makeCreatedRun({
+        jobId: 'watchedMovieRecommendations',
+        trigger: 'manual',
+        input,
+      }),
+    );
+
+    const run = await service.runJob({
+      jobId: 'watchedMovieRecommendations',
+      trigger: 'manual',
+      dryRun: false,
+      userId: 'admin-user',
+      input,
+    });
+
+    expect(run.status).toBe('PENDING');
+    expect(tx.autoRunMediaHistory.findUnique).not.toHaveBeenCalled();
+    expect(tx.jobRun.create).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/jobs/jobs.service.ts
+++ b/apps/api/src/jobs/jobs.service.ts
@@ -28,6 +28,10 @@ import {
   IMMACULATE_TASTE_PROFILE_ACTION_JOB_ID,
   JOB_DEFINITIONS,
 } from './job-registry';
+import {
+  buildAutoRunMediaHistoryPayload,
+  DURABLE_AUTO_RUN_JOB_ID_SET,
+} from './auto-run-media';
 import { JobsHandlers } from './jobs.handlers';
 import type { JobReportV1 } from './job-report-v1';
 import type {
@@ -145,6 +149,8 @@ type EstimateHistoryEntry = {
 
 type EstimateHistoryGroups = Map<string, EstimateHistoryEntry[]>;
 
+type EnqueueConflictReason = 'already_processed' | 'already_queued_or_running';
+
 function toIsoString(value: unknown): string | null {
   if (value instanceof Date) return value.toISOString();
   if (typeof value === 'string') return value.trim() ? value.trim() : null;
@@ -211,6 +217,58 @@ function evaluateJobReportFailure(report: JobReportV1): {
   return {
     failed: true,
     reason: `Job reported failed task(s): ${parts.join(' | ')}${more}`,
+  };
+}
+
+function buildEnqueueConflictException(
+  reason: EnqueueConflictReason,
+): ConflictException {
+  return new ConflictException({
+    reason,
+    message:
+      reason === 'already_processed'
+        ? 'Job already processed for this media.'
+        : 'Job already queued or running',
+  });
+}
+
+function shouldUseDurableAutoRunDedupe(params: {
+  jobId: string;
+  trigger: JobRunTrigger;
+  dryRun: boolean;
+}) {
+  return (
+    params.trigger === 'auto' &&
+    !params.dryRun &&
+    DURABLE_AUTO_RUN_JOB_ID_SET.has(params.jobId)
+  );
+}
+
+function isRunSummaryMarkedSkipped(summary: JsonObject | null | undefined) {
+  if (!summary) return false;
+  if (summary['skipped'] === true) return true;
+  const raw = summary['raw'];
+  return isPlainObject(raw) && raw['skipped'] === true;
+}
+
+function buildDurableAutoRunHistoryRecord(params: {
+  runId: string;
+  jobId: string;
+  trigger: JobRunTrigger;
+  dryRun: boolean;
+  input?: JsonObject | null;
+  summary?: JsonObject | null;
+}) {
+  if (!shouldUseDurableAutoRunDedupe(params)) return null;
+  if (isRunSummaryMarkedSkipped(params.summary)) return null;
+
+  const payload = buildAutoRunMediaHistoryPayload(params.input ?? null);
+  if (!payload) return null;
+
+  return {
+    ...payload,
+    jobId: params.jobId,
+    firstRunId: params.runId,
   };
 }
 
@@ -940,7 +998,32 @@ export class JobsService implements OnModuleInit {
             trigger: params.trigger,
             reason: 'already_queued_or_running',
           });
-          throw new ConflictException('Job already queued or running');
+          throw buildEnqueueConflictException('already_queued_or_running');
+        }
+      }
+
+      const durableHistory =
+        shouldUseDurableAutoRunDedupe(params) &&
+        params.input &&
+        buildAutoRunMediaHistoryPayload(params.input);
+      if (durableHistory) {
+        const existing = await tx.autoRunMediaHistory.findUnique({
+          where: {
+            jobId_mediaFingerprint: {
+              jobId: params.jobId,
+              mediaFingerprint: durableHistory.mediaFingerprint,
+            },
+          },
+          select: { id: true },
+        });
+        if (existing) {
+          this.logQueueDecision('enqueue_deduped', {
+            jobId: params.jobId,
+            trigger: params.trigger,
+            reason: 'already_processed',
+            mediaFingerprint: durableHistory.mediaFingerprint,
+          });
+          throw buildEnqueueConflictException('already_processed');
         }
       }
 
@@ -960,8 +1043,9 @@ export class JobsService implements OnModuleInit {
             jobId: params.jobId,
             trigger: params.trigger,
             queueFingerprint,
+            reason: 'already_queued_or_running',
           });
-          throw new ConflictException('Job already queued or running');
+          throw buildEnqueueConflictException('already_queued_or_running');
         }
       }
 
@@ -1279,6 +1363,12 @@ export class JobsService implements OnModuleInit {
           context: reportFailure.reason
             ? { reason: reportFailure.reason }
             : undefined,
+          runContext: {
+            jobId: run.jobId,
+            trigger: run.trigger,
+            dryRun: run.dryRun,
+            input: ctx.input ?? null,
+          },
         });
 
         const ms = finishedAt.getTime() - executionStartedAt.getTime();
@@ -1302,6 +1392,12 @@ export class JobsService implements OnModuleInit {
         finishedAt,
         summary: finalSummary,
         errorMessage: null,
+        runContext: {
+          jobId: run.jobId,
+          trigger: run.trigger,
+          dryRun: run.dryRun,
+          input: ctx.input ?? null,
+        },
       });
 
       const ms = finishedAt.getTime() - executionStartedAt.getTime();
@@ -1330,6 +1426,12 @@ export class JobsService implements OnModuleInit {
         finishedAt,
         summary: ctx.getSummary() ?? null,
         errorMessage: message,
+        runContext: {
+          jobId: run.jobId,
+          trigger: run.trigger,
+          dryRun: run.dryRun,
+          input: ctx.input ?? null,
+        },
       });
 
       const ms = finishedAt.getTime() - executionStartedAt.getTime();
@@ -1355,14 +1457,32 @@ export class JobsService implements OnModuleInit {
     errorMessage?: string | null;
     message?: string;
     context?: JsonObject;
+    runContext?: {
+      jobId: string;
+      trigger: JobRunTrigger;
+      dryRun: boolean;
+      input?: JsonObject | null;
+    };
   }) {
     const cooldownUntil =
       params.status === 'CANCELLED'
         ? null
         : new Date(params.finishedAt.getTime() + QUEUE_COOLDOWN_MS);
 
-    const [runResult] = await this.prisma.$transaction([
-      this.prisma.jobRun.updateMany({
+    const durableHistoryRecord =
+      params.status === 'SUCCESS' && params.runContext
+        ? buildDurableAutoRunHistoryRecord({
+            runId: params.runId,
+            jobId: params.runContext.jobId,
+            trigger: params.runContext.trigger,
+            dryRun: params.runContext.dryRun,
+            input: params.runContext.input ?? null,
+            summary: params.summary ?? null,
+          })
+        : null;
+
+    const runResult = await this.prisma.$transaction(async (tx) => {
+      const updatedRun = await tx.jobRun.updateMany({
         where: { id: params.runId, status: 'RUNNING' },
         data: {
           status: params.status,
@@ -1370,28 +1490,44 @@ export class JobsService implements OnModuleInit {
           summary: params.summary ?? Prisma.DbNull,
           errorMessage: params.errorMessage ?? null,
         },
-      }),
-      this.prisma.jobQueueState.update({
+      });
+
+      await tx.jobQueueState.update({
         where: { id: GLOBAL_QUEUE_STATE_ID },
         data: {
           activeRunId: null,
           cooldownUntil,
           version: { increment: 1 },
         },
-      }),
-      ...(params.message
-        ? [
-            this.prisma.jobLogLine.create({
-              data: {
-                runId: params.runId,
-                level: params.status === 'SUCCESS' ? 'info' : 'error',
-                message: params.message,
-                context: params.context ?? Prisma.DbNull,
-              },
-            }),
-          ]
-        : []),
-    ]);
+      });
+
+      if (params.message) {
+        await tx.jobLogLine.create({
+          data: {
+            runId: params.runId,
+            level: params.status === 'SUCCESS' ? 'info' : 'error',
+            message: params.message,
+            context: params.context ?? Prisma.DbNull,
+          },
+        });
+      }
+
+      if (updatedRun.count > 0 && durableHistoryRecord) {
+        await tx.autoRunMediaHistory.upsert({
+          where: {
+            jobId_mediaFingerprint: {
+              jobId: durableHistoryRecord.jobId,
+              mediaFingerprint: durableHistoryRecord.mediaFingerprint,
+            },
+          },
+          update: {},
+          create: durableHistoryRecord,
+        });
+      }
+
+      return updatedRun;
+    });
+
     return runResult.count > 0;
   }
 

--- a/apps/api/src/jobs/rotten-tomatoes-upcoming-movies.job.spec.ts
+++ b/apps/api/src/jobs/rotten-tomatoes-upcoming-movies.job.spec.ts
@@ -1,0 +1,496 @@
+import type { JobContext, JobRunTrigger, JsonObject } from './jobs.types';
+import {
+  RottenTomatoesUpcomingMoviesJob,
+  buildRadarrMovieIndex,
+  dedupeScrapedMovies,
+  parseRottenTomatoesMoviesFromHtml,
+  selectLookupMovie,
+} from './rotten-tomatoes-upcoming-movies.job';
+import { SettingsService } from '../settings/settings.service';
+import { RadarrService } from '../radarr/radarr.service';
+import { SeerrService } from '../seerr/seerr.service';
+
+type SettingsMock = Pick<
+  SettingsService,
+  'getInternalSettings' | 'readServiceSecret'
+>;
+type RadarrMock = Pick<
+  RadarrService,
+  | 'listMovies'
+  | 'lookupMovies'
+  | 'listRootFolders'
+  | 'listQualityProfiles'
+  | 'listTags'
+  | 'addMovie'
+>;
+type SeerrMock = Pick<SeerrService, 'requestMovie'>;
+
+function createContext(params?: {
+  trigger?: JobRunTrigger;
+  dryRun?: boolean;
+}): JobContext {
+  const trigger = params?.trigger ?? 'manual';
+  const dryRun = params?.dryRun ?? false;
+  let currentSummary: JsonObject | null = null;
+  const setSummary = jest.fn((summary: JsonObject | null) => {
+    currentSummary = summary;
+    return Promise.resolve();
+  });
+  const patchSummary = jest.fn((patch: JsonObject) => {
+    currentSummary = { ...(currentSummary ?? {}), ...patch };
+    return Promise.resolve();
+  });
+  const log = jest.fn(() => Promise.resolve());
+
+  return {
+    jobId: 'rottenTomatoesUpcomingMovies',
+    runId: 'run-1',
+    userId: 'user-1',
+    trigger,
+    dryRun,
+    getSummary: () => currentSummary,
+    setSummary,
+    patchSummary,
+    log,
+    debug: log,
+    info: log,
+    warn: log,
+    error: log,
+  };
+}
+
+function createJob() {
+  const settings: jest.Mocked<SettingsMock> = {
+    getInternalSettings: jest.fn(),
+    readServiceSecret: jest.fn(),
+  };
+  const radarr: jest.Mocked<RadarrMock> = {
+    listMovies: jest.fn(),
+    lookupMovies: jest.fn(),
+    listRootFolders: jest.fn(),
+    listQualityProfiles: jest.fn(),
+    listTags: jest.fn(),
+    addMovie: jest.fn(),
+  };
+  const seerr: jest.Mocked<SeerrMock> = {
+    requestMovie: jest.fn(),
+  };
+
+  const job = new RottenTomatoesUpcomingMoviesJob(
+    settings as unknown as SettingsService,
+    radarr as unknown as RadarrService,
+    seerr as unknown as SeerrService,
+  );
+
+  return { job, settings, radarr, seerr };
+}
+
+function createSourceHtml(
+  entries: Array<{ title: string; href: string; startDate: string }>,
+): string {
+  return entries
+    .map(
+      (entry) => `
+        <a data-qa="discovery-media-list-item-caption" href="${entry.href}">
+          <span data-qa="discovery-media-list-item-title">${entry.title}</span>
+          <span data-qa="discovery-media-list-item-start-date">${entry.startDate}</span>
+        </a>
+      `,
+    )
+    .join('\n');
+}
+
+describe('RottenTomatoesUpcomingMoviesJob', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('parses Rotten Tomatoes cards and prefers year from slug before start-date', () => {
+    const parsed = parseRottenTomatoesMoviesFromHtml({
+      sourceUrl:
+        'https://www.rottentomatoes.com/browse/movies_in_theaters/sort:newest',
+      html: createSourceHtml([
+        {
+          title: 'The Example',
+          href: '/m/the_example_2026',
+          startDate: 'Streaming Apr 7, 2025',
+        },
+      ]),
+    });
+
+    expect(parsed.discoveredEntries).toBe(1);
+    expect(parsed.skippedNoYear).toBe(0);
+    expect(parsed.movies).toEqual([
+      expect.objectContaining({
+        title: 'The Example',
+        year: '2026',
+        href: '/m/the_example_2026',
+      }),
+    ]);
+  });
+
+  it('dedupes scraped movies by normalized title and year across sources', () => {
+    const deduped = dedupeScrapedMovies([
+      {
+        title: 'Touch Me',
+        year: '2025',
+        href: '/m/touch_me_2025',
+        startDate: 'Streaming Apr 7, 2025',
+        sourceUrl: 'source-a',
+      },
+      {
+        title: 'Touch Me',
+        year: '2025',
+        href: '/m/touch_me_2025',
+        startDate: 'Streaming Apr 7, 2025',
+        sourceUrl: 'source-b',
+      },
+      {
+        title: 'Touch Me',
+        year: '2026',
+        href: '/m/touch_me_2026',
+        startDate: 'Streaming Apr 7, 2026',
+        sourceUrl: 'source-c',
+      },
+    ]);
+
+    expect(deduped).toHaveLength(2);
+    expect(deduped.map((movie) => `${movie.title}:${movie.year}`)).toEqual([
+      'Touch Me:2025',
+      'Touch Me:2026',
+    ]);
+  });
+
+  it('selects conservative title-only lookup matches and rejects unrelated same-title years', () => {
+    const safeMatch = selectLookupMovie(
+      [
+        { id: 1, title: 'Touch Me', year: 2024, tmdbId: 101 },
+        { id: 2, title: 'Touch Me', year: 2026, tmdbId: 102 },
+      ],
+      'Touch Me',
+      '2025',
+    );
+    const rejectedMatch = selectLookupMovie(
+      [{ id: 3, title: 'Family Tree', year: 2009, tmdbId: 201 }],
+      'Family Tree',
+      '2025',
+    );
+
+    expect(safeMatch).toEqual(
+      expect.objectContaining({ title: 'Touch Me', year: 2024, tmdbId: 101 }),
+    );
+    expect(rejectedMatch).toBeNull();
+  });
+
+  it('builds Radarr index from tmdb ids and normalized title-year keys', () => {
+    const index = buildRadarrMovieIndex([
+      { id: 1, title: 'The Bride!', year: 2026, tmdbId: 101 },
+      { id: 2, title: 'Touch Me', year: 2025, tmdbId: 102 },
+    ]);
+
+    expect(index.tmdbIds.has(101)).toBe(true);
+    expect(index.tmdbIds.has(102)).toBe(true);
+    expect(index.titleYearKeys.has('the bride|2026')).toBe(true);
+    expect(index.titleYearKeys.has('touch me|2025')).toBe(true);
+  });
+
+  it('continues when one Rotten Tomatoes source fails', async () => {
+    const { job, settings } = createJob();
+    const ctx = createContext({ dryRun: true });
+    const fetchMock = jest.spyOn(globalThis, 'fetch');
+
+    settings.getInternalSettings.mockResolvedValue({
+      settings: {},
+      secrets: {},
+    });
+    settings.readServiceSecret.mockReturnValue('');
+    let callCount = 0;
+    fetchMock.mockImplementation(() => {
+      callCount += 1;
+      if (callCount === 1) {
+        return Promise.reject(new Error('boom'));
+      }
+      if (callCount === 2) {
+        return Promise.resolve({
+          ok: true,
+          text: () =>
+            Promise.resolve(
+              createSourceHtml([
+                {
+                  title: 'Touch Me',
+                  href: '/m/touch_me_2025',
+                  startDate: 'Streaming Apr 7, 2025',
+                },
+              ]),
+            ),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        text: () => Promise.resolve(''),
+      } as Response);
+    });
+
+    const result = await job.run(ctx);
+    const summary = result.summary as Record<string, unknown>;
+    const raw = summary.raw as Record<string, unknown>;
+    const sourceStats = raw.sourceStats as Array<Record<string, unknown>>;
+    const destinationStats = raw.destinationStats as Record<string, unknown>;
+
+    expect(sourceStats.some((row) => row.failed === true)).toBe(true);
+    expect((raw.sampleCandidates as Array<unknown>).length).toBe(1);
+    expect(destinationStats.skipped).toBe(1);
+  });
+
+  it('fails discovery clearly when all Rotten Tomatoes sources fail', async () => {
+    const { job, settings } = createJob();
+    const ctx = createContext({ dryRun: true });
+    const fetchMock = jest.spyOn(globalThis, 'fetch');
+
+    settings.getInternalSettings.mockResolvedValue({
+      settings: {},
+      secrets: {},
+    });
+    settings.readServiceSecret.mockReturnValue('');
+    fetchMock.mockRejectedValue(new Error('network down'));
+
+    const result = await job.run(ctx);
+    const summary = result.summary as Record<string, unknown>;
+    const tasks = summary.tasks as Array<Record<string, unknown>>;
+    const scrapeTask = tasks.find((task) => task.id === 'scrape_sources');
+    const issues = summary.issues as Array<Record<string, unknown>>;
+
+    expect(scrapeTask?.status).toBe('failed');
+    expect(
+      issues.some(
+        (issue) =>
+          typeof issue.message === 'string' &&
+          issue.message.includes('Rotten Tomatoes discovery failed'),
+      ),
+    ).toBe(true);
+  });
+
+  it('treats Radarr prechecked duplicates as exists instead of add failures', async () => {
+    const { job, settings, radarr } = createJob();
+    const ctx = createContext({ dryRun: false });
+    const fetchMock = jest.spyOn(globalThis, 'fetch');
+
+    settings.getInternalSettings.mockResolvedValue({
+      settings: {
+        radarr: {
+          enabled: true,
+          baseUrl: 'http://radarr.local:7878',
+          defaultRootFolderPath: '/movies',
+          defaultQualityProfileId: 1,
+        },
+      },
+      secrets: {
+        radarr: { apiKey: 'radarr-key' },
+      },
+    });
+    settings.readServiceSecret.mockImplementation((service) =>
+      service === 'radarr' ? 'radarr-key' : '',
+    );
+    fetchMock.mockResolvedValue({
+      ok: true,
+      text: () =>
+        Promise.resolve(
+          createSourceHtml([
+            {
+              title: 'Avatar: Fire and Ash',
+              href: '/m/avatar_fire_and_ash_2026',
+              startDate: 'In Theaters Dec 18, 2026',
+            },
+          ]),
+        ),
+    } as Response);
+    radarr.listMovies.mockResolvedValue([]);
+    radarr.listRootFolders.mockResolvedValue([{ id: 1, path: '/movies' }]);
+    radarr.listQualityProfiles.mockResolvedValue([{ id: 1, name: 'Any' }]);
+    radarr.listTags.mockResolvedValue([]);
+    radarr.lookupMovies
+      .mockResolvedValueOnce([
+        { id: 11, title: 'Avatar: Fire and Ash', year: 2025, tmdbId: 83533 },
+      ])
+      .mockResolvedValueOnce([
+        { id: 11, title: 'Avatar: Fire and Ash', year: 2025, tmdbId: 83533 },
+      ]);
+    radarr.addMovie.mockResolvedValue({ status: 'exists', movie: null });
+
+    const result = await job.run(ctx);
+    const summary = result.summary as Record<string, unknown>;
+    const raw = summary.raw as Record<string, unknown>;
+    const destinationStats = raw.destinationStats as Record<string, unknown>;
+
+    expect(radarr.addMovie).toHaveBeenCalledTimes(1);
+    expect(destinationStats.exists).toBe(1);
+    expect(destinationStats.failed).toBe(0);
+  });
+
+  it('routes matched movies to Seerr when enabled', async () => {
+    const { job, settings, radarr, seerr } = createJob();
+    const ctx = createContext({ dryRun: false });
+    const fetchMock = jest.spyOn(globalThis, 'fetch');
+
+    settings.getInternalSettings.mockResolvedValue({
+      settings: {
+        jobs: {
+          rottenTomatoesUpcomingMovies: {
+            routeViaSeerr: true,
+          },
+        },
+        radarr: {
+          enabled: true,
+          baseUrl: 'http://radarr.local:7878',
+        },
+        seerr: {
+          enabled: true,
+          baseUrl: 'http://seerr.local:5055',
+        },
+      },
+      secrets: {
+        radarr: { apiKey: 'radarr-key' },
+        seerr: { apiKey: 'seerr-key' },
+      },
+    });
+    settings.readServiceSecret.mockImplementation((service) => {
+      if (service === 'radarr') return 'radarr-key';
+      if (service === 'seerr') return 'seerr-key';
+      return '';
+    });
+    fetchMock.mockResolvedValue({
+      ok: true,
+      text: () =>
+        Promise.resolve(
+          createSourceHtml([
+            {
+              title: 'Touch Me',
+              href: '/m/touch_me_2025',
+              startDate: 'Streaming Apr 7, 2025',
+            },
+          ]),
+        ),
+    } as Response);
+    radarr.listMovies.mockResolvedValue([]);
+    radarr.lookupMovies.mockResolvedValue([
+      { id: 21, title: 'Touch Me', year: 2025, tmdbId: 1400763 },
+    ]);
+    seerr.requestMovie.mockResolvedValue({
+      status: 'requested',
+      requestId: 77,
+      error: null,
+    });
+
+    const result = await job.run(ctx);
+    const summary = result.summary as Record<string, unknown>;
+    const raw = summary.raw as Record<string, unknown>;
+    const destinationStats = raw.destinationStats as Record<string, unknown>;
+
+    expect(seerr.requestMovie).toHaveBeenCalledWith({
+      baseUrl: 'http://seerr.local:5055',
+      apiKey: 'seerr-key',
+      tmdbId: 1400763,
+    });
+    expect(radarr.addMovie).not.toHaveBeenCalled();
+    expect(radarr.listRootFolders).not.toHaveBeenCalled();
+    expect(radarr.listQualityProfiles).not.toHaveBeenCalled();
+    expect(radarr.listTags).not.toHaveBeenCalled();
+    expect(destinationStats.attempted).toBe(1);
+    expect(destinationStats.requested).toBe(1);
+    expect(destinationStats.failed).toBe(0);
+  });
+
+  it('skips Seerr routing gracefully when Seerr is not configured', async () => {
+    const { job, settings, radarr, seerr } = createJob();
+    const ctx = createContext({ dryRun: false });
+    const fetchMock = jest.spyOn(globalThis, 'fetch');
+
+    settings.getInternalSettings.mockResolvedValue({
+      settings: {
+        jobs: {
+          rottenTomatoesUpcomingMovies: {
+            routeViaSeerr: true,
+          },
+        },
+        radarr: {
+          enabled: true,
+          baseUrl: 'http://radarr.local:7878',
+        },
+      },
+      secrets: {
+        radarr: { apiKey: 'radarr-key' },
+      },
+    });
+    settings.readServiceSecret.mockImplementation((service) =>
+      service === 'radarr' ? 'radarr-key' : '',
+    );
+    fetchMock.mockResolvedValue({
+      ok: true,
+      text: () =>
+        Promise.resolve(
+          createSourceHtml([
+            {
+              title: 'Touch Me',
+              href: '/m/touch_me_2025',
+              startDate: 'Streaming Apr 7, 2025',
+            },
+          ]),
+        ),
+    } as Response);
+    radarr.listMovies.mockResolvedValue([]);
+
+    const result = await job.run(ctx);
+    const summary = result.summary as Record<string, unknown>;
+    const tasks = summary.tasks as Array<Record<string, unknown>>;
+    const prepareTask = tasks.find((task) => task.id === 'prepare_radarr');
+    const routeTask = tasks.find((task) => task.id === 'route_movies');
+    const raw = summary.raw as Record<string, unknown>;
+    const destinationStats = raw.destinationStats as Record<string, unknown>;
+
+    expect(prepareTask?.status).toBe('skipped');
+    expect(routeTask?.status).toBe('skipped');
+    expect(destinationStats.skipped).toBe(1);
+    expect(radarr.lookupMovies).not.toHaveBeenCalled();
+    expect(radarr.addMovie).not.toHaveBeenCalled();
+    expect(seerr.requestMovie).not.toHaveBeenCalled();
+  });
+
+  it('skips destination gracefully when Radarr is not configured', async () => {
+    const { job, settings, radarr } = createJob();
+    const ctx = createContext({ dryRun: false });
+    const fetchMock = jest.spyOn(globalThis, 'fetch');
+
+    settings.getInternalSettings.mockResolvedValue({
+      settings: {},
+      secrets: {},
+    });
+    settings.readServiceSecret.mockReturnValue('');
+    fetchMock.mockResolvedValue({
+      ok: true,
+      text: () =>
+        Promise.resolve(
+          createSourceHtml([
+            {
+              title: 'Touch Me',
+              href: '/m/touch_me_2025',
+              startDate: 'Streaming Apr 7, 2025',
+            },
+          ]),
+        ),
+    } as Response);
+
+    const result = await job.run(ctx);
+    const summary = result.summary as Record<string, unknown>;
+    const tasks = summary.tasks as Array<Record<string, unknown>>;
+    const prepareTask = tasks.find((task) => task.id === 'prepare_radarr');
+    const routeTask = tasks.find((task) => task.id === 'route_movies');
+    const raw = summary.raw as Record<string, unknown>;
+    const destinationStats = raw.destinationStats as Record<string, unknown>;
+
+    expect(prepareTask?.status).toBe('skipped');
+    expect(routeTask?.status).toBe('skipped');
+    expect(destinationStats.skipped).toBe(1);
+    expect(radarr.lookupMovies).not.toHaveBeenCalled();
+    expect(radarr.addMovie).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/jobs/rotten-tomatoes-upcoming-movies.job.ts
+++ b/apps/api/src/jobs/rotten-tomatoes-upcoming-movies.job.ts
@@ -1,0 +1,1182 @@
+import { Injectable } from '@nestjs/common';
+import { RadarrService, type RadarrMovie } from '../radarr/radarr.service';
+import { SeerrService } from '../seerr/seerr.service';
+import { SettingsService } from '../settings/settings.service';
+import {
+  decodeHtmlEntities,
+  normalizeTitleForMatching,
+} from '../lib/title-normalize';
+import { errToMessage } from '../log.utils';
+import type { JobContext, JobRunResult, JsonObject } from './jobs.types';
+import type { JobReportTaskStatus, JobReportV1 } from './job-report-v1';
+import { issue, metricRow } from './job-report-v1';
+
+type ScrapedMovie = {
+  title: string;
+  year: string;
+  href: string;
+  startDate: string;
+  sourceUrl: string;
+};
+
+type SourceScrapeStats = {
+  url: string;
+  discoveredEntries: number;
+  parseableEntries: number;
+  skippedNoYear: number;
+  failed: boolean;
+  error: string | null;
+};
+
+type DestinationStats = {
+  attempted: number;
+  requested: number;
+  added: number;
+  exists: number;
+  failed: number;
+  skipped: number;
+};
+
+type DestinationTitleBuckets = {
+  attemptedTitles: string[];
+  sentTitles: string[];
+  existsTitles: string[];
+  failedTitles: string[];
+  skippedTitles: string[];
+};
+
+type LookupSelection = {
+  movie: RadarrMovie;
+  usedTitleOnlyFallback: boolean;
+};
+
+type RadarrMovieIndex = {
+  titleYearKeys: Set<string>;
+  tmdbIds: Set<number>;
+};
+
+type RadarrConfig = {
+  baseUrl: string;
+  apiKey: string;
+};
+
+type SeerrConfig = {
+  baseUrl: string;
+  apiKey: string;
+};
+
+const ROTTEN_TOMATOES_UPCOMING_JOB_HEADLINE = 'Rotten Tomatoes Upcoming Movies';
+const ROTTEN_TOMATOES_SOURCE_URLS = [
+  'https://www.rottentomatoes.com/browse/movies_in_theaters/sort:newest',
+  'https://www.rottentomatoes.com/browse/movies_at_home/affiliates:fandango-at-home~sort:newest',
+  'https://www.rottentomatoes.com/browse/movies_at_home/affiliates:apple-tv-plus~sort:newest',
+  'https://www.rottentomatoes.com/browse/movies_at_home/affiliates:netflix~sort:newest',
+  'https://www.rottentomatoes.com/browse/movies_at_home/affiliates:prime-video~sort:newest',
+  'https://www.rottentomatoes.com/browse/movies_at_home/affiliates:disney-plus~sort:newest',
+  'https://www.rottentomatoes.com/browse/movies_at_home/affiliates:max~sort:newest',
+  'https://www.rottentomatoes.com/browse/movies_at_home/affiliates:peacock~sort:newest',
+  'https://www.rottentomatoes.com/browse/movies_at_home/affiliates:hulu~sort:newest',
+  'https://www.rottentomatoes.com/browse/movies_at_home/affiliates:paramount-plus~sort:newest',
+  'https://www.rottentomatoes.com/browse/movies_at_home/affiliates:amc-plus~sort:newest',
+  'https://www.rottentomatoes.com/browse/movies_at_home/affiliates:acorn-tv~sort:newest',
+] as const;
+const REQUEST_TIMEOUT_MS = 30_000;
+const MAX_REPORT_TITLE_ITEMS = 100;
+const CLOSE_YEAR_MATCH_DELTA = 1;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function pick(obj: Record<string, unknown>, path: string): unknown {
+  const parts = path.split('.');
+  let current: unknown = obj;
+  for (const part of parts) {
+    if (!isPlainObject(current)) return undefined;
+    current = current[part];
+  }
+  return current;
+}
+
+function pickString(obj: Record<string, unknown>, path: string): string {
+  const value = pick(obj, path);
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function pickBool(obj: Record<string, unknown>, path: string): boolean | null {
+  const value = pick(obj, path);
+  return typeof value === 'boolean' ? value : null;
+}
+
+function pickNumber(obj: Record<string, unknown>, path: string): number | null {
+  const value = pick(obj, path);
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number.parseFloat(value.trim());
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function normalizeTitleList(titles: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+
+  for (const rawTitle of titles) {
+    const title = normalizeTitleForMatching(String(rawTitle ?? '').trim());
+    if (!title) continue;
+    const key = normalizeTitleKey(title);
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    out.push(title);
+    if (out.length >= MAX_REPORT_TITLE_ITEMS) break;
+  }
+
+  return out;
+}
+
+function buildTitleYearKey(title: string, year: string | number): string {
+  return `${normalizeTitleKey(title)}|${String(year ?? '').trim()}`;
+}
+
+function stripTags(value: string): string {
+  return value
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function parsePositiveInt(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    return Math.trunc(value);
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number.parseInt(value.trim(), 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+  }
+  return null;
+}
+
+function parseMaybeYear(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const normalized = Math.trunc(value);
+    return normalized > 0 ? normalized : null;
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number.parseInt(value.trim(), 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+  }
+  return null;
+}
+
+export function normalizeTitleKey(title: string): string {
+  return normalizeTitleForMatching(title)
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function extractYearFromText(
+  ...values: Array<string | null | undefined>
+): string | null {
+  for (const value of values) {
+    const source = String(value ?? '').trim();
+    if (!source) continue;
+    const match = source.match(/((?:19|20)\d{2})/);
+    if (match?.[1]) return match[1];
+  }
+  return null;
+}
+
+export function parseRottenTomatoesMoviesFromHtml(params: {
+  html: string;
+  sourceUrl: string;
+}): {
+  movies: ScrapedMovie[];
+  discoveredEntries: number;
+  skippedNoYear: number;
+} {
+  const html = String(params.html ?? '');
+  const sourceUrl = String(params.sourceUrl ?? '').trim();
+  const movies: ScrapedMovie[] = [];
+  let discoveredEntries = 0;
+  let skippedNoYear = 0;
+
+  const cardRegex =
+    /<a\b[^>]*data-qa="discovery-media-list-item-caption"[^>]*href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/gi;
+
+  for (const match of html.matchAll(cardRegex)) {
+    const href = decodeHtmlEntities(match[1] ?? '').trim();
+    const cardHtml = match[2] ?? '';
+    const titleMatch = cardHtml.match(
+      /data-qa="discovery-media-list-item-title"[^>]*>([\s\S]*?)<\/span>/i,
+    );
+    const title = normalizeTitleForMatching(
+      stripTags(decodeHtmlEntities(titleMatch?.[1] ?? '')),
+    );
+    if (!title) continue;
+
+    discoveredEntries += 1;
+    const startDateMatch = cardHtml.match(
+      /data-qa="discovery-media-list-item-start-date"[^>]*>([\s\S]*?)<\/span>/i,
+    );
+    const startDate = normalizeTitleForMatching(
+      stripTags(decodeHtmlEntities(startDateMatch?.[1] ?? '')),
+    );
+    const year = extractYearFromText(href, startDate);
+    if (!year) {
+      skippedNoYear += 1;
+      continue;
+    }
+
+    movies.push({
+      title,
+      year,
+      href,
+      startDate,
+      sourceUrl,
+    });
+  }
+
+  return { movies, discoveredEntries, skippedNoYear };
+}
+
+export function dedupeScrapedMovies(movies: ScrapedMovie[]): ScrapedMovie[] {
+  const seen = new Set<string>();
+  const out: ScrapedMovie[] = [];
+
+  for (const movie of movies) {
+    const key = buildTitleYearKey(movie.title, movie.year);
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    out.push(movie);
+  }
+
+  return out;
+}
+
+export function buildRadarrMovieIndex(movies: RadarrMovie[]): RadarrMovieIndex {
+  const titleYearKeys = new Set<string>();
+  const tmdbIds = new Set<number>();
+
+  for (const movie of movies) {
+    const title =
+      typeof movie?.title === 'string'
+        ? normalizeTitleForMatching(movie.title)
+        : '';
+    const year = parseMaybeYear(movie?.year);
+    const tmdbId = parsePositiveInt(movie?.tmdbId);
+
+    if (title && year) {
+      titleYearKeys.add(buildTitleYearKey(title, year));
+    }
+    if (tmdbId) {
+      tmdbIds.add(tmdbId);
+    }
+  }
+
+  return { titleYearKeys, tmdbIds };
+}
+
+export function selectLookupMovie(
+  results: RadarrMovie[],
+  requestedTitle: string,
+  requestedYear: string,
+): RadarrMovie | null {
+  const requestedKey = normalizeTitleKey(requestedTitle);
+  const requestedYearInt = parseMaybeYear(requestedYear);
+  if (!requestedKey) return null;
+
+  let best: { movie: RadarrMovie; score: number } | null = null;
+
+  for (const movie of results) {
+    const title =
+      typeof movie?.title === 'string'
+        ? normalizeTitleForMatching(movie.title)
+        : '';
+    if (!title) continue;
+    if (normalizeTitleKey(title) !== requestedKey) continue;
+
+    const year = parseMaybeYear(movie?.year);
+    let score: number | null = null;
+    if (requestedYearInt !== null && year === requestedYearInt) {
+      score = 0;
+    } else if (year === null) {
+      score = 1;
+    } else if (
+      requestedYearInt !== null &&
+      Math.abs(year - requestedYearInt) <= CLOSE_YEAR_MATCH_DELTA
+    ) {
+      score = 2;
+    }
+
+    if (score === null) continue;
+    if (!best || score < best.score) {
+      best = { movie, score };
+    }
+  }
+
+  return best?.movie ?? null;
+}
+
+function sourceStatsFact(
+  stats: SourceScrapeStats[],
+): Array<{ label: string; value: JsonObject }> {
+  return stats.map((source) => ({
+    label: source.url,
+    value: {
+      discoveredEntries: source.discoveredEntries,
+      parseableEntries: source.parseableEntries,
+      skippedNoYear: source.skippedNoYear,
+      failed: source.failed,
+      ...(source.error ? { error: source.error } : {}),
+    },
+  }));
+}
+
+@Injectable()
+export class RottenTomatoesUpcomingMoviesJob {
+  constructor(
+    private readonly settingsService: SettingsService,
+    private readonly radarr: RadarrService,
+    private readonly seerr: SeerrService,
+  ) {}
+
+  async run(ctx: JobContext): Promise<JobRunResult> {
+    const setProgress = async (
+      step: string,
+      message: string,
+      context?: JsonObject,
+    ) => {
+      await ctx.patchSummary({
+        phase: step === 'failed' ? 'failed' : 'running',
+        progress: {
+          step,
+          message,
+          updatedAt: new Date().toISOString(),
+          ...(context ?? {}),
+        },
+      });
+    };
+
+    await ctx.info('rottenTomatoesUpcomingMovies: start', {
+      trigger: ctx.trigger,
+      dryRun: ctx.dryRun,
+    });
+
+    await setProgress('load_settings', 'Loading settings…');
+    const { settings, secrets } =
+      await this.settingsService.getInternalSettings(ctx.userId);
+    const routeViaSeerr =
+      pickBool(settings, 'jobs.rottenTomatoesUpcomingMovies.routeViaSeerr') ??
+      false;
+
+    await setProgress('scrape_sources', 'Scraping Rotten Tomatoes sources…', {
+      totalSources: ROTTEN_TOMATOES_SOURCE_URLS.length,
+    });
+
+    const scrapedMovies: ScrapedMovie[] = [];
+    const sourceStats: SourceScrapeStats[] = [];
+    const reportIssues: JobReportV1['issues'] = [];
+    let sourceFailureCount = 0;
+
+    for (const sourceUrl of ROTTEN_TOMATOES_SOURCE_URLS) {
+      try {
+        const html = await this.fetchSourceHtml(sourceUrl);
+        const parsed = parseRottenTomatoesMoviesFromHtml({
+          html,
+          sourceUrl,
+        });
+        scrapedMovies.push(...parsed.movies);
+        sourceStats.push({
+          url: sourceUrl,
+          discoveredEntries: parsed.discoveredEntries,
+          parseableEntries: parsed.movies.length,
+          skippedNoYear: parsed.skippedNoYear,
+          failed: false,
+          error: null,
+        });
+      } catch (err) {
+        const error = errToMessage(err);
+        sourceFailureCount += 1;
+        sourceStats.push({
+          url: sourceUrl,
+          discoveredEntries: 0,
+          parseableEntries: 0,
+          skippedNoYear: 0,
+          failed: true,
+          error,
+        });
+        reportIssues.push(
+          issue(
+            'warn',
+            `Rotten Tomatoes source failed and was skipped: ${sourceUrl} (${error})`,
+          ),
+        );
+        await ctx.warn(
+          'rottenTomatoesUpcomingMovies: source scrape failed (continuing)',
+          {
+            sourceUrl,
+            error,
+          },
+        );
+      }
+    }
+
+    const dedupedMovies = dedupeScrapedMovies(scrapedMovies);
+    const discoveryFailed =
+      sourceFailureCount === ROTTEN_TOMATOES_SOURCE_URLS.length ||
+      dedupedMovies.length === 0;
+
+    const destinationStats: DestinationStats = {
+      attempted: 0,
+      requested: 0,
+      added: 0,
+      exists: 0,
+      failed: 0,
+      skipped: 0,
+    };
+    const destinationTitles: DestinationTitleBuckets = {
+      attemptedTitles: [],
+      sentTitles: [],
+      existsTitles: [],
+      failedTitles: [],
+      skippedTitles: [],
+    };
+
+    if (discoveryFailed) {
+      reportIssues.push(
+        issue(
+          'error',
+          'Rotten Tomatoes discovery failed: all sources failed or no usable movie cards were parsed.',
+        ),
+      );
+
+      const report = this.buildReport({
+        ctx,
+        sourceStats,
+        reportIssues,
+        dedupedMovies,
+        destinationStats,
+        destinationTitles,
+        routeViaSeerr,
+        discoveryTaskStatus: 'failed',
+        prepareTaskStatus: 'skipped',
+        routeTaskStatus: 'skipped',
+      });
+
+      await setProgress('failed', 'No usable Rotten Tomatoes movies found.', {
+        sourceFailures: sourceFailureCount,
+        dedupedCandidates: dedupedMovies.length,
+      });
+
+      return { summary: report as unknown as JsonObject };
+    }
+
+    let prepareTaskStatus: JobReportTaskStatus = ctx.dryRun
+      ? 'skipped'
+      : 'success';
+    let routeTaskStatus: JobReportTaskStatus = ctx.dryRun
+      ? 'skipped'
+      : 'success';
+    let safeMatchSkipCount = 0;
+    let radarrIndex: RadarrMovieIndex = {
+      titleYearKeys: new Set(),
+      tmdbIds: new Set(),
+    };
+
+    if (ctx.dryRun) {
+      destinationStats.skipped = dedupedMovies.length;
+      destinationTitles.skippedTitles = normalizeTitleList(
+        dedupedMovies.map((movie) => movie.title),
+      );
+    } else {
+      await setProgress(
+        'prepare_radarr',
+        routeViaSeerr
+          ? 'Preparing Radarr lookup + Seerr routing…'
+          : 'Preparing Radarr routing…',
+        {
+          candidates: dedupedMovies.length,
+          routeViaSeerr,
+        },
+      );
+
+      const radarrConfig = this.resolveRadarrConfig(settings, secrets);
+
+      if (!radarrConfig) {
+        destinationStats.skipped = dedupedMovies.length;
+        destinationTitles.skippedTitles = normalizeTitleList(
+          dedupedMovies.map((movie) => movie.title),
+        );
+        prepareTaskStatus = 'skipped';
+        routeTaskStatus = 'skipped';
+        reportIssues.push(
+          issue(
+            'warn',
+            routeViaSeerr
+              ? 'Radarr lookup is required for Rotten Tomatoes Seerr routing, but Radarr is not configured; all movies were skipped.'
+              : 'Radarr is not configured; Rotten Tomatoes discovery completed but all movies were skipped.',
+          ),
+        );
+      } else {
+        try {
+          const existingMovies = await this.radarr.listMovies(radarrConfig);
+          radarrIndex = buildRadarrMovieIndex(existingMovies);
+        } catch (err) {
+          const error = errToMessage(err);
+          reportIssues.push(
+            issue(
+              'warn',
+              `Radarr library snapshot failed; continuing with lookup/add safeguards only. (${error})`,
+            ),
+          );
+          await ctx.warn(
+            'rottenTomatoesUpcomingMovies: Radarr list movies failed (continuing)',
+            { error },
+          );
+        }
+
+        const seerrConfig = routeViaSeerr
+          ? this.resolveSeerrConfig(settings, secrets)
+          : null;
+        const radarrDefaults = routeViaSeerr
+          ? null
+          : await this.pickRadarrDefaults({
+              settings,
+              radarrConfig,
+            }).catch((err) => ({ error: errToMessage(err) }));
+
+        if (routeViaSeerr && !seerrConfig) {
+          destinationStats.skipped = dedupedMovies.length;
+          destinationTitles.skippedTitles = normalizeTitleList(
+            dedupedMovies.map((movie) => movie.title),
+          );
+          prepareTaskStatus = 'skipped';
+          routeTaskStatus = 'skipped';
+          reportIssues.push(
+            issue(
+              'warn',
+              'Seerr route selected but Seerr is not configured; all movies were skipped.',
+            ),
+          );
+        } else if (radarrDefaults && 'error' in radarrDefaults) {
+          destinationStats.skipped = dedupedMovies.length;
+          destinationTitles.skippedTitles = normalizeTitleList(
+            dedupedMovies.map((movie) => movie.title),
+          );
+          prepareTaskStatus = 'skipped';
+          routeTaskStatus = 'skipped';
+          reportIssues.push(
+            issue(
+              'warn',
+              `Radarr defaults could not be resolved; all movies were skipped. (${radarrDefaults.error})`,
+            ),
+          );
+        } else {
+          await setProgress(
+            'route_movies',
+            routeViaSeerr
+              ? 'Sending movies to Seerr…'
+              : 'Sending movies to Radarr…',
+            {
+              candidates: dedupedMovies.length,
+              routeViaSeerr,
+            },
+          );
+
+          for (const movie of dedupedMovies) {
+            const sourceKey = buildTitleYearKey(movie.title, movie.year);
+            if (radarrIndex.titleYearKeys.has(sourceKey)) {
+              destinationStats.exists += 1;
+              destinationTitles.existsTitles.push(movie.title);
+              continue;
+            }
+
+            const lookup = await this.lookupMovieWithFallback({
+              radarrConfig,
+              title: movie.title,
+              year: movie.year,
+            }).catch(async (err) => {
+              const error = errToMessage(err);
+              destinationStats.failed += 1;
+              destinationTitles.failedTitles.push(movie.title);
+              await ctx.warn(
+                'rottenTomatoesUpcomingMovies: Radarr lookup failed (continuing)',
+                {
+                  title: movie.title,
+                  year: movie.year,
+                  error,
+                },
+              );
+              return null;
+            });
+
+            if (!lookup) {
+              if (!destinationTitles.failedTitles.includes(movie.title)) {
+                safeMatchSkipCount += 1;
+                destinationStats.skipped += 1;
+                destinationTitles.skippedTitles.push(movie.title);
+                await ctx.warn(
+                  'rottenTomatoesUpcomingMovies: no Radarr lookup match found',
+                  {
+                    title: movie.title,
+                    year: movie.year,
+                  },
+                );
+              }
+              continue;
+            }
+
+            const lookupTitle =
+              typeof lookup.movie.title === 'string'
+                ? normalizeTitleForMatching(lookup.movie.title)
+                : movie.title;
+            const lookupYear = parseMaybeYear(lookup.movie.year);
+            const lookupTmdbId = parsePositiveInt(lookup.movie.tmdbId);
+            const lookupKey =
+              lookupYear !== null
+                ? buildTitleYearKey(lookupTitle, lookupYear)
+                : '';
+
+            if (lookupTmdbId === null) {
+              safeMatchSkipCount += 1;
+              destinationStats.skipped += 1;
+              destinationTitles.skippedTitles.push(lookupTitle);
+              await ctx.warn(
+                'rottenTomatoesUpcomingMovies: Radarr lookup returned no TMDB id',
+                {
+                  title: lookupTitle,
+                  year: lookupYear,
+                },
+              );
+              continue;
+            }
+
+            if (
+              radarrIndex.tmdbIds.has(lookupTmdbId) ||
+              (lookupKey && radarrIndex.titleYearKeys.has(lookupKey))
+            ) {
+              destinationStats.exists += 1;
+              destinationTitles.existsTitles.push(lookupTitle);
+              radarrIndex.tmdbIds.add(lookupTmdbId);
+              if (lookupKey) {
+                radarrIndex.titleYearKeys.add(lookupKey);
+              }
+              continue;
+            }
+
+            destinationStats.attempted += 1;
+            destinationTitles.attemptedTitles.push(lookupTitle);
+
+            if (routeViaSeerr) {
+              const result = await this.seerr.requestMovie({
+                baseUrl: seerrConfig!.baseUrl,
+                apiKey: seerrConfig!.apiKey,
+                tmdbId: lookupTmdbId,
+              });
+              if (result.status === 'requested') {
+                destinationStats.requested += 1;
+                destinationTitles.sentTitles.push(lookupTitle);
+                radarrIndex.tmdbIds.add(lookupTmdbId);
+                if (lookupKey) {
+                  radarrIndex.titleYearKeys.add(lookupKey);
+                }
+              } else if (result.status === 'exists') {
+                destinationStats.exists += 1;
+                destinationTitles.existsTitles.push(lookupTitle);
+                radarrIndex.tmdbIds.add(lookupTmdbId);
+                if (lookupKey) {
+                  radarrIndex.titleYearKeys.add(lookupKey);
+                }
+              } else {
+                destinationStats.failed += 1;
+                destinationTitles.failedTitles.push(lookupTitle);
+                await ctx.warn(
+                  'rottenTomatoesUpcomingMovies: Seerr request failed (continuing)',
+                  {
+                    title: lookupTitle,
+                    tmdbId: lookupTmdbId,
+                    error: result.error ?? 'unknown',
+                  },
+                );
+              }
+              continue;
+            }
+
+            try {
+              const result = await this.radarr.addMovie({
+                baseUrl: radarrConfig.baseUrl,
+                apiKey: radarrConfig.apiKey,
+                title: lookupTitle,
+                tmdbId: lookupTmdbId,
+                year: lookupYear,
+                qualityProfileId: radarrDefaults!.qualityProfileId,
+                rootFolderPath: radarrDefaults!.rootFolderPath,
+                tags: radarrDefaults!.tagIds,
+                monitored: true,
+                searchForMovie: true,
+              });
+              if (result.status === 'added') {
+                destinationStats.added += 1;
+                destinationTitles.sentTitles.push(lookupTitle);
+              } else {
+                destinationStats.exists += 1;
+                destinationTitles.existsTitles.push(lookupTitle);
+              }
+              radarrIndex.tmdbIds.add(lookupTmdbId);
+              if (lookupYear !== null) {
+                radarrIndex.titleYearKeys.add(
+                  buildTitleYearKey(lookupTitle, lookupYear),
+                );
+              }
+            } catch (err) {
+              destinationStats.failed += 1;
+              destinationTitles.failedTitles.push(lookupTitle);
+              await ctx.warn(
+                'rottenTomatoesUpcomingMovies: Radarr add failed (continuing)',
+                {
+                  title: lookupTitle,
+                  year: lookupYear,
+                  error: errToMessage(err),
+                },
+              );
+            }
+          }
+        }
+      }
+    }
+
+    if (destinationStats.failed > 0) {
+      reportIssues.push(
+        issue(
+          'warn',
+          `Destination reported ${destinationStats.failed} failed operation(s); the run continued.`,
+        ),
+      );
+    }
+
+    if (safeMatchSkipCount > 0 && !ctx.dryRun) {
+      reportIssues.push(
+        issue(
+          'warn',
+          `Some Rotten Tomatoes movies were skipped because Radarr lookup did not find a safe match (${safeMatchSkipCount}).`,
+        ),
+      );
+    }
+
+    const report = this.buildReport({
+      ctx,
+      sourceStats,
+      reportIssues,
+      dedupedMovies,
+      destinationStats,
+      destinationTitles,
+      routeViaSeerr,
+      discoveryTaskStatus: 'success',
+      prepareTaskStatus,
+      routeTaskStatus,
+    });
+
+    await setProgress('done', 'Done.', {
+      dedupedCandidates: dedupedMovies.length,
+      destinationAttempted: destinationStats.attempted,
+      destinationAdded: destinationStats.added,
+      destinationRequested: destinationStats.requested,
+      destinationExists: destinationStats.exists,
+      destinationFailed: destinationStats.failed,
+      destinationSkipped: destinationStats.skipped,
+    });
+    await ctx.info('rottenTomatoesUpcomingMovies: done', {
+      dedupedCandidates: dedupedMovies.length,
+      destinationStats,
+    });
+
+    return {
+      summary: report as unknown as JsonObject,
+    };
+  }
+
+  private async fetchSourceHtml(url: string): Promise<string> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+    try {
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          Accept: 'text/html,application/xhtml+xml',
+        },
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        const body = await response.text().catch(() => '');
+        throw new Error(
+          `HTTP ${response.status}${body ? ` ${body.slice(0, 200)}` : ''}`.trim(),
+        );
+      }
+      return await response.text();
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private resolveRadarrConfig(
+    settings: Record<string, unknown>,
+    secrets: Record<string, unknown>,
+  ): RadarrConfig | null {
+    const baseUrl =
+      pickString(settings, 'radarr.baseUrl') ||
+      pickString(settings, 'radarr.url');
+    const apiKey = this.settingsService.readServiceSecret('radarr', secrets);
+    const enabledSetting = pickBool(settings, 'radarr.enabled');
+    const enabled = (enabledSetting ?? Boolean(apiKey)) === true;
+
+    if (!enabled || !baseUrl || !apiKey) {
+      return null;
+    }
+
+    return { baseUrl, apiKey };
+  }
+
+  private resolveSeerrConfig(
+    settings: Record<string, unknown>,
+    secrets: Record<string, unknown>,
+  ): SeerrConfig | null {
+    const baseUrl =
+      pickString(settings, 'seerr.baseUrl') ||
+      pickString(settings, 'seerr.url');
+    const apiKey = this.settingsService.readServiceSecret('seerr', secrets);
+    const enabledSetting = pickBool(settings, 'seerr.enabled');
+    const enabled = (enabledSetting ?? Boolean(apiKey)) === true;
+
+    if (!enabled || !baseUrl || !apiKey) {
+      return null;
+    }
+
+    return { baseUrl, apiKey };
+  }
+
+  private async pickRadarrDefaults(params: {
+    settings: Record<string, unknown>;
+    radarrConfig: RadarrConfig;
+  }): Promise<{
+    rootFolderPath: string;
+    qualityProfileId: number;
+    tagIds: number[];
+  }> {
+    const [rootFolders, qualityProfiles, tags] = await Promise.all([
+      this.radarr.listRootFolders(params.radarrConfig),
+      this.radarr.listQualityProfiles(params.radarrConfig),
+      this.radarr.listTags(params.radarrConfig),
+    ]);
+
+    if (!rootFolders.length) {
+      throw new Error('Radarr has no root folders configured');
+    }
+    if (!qualityProfiles.length) {
+      throw new Error('Radarr has no quality profiles configured');
+    }
+
+    const preferredRootFolderPath =
+      pickString(params.settings, 'radarr.defaultRootFolderPath') ||
+      pickString(params.settings, 'radarr.rootFolderPath');
+    const preferredQualityProfileId =
+      pickNumber(params.settings, 'radarr.defaultQualityProfileId') ??
+      pickNumber(params.settings, 'radarr.qualityProfileId') ??
+      1;
+    const preferredTagId =
+      pickNumber(params.settings, 'radarr.defaultTagId') ??
+      pickNumber(params.settings, 'radarr.tagId');
+
+    const rootFolder = preferredRootFolderPath
+      ? (rootFolders.find((row) => row.path === preferredRootFolderPath) ??
+        rootFolders[0])
+      : rootFolders[0];
+    const qualityProfile =
+      qualityProfiles.find(
+        (row) => row.id === Math.max(1, Math.trunc(preferredQualityProfileId)),
+      ) ?? qualityProfiles[0];
+    const tag =
+      preferredTagId !== null
+        ? tags.find((row) => row.id === Math.max(1, Math.trunc(preferredTagId)))
+        : null;
+
+    return {
+      rootFolderPath: rootFolder.path,
+      qualityProfileId: qualityProfile.id,
+      tagIds: tag ? [tag.id] : [],
+    };
+  }
+
+  private async lookupMovieWithFallback(params: {
+    radarrConfig: RadarrConfig;
+    title: string;
+    year: string;
+  }): Promise<LookupSelection | null> {
+    const strictResults = await this.radarr.lookupMovies({
+      baseUrl: params.radarrConfig.baseUrl,
+      apiKey: params.radarrConfig.apiKey,
+      term: `${params.title} ${params.year}`,
+    });
+    const strictMatch = selectLookupMovie(
+      strictResults,
+      params.title,
+      params.year,
+    );
+    if (strictMatch) {
+      return { movie: strictMatch, usedTitleOnlyFallback: false };
+    }
+
+    const fallbackResults = await this.radarr.lookupMovies({
+      baseUrl: params.radarrConfig.baseUrl,
+      apiKey: params.radarrConfig.apiKey,
+      term: params.title,
+    });
+    const fallbackMatch = selectLookupMovie(
+      fallbackResults,
+      params.title,
+      params.year,
+    );
+    if (!fallbackMatch) return null;
+
+    return { movie: fallbackMatch, usedTitleOnlyFallback: true };
+  }
+
+  private buildReport(params: {
+    ctx: JobContext;
+    sourceStats: SourceScrapeStats[];
+    reportIssues: JobReportV1['issues'];
+    dedupedMovies: ScrapedMovie[];
+    destinationStats: DestinationStats;
+    destinationTitles: DestinationTitleBuckets;
+    routeViaSeerr: boolean;
+    discoveryTaskStatus: JobReportTaskStatus;
+    prepareTaskStatus: JobReportTaskStatus;
+    routeTaskStatus: JobReportTaskStatus;
+  }): JobReportV1 {
+    const totalDiscoveredEntries = params.sourceStats.reduce(
+      (sum, source) => sum + source.discoveredEntries,
+      0,
+    );
+    const totalParseableEntries = params.sourceStats.reduce(
+      (sum, source) => sum + source.parseableEntries,
+      0,
+    );
+    const totalSkippedNoYear = params.sourceStats.reduce(
+      (sum, source) => sum + source.skippedNoYear,
+      0,
+    );
+    const totalSourceFailures = params.sourceStats.filter(
+      (source) => source.failed,
+    ).length;
+    const sourceFacts = sourceStatsFact(params.sourceStats);
+    const destinationName = params.routeViaSeerr ? 'Seerr' : 'Radarr';
+    const destinationSectionTitle = params.routeViaSeerr
+      ? 'Seerr requests'
+      : 'Radarr adds';
+    const destinationSuccessLabel = params.routeViaSeerr
+      ? 'Requested'
+      : 'Added';
+    const destinationSuccessCount = params.routeViaSeerr
+      ? params.destinationStats.requested
+      : params.destinationStats.added;
+
+    return {
+      template: 'jobReportV1',
+      version: 1,
+      jobId: params.ctx.jobId,
+      dryRun: params.ctx.dryRun,
+      trigger: params.ctx.trigger,
+      headline: ROTTEN_TOMATOES_UPCOMING_JOB_HEADLINE,
+      sections: [
+        {
+          id: 'discovery',
+          title: 'Discovery',
+          rows: [
+            metricRow({
+              label: 'Source pages',
+              start: 0,
+              changed: params.sourceStats.length,
+              end: params.sourceStats.length,
+              unit: 'pages',
+              note: `Failures: ${totalSourceFailures}`,
+            }),
+            metricRow({
+              label: 'Discovered entries',
+              start: 0,
+              changed: totalDiscoveredEntries,
+              end: totalDiscoveredEntries,
+              unit: 'movies',
+            }),
+            metricRow({
+              label: 'Parseable entries',
+              start: 0,
+              changed: totalParseableEntries,
+              end: totalParseableEntries,
+              unit: 'movies',
+              note: `Skipped without usable year: ${totalSkippedNoYear}`,
+            }),
+            metricRow({
+              label: 'Merged and deduped',
+              start: 0,
+              changed: params.dedupedMovies.length,
+              end: params.dedupedMovies.length,
+              unit: 'movies',
+            }),
+          ],
+        },
+        {
+          id: 'destination',
+          title: destinationSectionTitle,
+          rows: [
+            metricRow({
+              label: 'Attempted',
+              start: 0,
+              changed: params.destinationStats.attempted,
+              end: params.destinationStats.attempted,
+              unit: 'movies',
+            }),
+            metricRow({
+              label: destinationSuccessLabel,
+              start: 0,
+              changed: destinationSuccessCount,
+              end: destinationSuccessCount,
+              unit: 'movies',
+            }),
+            metricRow({
+              label: 'Already exists',
+              start: 0,
+              changed: params.destinationStats.exists,
+              end: params.destinationStats.exists,
+              unit: 'movies',
+            }),
+            metricRow({
+              label: 'Failed',
+              start: 0,
+              changed: params.destinationStats.failed,
+              end: params.destinationStats.failed,
+              unit: 'movies',
+            }),
+            metricRow({
+              label: 'Skipped',
+              start: 0,
+              changed: params.destinationStats.skipped,
+              end: params.destinationStats.skipped,
+              unit: 'movies',
+            }),
+          ],
+        },
+      ],
+      tasks: [
+        {
+          id: 'load_settings',
+          title: 'Load settings',
+          status: 'success',
+        },
+        {
+          id: 'scrape_sources',
+          title: 'Scrape Rotten Tomatoes sources',
+          status: params.discoveryTaskStatus,
+          facts: sourceFacts,
+        },
+        {
+          id: 'prepare_radarr',
+          title: params.routeViaSeerr
+            ? 'Prepare Radarr lookup + Seerr routing'
+            : 'Prepare Radarr routing',
+          status: params.prepareTaskStatus,
+        },
+        {
+          id: 'route_movies',
+          title: params.routeViaSeerr ? 'Send to Seerr' : 'Send to Radarr',
+          status: params.routeTaskStatus,
+          facts: [
+            {
+              label: params.routeViaSeerr
+                ? 'Attempted requests'
+                : 'Attempted adds',
+              value: {
+                count: params.destinationStats.attempted,
+                unit: 'movies',
+                items: normalizeTitleList(
+                  params.destinationTitles.attemptedTitles,
+                ),
+              },
+            },
+            {
+              label: params.routeViaSeerr
+                ? 'Requested in Seerr'
+                : 'Added in Radarr',
+              value: {
+                count: destinationSuccessCount,
+                unit: 'movies',
+                items: normalizeTitleList(params.destinationTitles.sentTitles),
+              },
+            },
+            {
+              label: 'Already exists',
+              value: {
+                count: params.destinationStats.exists,
+                unit: 'movies',
+                items: normalizeTitleList(
+                  params.destinationTitles.existsTitles,
+                ),
+              },
+            },
+            {
+              label: 'Failed adds',
+              value: {
+                count: params.destinationStats.failed,
+                unit: 'movies',
+                items: normalizeTitleList(
+                  params.destinationTitles.failedTitles,
+                ),
+              },
+            },
+            {
+              label: 'Skipped sends',
+              value: {
+                count: params.destinationStats.skipped,
+                unit: 'movies',
+                items: normalizeTitleList(
+                  params.destinationTitles.skippedTitles,
+                ),
+              },
+            },
+          ],
+        },
+      ],
+      issues: params.reportIssues,
+      raw: {
+        sourceStats: params.sourceStats.map((source) => ({
+          url: source.url,
+          discoveredEntries: source.discoveredEntries,
+          parseableEntries: source.parseableEntries,
+          skippedNoYear: source.skippedNoYear,
+          failed: source.failed,
+          error: source.error,
+        })),
+        sampleCandidates: params.dedupedMovies.slice(0, 25).map((movie) => ({
+          title: movie.title,
+          year: movie.year,
+          href: movie.href,
+          sourceUrl: movie.sourceUrl,
+        })),
+        routeViaSeerr: params.routeViaSeerr,
+        destinationName,
+        destinationStats: params.destinationStats,
+        destinationTitleBuckets: {
+          attempted: normalizeTitleList(
+            params.destinationTitles.attemptedTitles,
+          ),
+          sent: normalizeTitleList(params.destinationTitles.sentTitles),
+          exists: normalizeTitleList(params.destinationTitles.existsTitles),
+          failed: normalizeTitleList(params.destinationTitles.failedTitles),
+          skipped: normalizeTitleList(params.destinationTitles.skippedTitles),
+        },
+      },
+    };
+  }
+}

--- a/apps/api/src/scripts/migrate-with-repair.spec.ts
+++ b/apps/api/src/scripts/migrate-with-repair.spec.ts
@@ -61,6 +61,10 @@ function createPrismaMock(state: Partial<PrismaMockState> = {}): {
         mockState.tables.add('ImportedWatchEntry');
         mockState.columns.ImportedWatchEntry = ['id'];
       }
+      if (sql.includes('CREATE TABLE "AutoRunMediaHistory"')) {
+        mockState.tables.add('AutoRunMediaHistory');
+        mockState.columns.AutoRunMediaHistory = ['id'];
+      }
       if (
         sql.includes('ADD COLUMN "scopeAllUsers"') &&
         mockState.columns.ImmaculateTasteProfile
@@ -377,6 +381,25 @@ describe('scripts/migrate-with-repair', () => {
         sql.includes('"ImportedWatchEntry"'),
       ),
     ).toBe(false);
+  });
+
+  it('resolves the auto-run media history migration as applied when the table pre-exists', async () => {
+    const prisma = createPrismaMock({
+      tables: new Set(['User', 'AutoRunMediaHistory']),
+    });
+
+    await repairApril2026MigrationEdgeCases(prisma as never);
+
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.arrayContaining([
+        'migrate',
+        'resolve',
+        '--applied',
+        '20260411120000_add_auto_run_media_history',
+      ]),
+      expect.objectContaining({ env: process.env, stdio: 'inherit' }),
+    );
   });
 
   it('logs the exact failed migration names that still block deploy', async () => {

--- a/apps/api/src/scripts/migrate-with-repair.spec.ts
+++ b/apps/api/src/scripts/migrate-with-repair.spec.ts
@@ -17,6 +17,7 @@ jest.mock('@prisma/client', () => ({
 
 import {
   logFailedMigrationDiagnostics,
+  repairApril2026MigrationEdgeCases,
   repairMarch2026MigrationEdgeCases,
 } from './migrate-with-repair';
 
@@ -55,6 +56,10 @@ function createPrismaMock(state: Partial<PrismaMockState> = {}): {
       if (sql.includes('CREATE TABLE "ImmaculateTasteProfile"')) {
         mockState.tables.add('ImmaculateTasteProfile');
         mockState.columns.ImmaculateTasteProfile = ['id'];
+      }
+      if (sql.includes('CREATE TABLE "ImportedWatchEntry"')) {
+        mockState.tables.add('ImportedWatchEntry');
+        mockState.columns.ImportedWatchEntry = ['id'];
       }
       if (
         sql.includes('ADD COLUMN "scopeAllUsers"') &&
@@ -308,6 +313,70 @@ describe('scripts/migrate-with-repair', () => {
       ]),
       expect.objectContaining({ env: process.env, stdio: 'inherit' }),
     );
+  });
+
+  it('creates ImportedWatchEntry and resolves the April migration as applied when ArrInstance pre-exists', async () => {
+    const prisma = createPrismaMock({
+      tables: new Set(['User', 'ArrInstance']),
+    });
+
+    await repairApril2026MigrationEdgeCases(prisma as never);
+
+    expect(
+      prisma.$executeRawUnsafe.mock.calls.some(
+        ([sql]) =>
+          sql.includes('CREATE TABLE') && sql.includes('"ImportedWatchEntry"'),
+      ),
+    ).toBe(true);
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.arrayContaining([
+        'migrate',
+        'resolve',
+        '--applied',
+        '20260405092958_add_imported_watch_entry',
+      ]),
+      expect.objectContaining({ env: process.env, stdio: 'inherit' }),
+    );
+  });
+
+  it('resolves the April migration as applied when ImportedWatchEntry already exists but the row is failed', async () => {
+    const prisma = createPrismaMock({
+      migrationRows: {
+        '20260405092958_add_imported_watch_entry': [
+          { finished_at: null, rolled_back_at: null },
+        ],
+      },
+      tables: new Set(['User', 'ImportedWatchEntry']),
+    });
+
+    await repairApril2026MigrationEdgeCases(prisma as never);
+
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.arrayContaining([
+        'migrate',
+        'resolve',
+        '--applied',
+        '20260405092958_add_imported_watch_entry',
+      ]),
+      expect.objectContaining({ env: process.env, stdio: 'inherit' }),
+    );
+  });
+
+  it('skips April imported watch repair when the legacy tables are absent', async () => {
+    const prisma = createPrismaMock({
+      tables: new Set(['User']),
+    });
+
+    await repairApril2026MigrationEdgeCases(prisma as never);
+
+    expect(mockSpawnSync).not.toHaveBeenCalled();
+    expect(
+      prisma.$executeRawUnsafe.mock.calls.some(([sql]) =>
+        sql.includes('"ImportedWatchEntry"'),
+      ),
+    ).toBe(false);
   });
 
   it('logs the exact failed migration names that still block deploy', async () => {

--- a/apps/api/src/scripts/migrate-with-repair.ts
+++ b/apps/api/src/scripts/migrate-with-repair.ts
@@ -11,6 +11,8 @@ const FRESH_RELEASE_CACHE_MIGRATION =
   '20260317120000_fresh_out_of_the_oven_recent_release_cache';
 const IMPORTED_WATCH_ENTRY_MIGRATION =
   '20260405092958_add_imported_watch_entry';
+const AUTO_RUN_MEDIA_HISTORY_MIGRATION =
+  '20260411120000_add_auto_run_media_history';
 const PRISMA_BIN_CANDIDATES = [
   './apps/api/node_modules/.bin/prisma',
   './node_modules/.bin/prisma',
@@ -135,6 +137,29 @@ const CREATE_IMPORTED_WATCH_ENTRY_STATUS_INDEX_SQL =
   'CREATE INDEX IF NOT EXISTS "ImportedWatchEntry_userId_status_idx" ON "ImportedWatchEntry"("userId", "status")';
 const CREATE_IMPORTED_WATCH_ENTRY_UNIQUE_PARSED_TITLE_INDEX_SQL =
   'CREATE UNIQUE INDEX IF NOT EXISTS "ImportedWatchEntry_userId_source_parsedTitle_key" ON "ImportedWatchEntry"("userId", "source", "parsedTitle")';
+const CREATE_AUTO_RUN_MEDIA_HISTORY_TABLE_SQL = [
+  'CREATE TABLE "AutoRunMediaHistory" (',
+  '  "id" TEXT NOT NULL PRIMARY KEY,',
+  '  "jobId" TEXT NOT NULL,',
+  '  "mediaFingerprint" TEXT NOT NULL,',
+  '  "plexUserId" TEXT NOT NULL,',
+  '  "mediaType" TEXT NOT NULL,',
+  '  "librarySectionKey" TEXT NOT NULL,',
+  '  "seedRatingKey" TEXT,',
+  '  "showRatingKey" TEXT,',
+  '  "seedTitle" TEXT,',
+  '  "seedYear" INTEGER,',
+  '  "seasonNumber" INTEGER,',
+  '  "episodeNumber" INTEGER,',
+  '  "source" TEXT NOT NULL,',
+  '  "firstRunId" TEXT NOT NULL,',
+  '  "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP',
+  ')',
+].join('\n');
+const CREATE_AUTO_RUN_MEDIA_HISTORY_UNIQUE_INDEX_SQL =
+  'CREATE UNIQUE INDEX IF NOT EXISTS "AutoRunMediaHistory_jobId_mediaFingerprint_key" ON "AutoRunMediaHistory"("jobId", "mediaFingerprint")';
+const CREATE_AUTO_RUN_MEDIA_HISTORY_LOOKUP_INDEX_SQL =
+  'CREATE INDEX IF NOT EXISTS "AutoRunMediaHistory_jobId_plexUserId_librarySectionKey_createdAt_idx" ON "AutoRunMediaHistory"("jobId", "plexUserId", "librarySectionKey", "createdAt")';
 const CREATE_IMMACULATE_TASTE_PROFILE_TABLE_SQL = [
   'CREATE TABLE "ImmaculateTasteProfile" (',
   '  "id" TEXT NOT NULL PRIMARY KEY,',
@@ -700,27 +725,47 @@ export async function repairApril2026MigrationEdgeCases(
     prisma,
     'ImportedWatchEntry',
   );
+  const autoRunMediaHistoryExists = await tableExists(
+    prisma,
+    'AutoRunMediaHistory',
+  );
 
-  if (!arrInstanceExists && !importedWatchEntryExists) {
-    return;
+  if (arrInstanceExists || importedWatchEntryExists) {
+    await ensureImportedWatchEntrySchema(prisma);
+
+    const importedWatchEntryMigrationState = await migrationRecordState(
+      prisma,
+      IMPORTED_WATCH_ENTRY_MIGRATION,
+    );
+    if (
+      importedWatchEntryMigrationState !== 'applied' &&
+      importedWatchEntryMigrationState !== 'migrations_table_missing'
+    ) {
+      resolveMigrationAsApplied(
+        IMPORTED_WATCH_ENTRY_MIGRATION,
+        importedWatchEntryExists
+          ? 'ImportedWatchEntry already exists'
+          : 'ArrInstance already exists; ImportedWatchEntry was provisioned by repair',
+      );
+    }
   }
 
-  await ensureImportedWatchEntrySchema(prisma);
+  if (autoRunMediaHistoryExists) {
+    await ensureAutoRunMediaHistorySchema(prisma);
 
-  const importedWatchEntryMigrationState = await migrationRecordState(
-    prisma,
-    IMPORTED_WATCH_ENTRY_MIGRATION,
-  );
-  if (
-    importedWatchEntryMigrationState !== 'applied' &&
-    importedWatchEntryMigrationState !== 'migrations_table_missing'
-  ) {
-    resolveMigrationAsApplied(
-      IMPORTED_WATCH_ENTRY_MIGRATION,
-      importedWatchEntryExists
-        ? 'ImportedWatchEntry already exists'
-        : 'ArrInstance already exists; ImportedWatchEntry was provisioned by repair',
+    const autoRunMediaHistoryMigrationState = await migrationRecordState(
+      prisma,
+      AUTO_RUN_MEDIA_HISTORY_MIGRATION,
     );
+    if (
+      autoRunMediaHistoryMigrationState !== 'applied' &&
+      autoRunMediaHistoryMigrationState !== 'migrations_table_missing'
+    ) {
+      resolveMigrationAsApplied(
+        AUTO_RUN_MEDIA_HISTORY_MIGRATION,
+        'AutoRunMediaHistory already exists',
+      );
+    }
   }
 }
 
@@ -770,6 +815,22 @@ async function ensureImportedWatchEntrySchema(
   await prisma.$executeRawUnsafe(CREATE_IMPORTED_WATCH_ENTRY_STATUS_INDEX_SQL);
   await prisma.$executeRawUnsafe(
     CREATE_IMPORTED_WATCH_ENTRY_UNIQUE_PARSED_TITLE_INDEX_SQL,
+  );
+}
+
+async function ensureAutoRunMediaHistorySchema(
+  prisma: PrismaClient,
+): Promise<void> {
+  const tableName = 'AutoRunMediaHistory';
+  if (!(await tableExists(prisma, tableName))) {
+    await prisma.$executeRawUnsafe(CREATE_AUTO_RUN_MEDIA_HISTORY_TABLE_SQL);
+  }
+
+  await prisma.$executeRawUnsafe(
+    CREATE_AUTO_RUN_MEDIA_HISTORY_UNIQUE_INDEX_SQL,
+  );
+  await prisma.$executeRawUnsafe(
+    CREATE_AUTO_RUN_MEDIA_HISTORY_LOOKUP_INDEX_SQL,
   );
 }
 
@@ -1022,6 +1083,7 @@ export async function main() {
     }
     await ensureArrInstanceSchema(prisma);
     await ensureImportedWatchEntrySchema(prisma);
+    await ensureAutoRunMediaHistorySchema(prisma);
     await ensureImmaculateTasteProfileSchema(prisma);
     await ensureImmaculateTasteLibrarySchema(prisma);
     await ensureFreshReleaseMovieLibrarySchema(prisma);

--- a/apps/api/src/scripts/migrate-with-repair.ts
+++ b/apps/api/src/scripts/migrate-with-repair.ts
@@ -9,6 +9,8 @@ const IMMACULATE_TASTE_SCOPE_ALL_USERS_MIGRATION =
   '20260316200000_add_scope_all_users_to_taste_profile';
 const FRESH_RELEASE_CACHE_MIGRATION =
   '20260317120000_fresh_out_of_the_oven_recent_release_cache';
+const IMPORTED_WATCH_ENTRY_MIGRATION =
+  '20260405092958_add_imported_watch_entry';
 const PRISMA_BIN_CANDIDATES = [
   './apps/api/node_modules/.bin/prisma',
   './node_modules/.bin/prisma',
@@ -107,6 +109,32 @@ const CREATE_ARR_INSTANCE_TYPE_INDEX_SQL =
   'CREATE INDEX IF NOT EXISTS "ArrInstance_userId_type_idx" ON "ArrInstance"("userId", "type")';
 const CREATE_ARR_INSTANCE_UNIQUE_NAME_INDEX_SQL =
   'CREATE UNIQUE INDEX IF NOT EXISTS "ArrInstance_userId_type_name_key" ON "ArrInstance"("userId", "type", "name")';
+const CREATE_IMPORTED_WATCH_ENTRY_TABLE_SQL = [
+  'CREATE TABLE "ImportedWatchEntry" (',
+  '  "id" TEXT NOT NULL PRIMARY KEY,',
+  '  "userId" TEXT NOT NULL,',
+  '  "source" TEXT NOT NULL,',
+  '  "rawTitle" TEXT NOT NULL,',
+  '  "parsedTitle" TEXT NOT NULL,',
+  '  "watchedAt" DATETIME,',
+  '  "mediaType" TEXT,',
+  '  "tmdbId" INTEGER,',
+  '  "tvdbId" INTEGER,',
+  '  "matchedTitle" TEXT,',
+  '  "status" TEXT NOT NULL DEFAULT \'pending\',',
+  '  "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,',
+  '  "updatedAt" DATETIME NOT NULL,',
+  '  CONSTRAINT "ImportedWatchEntry_userId_fkey"',
+  '    FOREIGN KEY ("userId") REFERENCES "User" ("id")',
+  '    ON DELETE CASCADE ON UPDATE CASCADE',
+  ')',
+].join('\n');
+const CREATE_IMPORTED_WATCH_ENTRY_SOURCE_INDEX_SQL =
+  'CREATE INDEX IF NOT EXISTS "ImportedWatchEntry_userId_source_idx" ON "ImportedWatchEntry"("userId", "source")';
+const CREATE_IMPORTED_WATCH_ENTRY_STATUS_INDEX_SQL =
+  'CREATE INDEX IF NOT EXISTS "ImportedWatchEntry_userId_status_idx" ON "ImportedWatchEntry"("userId", "status")';
+const CREATE_IMPORTED_WATCH_ENTRY_UNIQUE_PARSED_TITLE_INDEX_SQL =
+  'CREATE UNIQUE INDEX IF NOT EXISTS "ImportedWatchEntry_userId_source_parsedTitle_key" ON "ImportedWatchEntry"("userId", "source", "parsedTitle")';
 const CREATE_IMMACULATE_TASTE_PROFILE_TABLE_SQL = [
   'CREATE TABLE "ImmaculateTasteProfile" (',
   '  "id" TEXT NOT NULL PRIMARY KEY,',
@@ -662,6 +690,40 @@ export async function repairMarch2026MigrationEdgeCases(
   }
 }
 
+export async function repairApril2026MigrationEdgeCases(
+  prisma: PrismaClient,
+): Promise<void> {
+  if (!(await tableExists(prisma, 'User'))) return;
+
+  const arrInstanceExists = await tableExists(prisma, 'ArrInstance');
+  const importedWatchEntryExists = await tableExists(
+    prisma,
+    'ImportedWatchEntry',
+  );
+
+  if (!arrInstanceExists && !importedWatchEntryExists) {
+    return;
+  }
+
+  await ensureImportedWatchEntrySchema(prisma);
+
+  const importedWatchEntryMigrationState = await migrationRecordState(
+    prisma,
+    IMPORTED_WATCH_ENTRY_MIGRATION,
+  );
+  if (
+    importedWatchEntryMigrationState !== 'applied' &&
+    importedWatchEntryMigrationState !== 'migrations_table_missing'
+  ) {
+    resolveMigrationAsApplied(
+      IMPORTED_WATCH_ENTRY_MIGRATION,
+      importedWatchEntryExists
+        ? 'ImportedWatchEntry already exists'
+        : 'ArrInstance already exists; ImportedWatchEntry was provisioned by repair',
+    );
+  }
+}
+
 async function ensureArrInstanceSchema(prisma: PrismaClient): Promise<void> {
   const tableName = 'ArrInstance';
   const exists = await tableExists(prisma, tableName);
@@ -694,6 +756,21 @@ async function ensureArrInstanceSchema(prisma: PrismaClient): Promise<void> {
 
   await prisma.$executeRawUnsafe(CREATE_ARR_INSTANCE_TYPE_INDEX_SQL);
   await prisma.$executeRawUnsafe(CREATE_ARR_INSTANCE_UNIQUE_NAME_INDEX_SQL);
+}
+
+async function ensureImportedWatchEntrySchema(
+  prisma: PrismaClient,
+): Promise<void> {
+  const tableName = 'ImportedWatchEntry';
+  if (!(await tableExists(prisma, tableName))) {
+    await prisma.$executeRawUnsafe(CREATE_IMPORTED_WATCH_ENTRY_TABLE_SQL);
+  }
+
+  await prisma.$executeRawUnsafe(CREATE_IMPORTED_WATCH_ENTRY_SOURCE_INDEX_SQL);
+  await prisma.$executeRawUnsafe(CREATE_IMPORTED_WATCH_ENTRY_STATUS_INDEX_SQL);
+  await prisma.$executeRawUnsafe(
+    CREATE_IMPORTED_WATCH_ENTRY_UNIQUE_PARSED_TITLE_INDEX_SQL,
+  );
 }
 
 async function rebuildImmaculateTasteMovieLibraryWithProfileId(
@@ -935,6 +1012,7 @@ export async function main() {
   try {
     await repairFailedMigrationIfNeeded(prisma);
     await repairMarch2026MigrationEdgeCases(prisma);
+    await repairApril2026MigrationEdgeCases(prisma);
 
     try {
       runPrisma(['migrate', 'deploy'], 'prisma migrate deploy');
@@ -943,6 +1021,7 @@ export async function main() {
       throw err;
     }
     await ensureArrInstanceSchema(prisma);
+    await ensureImportedWatchEntrySchema(prisma);
     await ensureImmaculateTasteProfileSchema(prisma);
     await ensureImmaculateTasteLibrarySchema(prisma);
     await ensureFreshReleaseMovieLibrarySchema(prisma);

--- a/apps/api/src/version.ts
+++ b/apps/api/src/version.ts
@@ -1,6 +1,6 @@
 // Single source of truth for the app version.
 // Bump this constant only.
 
-export const APP_VERSION = '1.7.7' as const;
+export const APP_VERSION = '1.7.7-beta-1' as const;
 
 export const APP_VERSION_TAG = `v${APP_VERSION}` as const;

--- a/apps/api/src/version.ts
+++ b/apps/api/src/version.ts
@@ -1,6 +1,6 @@
 // Single source of truth for the app version.
 // Bump this constant only.
 
-export const APP_VERSION = '1.7.6' as const;
+export const APP_VERSION = '1.7.7' as const;
 
 export const APP_VERSION_TAG = `v${APP_VERSION}` as const;

--- a/apps/api/src/webhooks/plex-polling.service.spec.ts
+++ b/apps/api/src/webhooks/plex-polling.service.spec.ts
@@ -1,3 +1,4 @@
+import { ConflictException } from '@nestjs/common';
 import { PlexPollingService } from './plex-polling.service';
 
 type InternalPlexPollingService = {
@@ -6,56 +7,153 @@ type InternalPlexPollingService = {
     snap: Record<string, unknown>;
     settings: Record<string, unknown>;
     reason: string;
-  }): Promise<void>;
+  }): Promise<Record<string, unknown>>;
 };
 
+function makeAlreadyProcessedConflict() {
+  return new ConflictException({
+    reason: 'already_processed',
+    message: 'Job already processed for this media.',
+  });
+}
+
+function makeService() {
+  const authService = {
+    getFirstAdminUserId: jest.fn(),
+  };
+  const settingsService = {
+    getInternalSettings: jest.fn(),
+  };
+  const jobsService = {
+    runJob: jest.fn(),
+  };
+  const plexServer = {
+    listNowPlayingSessions: jest.fn(),
+    listRecentlyAdded: jest.fn(),
+    listRecentlyAddedForSectionKey: jest.fn(),
+  };
+  const plexUsers = {
+    resolvePlexUser: jest.fn(),
+  };
+  const webhooksService = {
+    persistPlexWebhookEvent: jest.fn(),
+    logPlexWebhookSummary: jest.fn(),
+    logPlexWebhookAutomation: jest.fn(),
+    logPlexUserMonitoringSkipped: jest.fn(),
+  };
+  const plexAnalytics = {
+    invalidateLibraryGrowth: jest.fn(),
+  };
+
+  const service = new PlexPollingService(
+    authService as never,
+    settingsService as never,
+    jobsService as never,
+    plexServer as never,
+    plexUsers as never,
+    webhooksService as never,
+    plexAnalytics as never,
+  );
+
+  webhooksService.persistPlexWebhookEvent.mockResolvedValue({
+    path: '/tmp/polling-webhook.json',
+  });
+
+  return {
+    service,
+    jobsService,
+    plexUsers,
+    webhooksService,
+  };
+}
+
+function makeSettings(overrides?: Record<string, unknown>) {
+  return {
+    jobs: {
+      webhookEnabled: {
+        watchedMovieRecommendations: true,
+        immaculateTastePoints: true,
+      },
+    },
+    ...(overrides ?? {}),
+  };
+}
+
+function makeMovieSnap(
+  overrides?: Partial<Record<string, unknown>>,
+): Record<string, unknown> {
+  const now = Date.now();
+  return {
+    sessionKey: 'session-1',
+    type: 'movie',
+    ratingKey: 'movie-1',
+    title: 'Inception',
+    year: 2010,
+    grandparentTitle: null,
+    grandparentRatingKey: null,
+    parentIndex: null,
+    index: null,
+    librarySectionId: 1,
+    librarySectionTitle: 'Movies',
+    viewOffsetMs: 95_000,
+    durationMs: 100_000,
+    userTitle: 'Alice',
+    userId: 2,
+    firstSeenAtMs: now,
+    lastSeenAtMs: now,
+    firstViewOffsetMs: 95_000,
+    lastViewOffsetMs: 95_000,
+    watchedTriggered: false,
+    watchedTriggeredAtMs: null,
+    immaculateTriggered: false,
+    immaculateTriggeredAtMs: null,
+    ...(overrides ?? {}),
+  };
+}
+
+function makeEpisodeSnap(
+  overrides?: Partial<Record<string, unknown>>,
+): Record<string, unknown> {
+  const now = Date.now();
+  return {
+    sessionKey: 'session-episode-1',
+    type: 'episode',
+    ratingKey: 'episode-1',
+    title: 'Pilot',
+    year: null,
+    grandparentTitle: 'Lost',
+    grandparentRatingKey: 'show-1',
+    parentIndex: 1,
+    index: 1,
+    librarySectionId: 4,
+    librarySectionTitle: 'TV Shows',
+    viewOffsetMs: 95_000,
+    durationMs: 100_000,
+    userTitle: 'Alice',
+    userId: 2,
+    firstSeenAtMs: now,
+    lastSeenAtMs: now,
+    firstViewOffsetMs: 95_000,
+    lastViewOffsetMs: 95_000,
+    watchedTriggered: false,
+    watchedTriggeredAtMs: null,
+    immaculateTriggered: false,
+    immaculateTriggeredAtMs: null,
+    ...(overrides ?? {}),
+  };
+}
+
+function getRunJobFingerprint(
+  jobsService: { runJob: jest.Mock },
+  callIndex: number,
+): string {
+  const call = jobsService.runJob.mock.calls[callIndex] as [
+    { input: { autoRunMediaFingerprint: string } },
+  ];
+  return call[0].input.autoRunMediaFingerprint;
+}
+
 describe('PlexPollingService user monitoring exclusion', () => {
-  function makeService() {
-    const authService = {
-      getFirstAdminUserId: jest.fn(),
-    };
-    const settingsService = {
-      getInternalSettings: jest.fn(),
-    };
-    const jobsService = {
-      runJob: jest.fn(),
-    };
-    const plexServer = {
-      listNowPlayingSessions: jest.fn(),
-      listRecentlyAdded: jest.fn(),
-      listRecentlyAddedForSectionKey: jest.fn(),
-    };
-    const plexUsers = {
-      resolvePlexUser: jest.fn(),
-    };
-    const webhooksService = {
-      persistPlexWebhookEvent: jest.fn(),
-      logPlexWebhookSummary: jest.fn(),
-      logPlexWebhookAutomation: jest.fn(),
-      logPlexUserMonitoringSkipped: jest.fn(),
-    };
-    const plexAnalytics = {
-      invalidateLibraryGrowth: jest.fn(),
-    };
-
-    const service = new PlexPollingService(
-      authService as never,
-      settingsService as never,
-      jobsService as never,
-      plexServer as never,
-      plexUsers as never,
-      webhooksService as never,
-      plexAnalytics as never,
-    );
-
-    return {
-      service,
-      jobsService,
-      plexUsers,
-      webhooksService,
-    };
-  }
-
   it('logs skip only once per session when user is excluded', async () => {
     const { service, jobsService, plexUsers, webhooksService } = makeService();
     const internalService = service as unknown as InternalPlexPollingService;
@@ -64,46 +162,15 @@ describe('PlexPollingService user monitoring exclusion', () => {
       plexAccountTitle: 'Alice',
     });
 
-    const now = Date.now();
-    const snap = {
-      sessionKey: 's1',
-      type: 'movie',
-      ratingKey: 'rk-1',
-      title: 'Inception',
-      year: 2010,
-      grandparentTitle: null,
-      grandparentRatingKey: null,
-      parentIndex: null,
-      index: null,
-      librarySectionId: 1,
-      librarySectionTitle: 'Movies',
-      viewOffsetMs: 70_000,
-      durationMs: 100_000,
-      userTitle: 'Alice',
-      userId: 2,
-      firstSeenAtMs: now,
-      lastSeenAtMs: now,
-      firstViewOffsetMs: 70_000,
-      lastViewOffsetMs: 70_000,
-      watchedTriggered: false,
-      watchedTriggeredAtMs: null,
-      immaculateTriggered: false,
-      immaculateTriggeredAtMs: null,
-    };
-
-    const settings = {
-      jobs: {
-        webhookEnabled: {
-          watchedMovieRecommendations: true,
-          immaculateTastePoints: true,
-        },
-      },
+    const settings = makeSettings({
       plex: {
         userMonitoring: {
           excludedPlexUserIds: ['plex-user-2'],
         },
       },
-    };
+    });
+
+    const snap = makeMovieSnap();
 
     await internalService.maybeTriggerWatchedAutomation({
       userId: 'admin',
@@ -123,5 +190,164 @@ describe('PlexPollingService user monitoring exclusion', () => {
       1,
     );
     expect(webhooksService.logPlexWebhookAutomation).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('PlexPollingService durable auto-run dedupe', () => {
+  it('skips both target jobs as already_processed for the same movie on a later session', async () => {
+    const { service, jobsService, plexUsers, webhooksService } = makeService();
+    const internalService = service as unknown as InternalPlexPollingService;
+    plexUsers.resolvePlexUser.mockResolvedValue({
+      id: 'plex-user-2',
+      plexAccountTitle: 'Alice',
+    });
+    jobsService.runJob
+      .mockResolvedValueOnce({ id: 'watched-run-1' })
+      .mockResolvedValueOnce({ id: 'immaculate-run-1' })
+      .mockRejectedValueOnce(makeAlreadyProcessedConflict())
+      .mockRejectedValueOnce(makeAlreadyProcessedConflict());
+
+    const settings = makeSettings();
+
+    await internalService.maybeTriggerWatchedAutomation({
+      userId: 'admin',
+      snap: makeMovieSnap({ sessionKey: 'session-1' }),
+      settings,
+      reason: 'progress',
+    });
+    await internalService.maybeTriggerWatchedAutomation({
+      userId: 'admin',
+      snap: makeMovieSnap({ sessionKey: 'session-2' }),
+      settings,
+      reason: 'progress',
+    });
+
+    expect(jobsService.runJob).toHaveBeenCalledTimes(4);
+    const firstFingerprint = getRunJobFingerprint(jobsService, 0);
+    const secondFingerprint = getRunJobFingerprint(jobsService, 2);
+    expect(firstFingerprint).toBe(secondFingerprint);
+    expect(webhooksService.logPlexWebhookAutomation).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        skipped: {
+          watchedMovieRecommendations: 'already_processed',
+          immaculateTastePoints: 'already_processed',
+        },
+      }),
+    );
+  });
+
+  it('skips a repeated episode but still runs a different episode of the same show', async () => {
+    const { service, jobsService, plexUsers } = makeService();
+    const internalService = service as unknown as InternalPlexPollingService;
+    plexUsers.resolvePlexUser.mockResolvedValue({
+      id: 'plex-user-2',
+      plexAccountTitle: 'Alice',
+    });
+    jobsService.runJob
+      .mockResolvedValueOnce({ id: 'watched-run-1' })
+      .mockResolvedValueOnce({ id: 'immaculate-run-1' })
+      .mockRejectedValueOnce(makeAlreadyProcessedConflict())
+      .mockRejectedValueOnce(makeAlreadyProcessedConflict())
+      .mockResolvedValueOnce({ id: 'watched-run-2' })
+      .mockResolvedValueOnce({ id: 'immaculate-run-2' });
+
+    const settings = makeSettings();
+
+    await internalService.maybeTriggerWatchedAutomation({
+      userId: 'admin',
+      snap: makeEpisodeSnap({
+        sessionKey: 'episode-session-1',
+        ratingKey: 'episode-1',
+        parentIndex: 1,
+        index: 1,
+      }),
+      settings,
+      reason: 'progress',
+    });
+    await internalService.maybeTriggerWatchedAutomation({
+      userId: 'admin',
+      snap: makeEpisodeSnap({
+        sessionKey: 'episode-session-2',
+        ratingKey: 'episode-1',
+        parentIndex: 1,
+        index: 1,
+      }),
+      settings,
+      reason: 'progress',
+    });
+    await internalService.maybeTriggerWatchedAutomation({
+      userId: 'admin',
+      snap: makeEpisodeSnap({
+        sessionKey: 'episode-session-3',
+        ratingKey: 'episode-2',
+        title: 'Tabula Rasa',
+        parentIndex: 1,
+        index: 2,
+      }),
+      settings,
+      reason: 'progress',
+    });
+
+    expect(jobsService.runJob).toHaveBeenCalledTimes(6);
+    const firstFingerprint = getRunJobFingerprint(jobsService, 0);
+    const repeatedFingerprint = getRunJobFingerprint(jobsService, 2);
+    const differentEpisodeFingerprint = getRunJobFingerprint(jobsService, 4);
+    expect(firstFingerprint).toBe(repeatedFingerprint);
+    expect(firstFingerprint).not.toBe(differentEpisodeFingerprint);
+  });
+
+  it('still runs the same title for a different Plex user or a different library', async () => {
+    const { service, jobsService, plexUsers } = makeService();
+    const internalService = service as unknown as InternalPlexPollingService;
+    plexUsers.resolvePlexUser
+      .mockResolvedValueOnce({
+        id: 'plex-user-2',
+        plexAccountTitle: 'Alice',
+      })
+      .mockResolvedValueOnce({
+        id: 'plex-user-3',
+        plexAccountTitle: 'Bob',
+      })
+      .mockResolvedValueOnce({
+        id: 'plex-user-2',
+        plexAccountTitle: 'Alice',
+      });
+    jobsService.runJob.mockResolvedValue({ id: 'run-ok' });
+
+    const settings = makeSettings();
+
+    await internalService.maybeTriggerWatchedAutomation({
+      userId: 'admin',
+      snap: makeMovieSnap({ sessionKey: 'user-a-library-1', userId: 2 }),
+      settings,
+      reason: 'progress',
+    });
+    await internalService.maybeTriggerWatchedAutomation({
+      userId: 'admin',
+      snap: makeMovieSnap({
+        sessionKey: 'user-b-library-1',
+        userId: 3,
+        userTitle: 'Bob',
+      }),
+      settings,
+      reason: 'progress',
+    });
+    await internalService.maybeTriggerWatchedAutomation({
+      userId: 'admin',
+      snap: makeMovieSnap({
+        sessionKey: 'user-a-library-2',
+        librarySectionId: 2,
+        librarySectionTitle: 'Movies 2',
+      }),
+      settings,
+      reason: 'progress',
+    });
+
+    expect(jobsService.runJob).toHaveBeenCalledTimes(6);
+    const baseFingerprint = getRunJobFingerprint(jobsService, 0);
+    const differentUserFingerprint = getRunJobFingerprint(jobsService, 2);
+    const differentLibraryFingerprint = getRunJobFingerprint(jobsService, 4);
+    expect(baseFingerprint).not.toBe(differentUserFingerprint);
+    expect(baseFingerprint).not.toBe(differentLibraryFingerprint);
   });
 });

--- a/apps/api/src/webhooks/plex-polling.service.ts
+++ b/apps/api/src/webhooks/plex-polling.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { Interval } from '@nestjs/schedule';
 import { AuthService } from '../auth/auth.service';
+import { buildAutoRunMediaFingerprint } from '../jobs/auto-run-media';
 import { JobsService } from '../jobs/jobs.service';
 import type { JsonObject } from '../jobs/jobs.types';
 import { PlexAnalyticsService } from '../plex/plex-analytics.service';
@@ -45,6 +46,14 @@ function pickBool(obj: Record<string, unknown>, path: string): boolean | null {
   return typeof v === 'boolean' ? v : null;
 }
 
+function readConflictReason(error: unknown): string | null {
+  if (!(error instanceof ConflictException)) return null;
+  const response = error.getResponse();
+  if (!isPlainObject(response)) return null;
+  const reason = response['reason'];
+  return typeof reason === 'string' && reason.trim() ? reason.trim() : null;
+}
+
 function parseBoolEnv(raw: string | undefined, defaultValue: boolean): boolean {
   const v = raw?.trim().toLowerCase();
   if (!v) return defaultValue;
@@ -80,6 +89,7 @@ type SessionCollectionJobStatus =
   | 'idle'
   | 'queued'
   | 'running'
+  | 'processed'
   | 'success'
   | 'failed';
 
@@ -280,7 +290,12 @@ export class PlexPollingService implements OnModuleInit {
     jobId: CollectionJobId,
   ) {
     const status = this.getSessionJobStatus(sessionAutomationId, jobId);
-    return status !== 'queued' && status !== 'running' && status !== 'success';
+    return (
+      status !== 'queued' &&
+      status !== 'running' &&
+      status !== 'processed' &&
+      status !== 'success'
+    );
   }
 
   private pruneSessionAutomationState(nowMs: number) {
@@ -1245,12 +1260,15 @@ export class PlexPollingService implements OnModuleInit {
       sessionAutomationId,
       forceBothAtNinetyPercent,
     } as const;
+    const autoRunMediaFingerprint = buildAutoRunMediaFingerprint(payloadInput);
     const watchedInput = {
       ...payloadInput,
+      ...(autoRunMediaFingerprint ? { autoRunMediaFingerprint } : {}),
       threshold: this.watchedScrobbleThreshold,
     } as const;
     const immaculateInput = {
       ...payloadInput,
+      ...(autoRunMediaFingerprint ? { autoRunMediaFingerprint } : {}),
       threshold: this.immaculateScrobbleThreshold,
     } as const;
 
@@ -1308,12 +1326,13 @@ export class PlexPollingService implements OnModuleInit {
           now,
         );
       } catch (error) {
-        if (error instanceof ConflictException) {
-          skipped[params.jobId] = params.reason || 'already_queued_or_running';
+        const conflictReason = readConflictReason(error);
+        if (conflictReason) {
+          skipped[params.jobId] = conflictReason;
           this.setSessionJobStatus(
             sessionAutomationId,
             params.jobId,
-            'queued',
+            conflictReason === 'already_processed' ? 'processed' : 'queued',
             now,
           );
         } else {

--- a/apps/api/src/webhooks/webhooks.controller.spec.ts
+++ b/apps/api/src/webhooks/webhooks.controller.spec.ts
@@ -1,71 +1,102 @@
+import { ConflictException } from '@nestjs/common';
 import { WebhooksController } from './webhooks.controller';
 
-describe('WebhooksController user monitoring exclusion', () => {
-  function makeController() {
-    const webhooksService = {
-      isDuplicatePayload: jest.fn().mockReturnValue(false),
-      persistPlexWebhookEvent: jest.fn(),
-      logPlexWebhookSummary: jest.fn(),
-      logPlexWebhookAutomation: jest.fn(),
-      logPlexUserMonitoringSkipped: jest.fn(),
-    };
-    const webhookSecret = {
-      getSecret: jest.fn().mockReturnValue(''),
-    };
-    const jobsService = {
-      runJob: jest.fn(),
-    };
-    const authService = {
-      getFirstAdminUserId: jest.fn(),
-    };
-    const settingsService = {
-      getInternalSettings: jest.fn(),
-    };
-    const plexUsers = {
-      resolvePlexUser: jest.fn(),
-    };
-    const plexAnalytics = {
-      invalidateLibraryGrowth: jest.fn(),
-    };
+function makeAlreadyProcessedConflict() {
+  return new ConflictException({
+    reason: 'already_processed',
+    message: 'Job already processed for this media.',
+  });
+}
 
-    const controller = new WebhooksController(
-      webhooksService as never,
-      webhookSecret as never,
-      jobsService as never,
-      authService as never,
-      settingsService as never,
-      plexUsers as never,
-      plexAnalytics as never,
-    );
+function makeController() {
+  const webhooksService = {
+    isDuplicatePayload: jest.fn().mockReturnValue(false),
+    persistPlexWebhookEvent: jest.fn(),
+    logPlexWebhookSummary: jest.fn(),
+    logPlexWebhookAutomation: jest.fn(),
+    logPlexUserMonitoringSkipped: jest.fn(),
+  };
+  const webhookSecret = {
+    getSecret: jest.fn().mockReturnValue(''),
+  };
+  const jobsService = {
+    runJob: jest.fn(),
+  };
+  const authService = {
+    getFirstAdminUserId: jest.fn(),
+  };
+  const settingsService = {
+    getInternalSettings: jest.fn(),
+  };
+  const plexUsers = {
+    resolvePlexUser: jest.fn(),
+  };
+  const plexAnalytics = {
+    invalidateLibraryGrowth: jest.fn(),
+  };
 
-    return {
-      controller,
-      webhooksService,
-      jobsService,
-      authService,
-      settingsService,
-      plexUsers,
-    };
-  }
+  const controller = new WebhooksController(
+    webhooksService as never,
+    webhookSecret as never,
+    jobsService as never,
+    authService as never,
+    settingsService as never,
+    plexUsers as never,
+    plexAnalytics as never,
+  );
 
+  webhooksService.persistPlexWebhookEvent.mockResolvedValue({
+    path: '/tmp/webhook.json',
+  });
+  authService.getFirstAdminUserId.mockResolvedValue('admin-user');
+  plexUsers.resolvePlexUser.mockResolvedValue({
+    id: 'plex-user-2',
+    plexAccountTitle: 'Alice',
+    plexAccountId: 2,
+  });
+
+  return {
+    controller,
+    webhooksService,
+    jobsService,
+    authService,
+    settingsService,
+    plexUsers,
+  };
+}
+
+function makeMovieWebhookPayload() {
+  return {
+    payload: JSON.stringify({
+      event: 'media.scrobble',
+      Account: { id: 2, title: 'Alice' },
+      Metadata: {
+        type: 'movie',
+        title: 'Inception',
+        year: 2010,
+        ratingKey: 'movie-1',
+        librarySectionID: 1,
+        librarySectionTitle: 'Movies',
+      },
+    }),
+  };
+}
+
+function getRunJobFingerprint(
+  jobsService: { runJob: jest.Mock },
+  callIndex: number,
+): string {
+  const call = jobsService.runJob.mock.calls[callIndex] as [
+    { input: { autoRunMediaFingerprint: string } },
+  ];
+  return call[0].input.autoRunMediaFingerprint;
+}
+
+describe('WebhooksController plex webhook auto-runs', () => {
   it('skips scrobble automation when plex user is toggled off by admin', async () => {
-    const {
-      controller,
-      webhooksService,
-      jobsService,
-      authService,
-      settingsService,
-      plexUsers,
-    } = makeController();
+    const { controller, webhooksService, jobsService, settingsService } =
+      makeController();
 
-    webhooksService.persistPlexWebhookEvent.mockResolvedValue({
-      path: '/tmp/webhook.json',
-    });
-    authService.getFirstAdminUserId.mockResolvedValue('admin-user');
-    plexUsers.resolvePlexUser.mockResolvedValue({
-      id: 'plex-user-2',
-      plexAccountTitle: 'Alice',
-    });
     settingsService.getInternalSettings.mockResolvedValue({
       settings: {
         plex: {
@@ -79,18 +110,7 @@ describe('WebhooksController user monitoring exclusion', () => {
 
     const result = await controller.plexWebhook(
       { ip: '127.0.0.1', headers: { 'user-agent': 'jest' } } as never,
-      {
-        payload: JSON.stringify({
-          event: 'media.scrobble',
-          Account: { id: 2, title: 'Alice' },
-          Metadata: {
-            type: 'movie',
-            title: 'Inception',
-            librarySectionID: 1,
-            librarySectionTitle: 'Movies',
-          },
-        }),
-      } as never,
+      makeMovieWebhookPayload() as never,
       [],
     );
 
@@ -107,5 +127,77 @@ describe('WebhooksController user monitoring exclusion', () => {
         plexUserTitle: 'Alice',
       }),
     );
+  });
+
+  it('skips immaculateTastePoints as already_processed after a prior successful auto-run', async () => {
+    const { controller, jobsService, settingsService } = makeController();
+    settingsService.getInternalSettings.mockResolvedValue({
+      settings: {
+        jobs: {
+          webhookEnabled: {
+            watchedMovieRecommendations: true,
+            immaculateTastePoints: true,
+          },
+        },
+      },
+      secrets: {},
+    });
+    jobsService.runJob
+      .mockResolvedValueOnce({ id: 'immaculate-run-1' })
+      .mockRejectedValueOnce(makeAlreadyProcessedConflict());
+
+    const request = {
+      ip: '127.0.0.1',
+      headers: { 'user-agent': 'jest' },
+    } as never;
+
+    await controller.plexWebhook(
+      request,
+      makeMovieWebhookPayload() as never,
+      [],
+    );
+    const result = await controller.plexWebhook(
+      request,
+      makeMovieWebhookPayload() as never,
+      [],
+    );
+
+    expect(result.triggered).toBe(false);
+    expect(result.skipped).toEqual({
+      watchedMovieRecommendations: 'polling_only',
+      immaculateTastePoints: 'already_processed',
+    });
+    expect(jobsService.runJob).toHaveBeenCalledTimes(2);
+    const firstFingerprint = getRunJobFingerprint(jobsService, 0);
+    const secondFingerprint = getRunJobFingerprint(jobsService, 1);
+    expect(firstFingerprint).toBe(secondFingerprint);
+  });
+
+  it('keeps the watched webhook path in polling_only mode', async () => {
+    const { controller, jobsService, settingsService } = makeController();
+    settingsService.getInternalSettings.mockResolvedValue({
+      settings: {
+        jobs: {
+          webhookEnabled: {
+            watchedMovieRecommendations: true,
+            immaculateTastePoints: false,
+          },
+        },
+      },
+      secrets: {},
+    });
+
+    const result = await controller.plexWebhook(
+      { ip: '127.0.0.1', headers: { 'user-agent': 'jest' } } as never,
+      makeMovieWebhookPayload() as never,
+      [],
+    );
+
+    expect(result.triggered).toBe(false);
+    expect(result.skipped).toEqual({
+      watchedMovieRecommendations: 'polling_only',
+      immaculateTastePoints: 'disabled',
+    });
+    expect(jobsService.runJob).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/webhooks/webhooks.controller.ts
+++ b/apps/api/src/webhooks/webhooks.controller.ts
@@ -16,6 +16,7 @@ import type { Express } from 'express';
 import type { Request } from 'express';
 import { AuthService } from '../auth/auth.service';
 import { Public } from '../auth/public.decorator';
+import { buildAutoRunMediaFingerprint } from '../jobs/auto-run-media';
 import { JobsService } from '../jobs/jobs.service';
 import { PlexAnalyticsService } from '../plex/plex-analytics.service';
 import { isPlexLibrarySectionExcluded } from '../plex/plex-library-selection.utils';
@@ -59,6 +60,14 @@ function pickNumber(obj: Record<string, unknown>, path: string): number | null {
 function pickBool(obj: Record<string, unknown>, path: string): boolean | null {
   const v = pick(obj, path);
   return typeof v === 'boolean' ? v : null;
+}
+
+function readConflictReason(error: unknown): string | null {
+  if (!(error instanceof ConflictException)) return null;
+  const response = error.getResponse();
+  if (!isPlainObject(response)) return null;
+  const reason = response['reason'];
+  return typeof reason === 'string' && reason.trim() ? reason.trim() : null;
 }
 
 function readSingleHeader(value: string | string[] | undefined): string | null {
@@ -304,6 +313,14 @@ export class WebhooksController {
                 : {}),
               persistedPath: persisted.path,
             } as const;
+            const autoRunMediaFingerprint =
+              buildAutoRunMediaFingerprint(payloadInput);
+            const runInput = autoRunMediaFingerprint
+              ? {
+                  ...payloadInput,
+                  autoRunMediaFingerprint,
+                }
+              : payloadInput;
 
             const runs: Record<string, string> = {};
             const errors: Record<string, string> = {};
@@ -385,12 +402,13 @@ export class WebhooksController {
                   trigger: 'auto',
                   dryRun: false,
                   userId,
-                  input: payloadInput,
+                  input: runInput,
                 });
                 runs.immaculateTastePoints = run.id;
               } catch (err) {
-                if (err instanceof ConflictException) {
-                  skipped.immaculateTastePoints = 'already_queued_or_running';
+                const conflictReason = readConflictReason(err);
+                if (conflictReason) {
+                  skipped.immaculateTastePoints = conflictReason;
                 } else {
                   errors.immaculateTastePoints =
                     (err as Error)?.message ?? String(err);

--- a/apps/web/src/lib/faq-feature-links.ts
+++ b/apps/web/src/lib/faq-feature-links.ts
@@ -28,6 +28,7 @@ export const FAQ_SECTION_BY_TASK_MANAGER_CARD_ID = {
   mediaAddedCleanup: 'task-manager-cleanup-after-adding-new-content',
   arrMonitoredSearch: 'task-manager-search-monitored',
   tmdbUpcomingMovies: 'task-manager-tmdb-upcoming-movies',
+  rottenTomatoesUpcomingMovies: 'task-manager-rotten-tomatoes-upcoming-movies',
   immaculateTastePoints: 'task-manager-immaculate-taste-collection',
   immaculateTasteRefresher: 'task-manager-immaculate-taste-refresher',
   watchedMovieRecommendations: 'task-manager-based-on-latest-watched-collection',

--- a/apps/web/src/lib/version-history.ts
+++ b/apps/web/src/lib/version-history.ts
@@ -37,7 +37,7 @@ export function splitVersionHistoryLabel(
 
 export const VERSION_HISTORY_ENTRIES: VersionHistoryEntry[] = [
   {
-    version: '1.7.7',
+    version: '1.7.7-beta-1',
     popupHighlights: [
       'Rotten Tomatoes Upcoming Movies adds a fixed-source movie discovery task that routes safe matches to Radarr or Seerr.',
       'Plex watched auto-runs now skip repeat watches of the same exact movie or episode after a successful run, while manual and scheduled runs stay available.',

--- a/apps/web/src/lib/version-history.ts
+++ b/apps/web/src/lib/version-history.ts
@@ -37,6 +37,33 @@ export function splitVersionHistoryLabel(
 
 export const VERSION_HISTORY_ENTRIES: VersionHistoryEntry[] = [
   {
+    version: '1.7.7',
+    popupHighlights: [
+      'Rotten Tomatoes Upcoming Movies adds a fixed-source movie discovery task that routes safe matches to Radarr or Seerr.',
+      'Plex watched auto-runs now skip repeat watches of the same exact movie or episode after a successful run, while manual and scheduled runs stay available.',
+    ],
+    sections: [
+      {
+        title: 'Rotten Tomatoes Upcoming Movies',
+        bullets: [
+          'Adds a new Task Manager job that scrapes fixed Rotten Tomatoes upcoming and newest movie pages.',
+          'Deduplicates discovered titles, applies conservative title-and-year matching, and only routes safe matches onward.',
+          'Can send matched movies directly to Radarr or, when enabled, route them through Seerr instead.',
+          'Reports include discovery, routing, and skip details so you can see exactly what happened during the run.',
+        ],
+      },
+      {
+        title: 'Durable repeat-watch dedupe for Plex auto-runs',
+        bullets: [
+          'Based on your recently watched and Change of Taste now remember successful auto-runs per Plex user, library, and exact movie or episode.',
+          'Repeat scrobbles of the same item are skipped as already processed instead of re-running the same automation again.',
+          'The same durable dedupe applies across Plex polling and the existing Immaculate Taste webhook trigger so both paths stay aligned.',
+          'Manual and scheduled runs still work normally, and only new successful auto-runs start building this dedupe history.',
+        ],
+      },
+    ],
+  },
+  {
     version: '1.7.6',
     popupHighlights: [
       'Plex Watch History Import: import your Plex watched history to generate personalized recommendations and Plex collections.',
@@ -401,8 +428,8 @@ export const VERSION_HISTORY_ENTRIES: VersionHistoryEntry[] = [
         title: 'Curated Movies and TV Shows collections',
         bullets: [
           'Inspired by your Immaculate Taste (long term collection)',
-          'Based on your recently watched (refreshes on every watch)',
-          'Change of Taste (refreshes on every watch)',
+          'Based on your recently watched (auto-refreshes for newly completed movies/episodes)',
+          'Change of Taste (auto-refreshes for newly completed movies/episodes)',
         ],
       },
       {

--- a/apps/web/src/pages/FaqPage.tsx
+++ b/apps/web/src/pages/FaqPage.tsx
@@ -1554,6 +1554,12 @@ export const FaqPage = () => {
                   at Plex scrobble timing.
                 </li>
                 <li>
+                  <span className="font-semibold text-white/85">Repeat-watch dedupe:</span> once one
+                  of these auto-runs completes successfully for the same Plex user, library, and
+                  exact movie/episode, repeated watches of that same item are skipped automatically.
+                  Manual runs still work any time.
+                </li>
+                <li>
                   <span className="font-semibold text-white/85">New content trigger:</span> when a
                   new movie or show episode is added, the cleanup task can trigger to scan for
                   duplicates.

--- a/apps/web/src/pages/FaqPage.tsx
+++ b/apps/web/src/pages/FaqPage.tsx
@@ -757,6 +757,105 @@ export const FaqPage = () => {
       ],
     },
     {
+      id: 'task-manager-rotten-tomatoes-upcoming-movies',
+      title: 'Rotten Tomatoes Upcoming Movies',
+      items: [
+        {
+          id: 'task-manager-rotten-tomatoes-upcoming-how-it-works',
+          question: 'How does Rotten Tomatoes Upcoming Movies work?',
+          answer: (
+            <>
+              <p>
+                This task scrapes fixed Rotten Tomatoes upcoming and newest movie pages, merges the
+                results, and routes safe matches to Radarr or, when enabled, to Seerr.
+              </p>
+              <p>Run flow:</p>
+              <ol className="list-decimal pl-5 space-y-1">
+                <li>Immaculaterr fetches each built-in Rotten Tomatoes source page.</li>
+                <li>
+                  Movie cards are parsed from the page HTML, then deduplicated by normalized title and
+                  year.
+                </li>
+                <li>
+                  Radarr is checked once up front, then each candidate is matched conservatively before
+                  it is added to Radarr or requested in Seerr.
+                </li>
+              </ol>
+            </>
+          ),
+        },
+        {
+          id: 'task-manager-rotten-tomatoes-upcoming-sources',
+          question: 'What sources does it check?',
+          answer: (
+            <ul className="list-disc pl-5 space-y-1">
+              <li>One Rotten Tomatoes in-theaters newest page.</li>
+              <li>
+                Eleven Rotten Tomatoes at-home newest pages for Fandango at Home, Apple TV+, Netflix,
+                Prime Video, Disney+, Max, Peacock, Hulu, Paramount+, AMC+, and Acorn TV.
+              </li>
+              <li>
+                These URLs are fixed in code for this task, so there is no custom source editor on the
+                card.
+              </li>
+              <li>
+                If one source page fails, the run keeps going and reports that source as skipped.
+              </li>
+            </ul>
+          ),
+        },
+        {
+          id: 'task-manager-rotten-tomatoes-upcoming-route-via-seerr',
+          question: 'What does the Route via Seerr toggle do?',
+          answer: (
+            <ul className="list-disc pl-5 space-y-1">
+              <li>
+                When the toggle is off, matched movies are added directly to Radarr with the app’s
+                saved Radarr defaults.
+              </li>
+              <li>
+                When the toggle is on, matched movies are requested in Seerr instead of being added
+                directly to Radarr.
+              </li>
+              <li>
+                Rotten Tomatoes titles are still matched conservatively through Radarr lookup first,
+                so Seerr requests only happen for safe title and year matches.
+              </li>
+              <li>
+                If Seerr routing is enabled but Seerr is not configured, discovery still completes and
+                the destination step is marked skipped.
+              </li>
+            </ul>
+          ),
+        },
+        {
+          id: 'task-manager-rotten-tomatoes-upcoming-results',
+          question: 'What results should I expect after a run?',
+          answer: (
+            <ul className="list-disc pl-5 space-y-1">
+              <li>
+                Movies already present in Radarr, or already present/requested in Seerr, are counted as
+                existing instead of surfacing as hard failures.
+              </li>
+              <li>
+                If Radarr is not configured, discovery still completes and the destination step is
+                marked skipped. If Seerr routing is enabled but Seerr is not configured, the routing
+                step is skipped too.
+              </li>
+              <li>
+                Rewind shows source-page counts plus destination outcomes for attempted, requested or
+                added, existing, failed, and skipped movies.
+              </li>
+              <li>
+                This task does not use TMDB filters. Seerr routing is optional, but safe matching still
+                relies on Radarr lookup.
+              </li>
+            </ul>
+          ),
+        },
+      ],
+    },
+    {
       id: 'task-manager-immaculate-taste-collection',
       title: 'Immaculate Taste Collection',
       items: [
@@ -2777,6 +2876,8 @@ export const FaqPage = () => {
     'task-manager-search-monitored': 'Off-peak missing searches for monitored ARR items.',
     'task-manager-tmdb-upcoming-movies':
       'What this task does, how each run works, and how to edit filters.',
+    'task-manager-rotten-tomatoes-upcoming-movies':
+      'Fixed-source Rotten Tomatoes discovery that routes safe matches to Radarr or Seerr.',
     'task-manager-immaculate-taste-collection':
       'Watch-triggered Immaculate Taste updates and missing-item routing.',
     'task-manager-immaculate-taste-refresher':
@@ -2841,6 +2942,10 @@ export const FaqPage = () => {
     'task-manager-tmdb-upcoming-movies': {
       icon: (className) => <Film className={className} />,
       toneClass: 'text-cyan-200',
+    },
+    'task-manager-rotten-tomatoes-upcoming-movies': {
+      icon: (className) => <Film className={className} />,
+      toneClass: 'text-rose-200',
     },
     'task-manager-immaculate-taste-collection': {
       icon: (className) => <Sparkles className={className} />,

--- a/apps/web/src/pages/JobRunDetailPage.tsx
+++ b/apps/web/src/pages/JobRunDetailPage.tsx
@@ -208,6 +208,26 @@ function getProgressPlan(jobId: string): ProgressPlan | null {
   const id = (jobId ?? '').trim();
   if (!id) return null;
 
+  if (id === 'rottenTomatoesUpcomingMovies') {
+    return {
+      total: 4,
+      getStage: ({ stepId }) => {
+        if (!stepId) return null;
+        if (stepId === 'load_settings') return 1;
+        if (stepId === 'scrape_sources') return 2;
+        if (stepId === 'prepare_radarr') return 3;
+        if (
+          stepId === 'route_movies' ||
+          stepId === 'done' ||
+          stepId === 'failed'
+        ) {
+          return 4;
+        }
+        return null;
+      },
+    };
+  }
+
   // Cleanup job: scan → delete/unmonitor → watchlist
   if (id === 'mediaAddedCleanup') {
     return {

--- a/apps/web/src/pages/TaskManagerPage.tsx
+++ b/apps/web/src/pages/TaskManagerPage.tsx
@@ -91,6 +91,10 @@ type TmdbUpcomingSettingsDraft = {
   filters: TmdbUpcomingFilterDraft[];
 };
 
+type RottenTomatoesUpcomingSettingsDraft = {
+  routeViaSeerr: boolean;
+};
+
 type TmdbFilterChipOption = {
   id: string;
   label: string;
@@ -158,6 +162,12 @@ const JOB_CONFIG: Record<
     color: 'text-cyan-300',
     description:
       'Discovers upcoming TMDB movies from custom filter sets and routes top picks to Radarr or Seerr.',
+  },
+  rottenTomatoesUpcomingMovies: {
+    icon: <Clapperboard className="w-8 h-8" />,
+    color: 'text-rose-300',
+    description:
+      'Scrapes fixed Rotten Tomatoes upcoming and newest movie pages, deduplicates safe matches, and routes them to Radarr or Seerr.',
   },
   mediaAddedCleanup: {
     icon: <CheckCircle2 className="w-8 h-8" />,
@@ -641,6 +651,16 @@ function normalizeTmdbUpcomingSettings(settings: unknown): TmdbUpcomingSettingsD
   };
 }
 
+function normalizeRottenTomatoesUpcomingSettings(
+  settings: unknown,
+): RottenTomatoesUpcomingSettingsDraft {
+  return {
+    routeViaSeerr:
+      readBool(settings, 'jobs.rottenTomatoesUpcomingMovies.routeViaSeerr') ??
+      false,
+  };
+}
+
 const TASK_MANAGER_AUTO_EXPAND_SEEN_KEY = 'immaculaterr.taskManager.autoExpandSeen.v1';
 
 export function TaskManagerPage() {
@@ -781,6 +801,12 @@ export function TaskManagerPage() {
         filters: [],
       };
     });
+  const [
+    rottenTomatoesUpcomingSettingsDraft,
+    setRottenTomatoesUpcomingSettingsDraft,
+  ] = useState<RottenTomatoesUpcomingSettingsDraft>({
+    routeViaSeerr: false,
+  });
   const [tmdbGenreSearchByFilter, setTmdbGenreSearchByFilter] = useState<
     Record<string, string>
   >({});
@@ -820,6 +846,10 @@ export function TaskManagerPage() {
   const tmdbUpcomingSettingsDraftRef = useRef<TmdbUpcomingSettingsDraft>(
     tmdbUpcomingSettingsDraft,
   );
+  const rottenTomatoesUpcomingSettingsDraftRef =
+    useRef<RottenTomatoesUpcomingSettingsDraft>(
+      rottenTomatoesUpcomingSettingsDraft,
+    );
   const tmdbCalendarToday = createDefaultTmdbWindowStart();
   const tmdbWindowStartCalendarCells = useMemo(
     () => buildCalendarMonthCells(tmdbWindowStartCalendarMonth),
@@ -908,6 +938,19 @@ export function TaskManagerPage() {
       queryClient.setQueryData(['publicSettings'], data);
     },
   });
+  const rottenTomatoesUpcomingSettingsMutation = useMutation({
+    mutationFn: async (next: RottenTomatoesUpcomingSettingsDraft) =>
+      putSettings({
+        settings: {
+          jobs: {
+            rottenTomatoesUpcomingMovies: next,
+          },
+        },
+      }),
+    onSuccess: (data) => {
+      queryClient.setQueryData(['publicSettings'], data);
+    },
+  });
 
   useEffect(() => {
     if (tmdbUpcomingSettingsMutation.isPending) return;
@@ -917,10 +960,22 @@ export function TaskManagerPage() {
     }, 0);
     return () => clearTimeout(timeout);
   }, [publicSettings, tmdbUpcomingSettingsMutation.isPending]);
+  useEffect(() => {
+    if (rottenTomatoesUpcomingSettingsMutation.isPending) return;
+    const nextDraft = normalizeRottenTomatoesUpcomingSettings(publicSettings);
+    const timeout = setTimeout(() => {
+      setRottenTomatoesUpcomingSettingsDraft(nextDraft);
+    }, 0);
+    return () => clearTimeout(timeout);
+  }, [publicSettings, rottenTomatoesUpcomingSettingsMutation.isPending]);
 
   useEffect(() => {
     tmdbUpcomingSettingsDraftRef.current = tmdbUpcomingSettingsDraft;
   }, [tmdbUpcomingSettingsDraft]);
+  useEffect(() => {
+    rottenTomatoesUpcomingSettingsDraftRef.current =
+      rottenTomatoesUpcomingSettingsDraft;
+  }, [rottenTomatoesUpcomingSettingsDraft]);
 
   useEffect(() => {
     if (!tmdbWindowStartCalendarOpen) return;
@@ -1446,30 +1501,44 @@ export function TaskManagerPage() {
         (job) =>
           job.visibleInTaskManager && !TASK_MANAGER_HIDDEN_JOB_IDS.has(job.id),
       );
-      const freshOutOfTheOvenJob = filteredJobs.find(
-        (job) => job.id === 'freshOutOfTheOven',
+      const targetOrder = [
+        'tmdbUpcomingMovies',
+        'rottenTomatoesUpcomingMovies',
+        'freshOutOfTheOven',
+      ] as const;
+      const orderedTargetJobs = targetOrder
+        .map((jobId) => filteredJobs.find((job) => job.id === jobId))
+        .filter((job): job is (typeof filteredJobs)[number] => Boolean(job));
+      const jobsWithoutUpcomingGroup = filteredJobs.filter(
+        (job) => !targetOrder.includes(job.id as (typeof targetOrder)[number]),
       );
-      if (!freshOutOfTheOvenJob) return filteredJobs;
+      if (orderedTargetJobs.length > 0) {
+        const firstUpcomingIndex = filteredJobs.findIndex(
+          (job) => targetOrder.includes(job.id as (typeof targetOrder)[number]),
+        );
+        if (firstUpcomingIndex !== -1) {
+          jobsWithoutUpcomingGroup.splice(
+            firstUpcomingIndex,
+            0,
+            ...orderedTargetJobs,
+          );
+        } else {
+          const monitorIndex = jobsWithoutUpcomingGroup.findIndex(
+            (job) => job.id === 'arrMonitoredSearch',
+          );
+          jobsWithoutUpcomingGroup.splice(
+            monitorIndex === -1 ? jobsWithoutUpcomingGroup.length : monitorIndex + 1,
+            0,
+            ...orderedTargetJobs,
+          );
+        }
+      }
 
-      const jobsWithoutFreshOutOfTheOven = filteredJobs.filter(
-        (job) => job.id !== 'freshOutOfTheOven',
-      );
-      const tmdbUpcomingMoviesIndex = jobsWithoutFreshOutOfTheOven.findIndex(
-        (job) => job.id === 'tmdbUpcomingMovies',
-      );
-      if (tmdbUpcomingMoviesIndex === -1) return filteredJobs;
-
-      jobsWithoutFreshOutOfTheOven.splice(
-        tmdbUpcomingMoviesIndex + 1,
-        0,
-        freshOutOfTheOvenJob,
-      );
-
-      const plexHistoryJob = jobsWithoutFreshOutOfTheOven.find(
+      const plexHistoryJob = jobsWithoutUpcomingGroup.find(
         (job) => job.id === 'importPlexHistory',
       );
       if (plexHistoryJob) {
-        const withoutPlexHistory = jobsWithoutFreshOutOfTheOven.filter(
+        const withoutPlexHistory = jobsWithoutUpcomingGroup.filter(
           (job) => job.id !== 'importPlexHistory',
         );
         const netflixIndex = withoutPlexHistory.findIndex(
@@ -1481,7 +1550,7 @@ export function TaskManagerPage() {
         }
       }
 
-      return jobsWithoutFreshOutOfTheOven;
+      return jobsWithoutUpcomingGroup;
     },
     [jobsQuery.data?.jobs],
   );
@@ -2573,6 +2642,25 @@ export function TaskManagerPage() {
     },
     [tmdbUpcomingSettingsMutation],
   );
+  const updateRottenTomatoesUpcomingSettings = useCallback(
+    (
+      updater: (
+        prev: RottenTomatoesUpcomingSettingsDraft,
+      ) => RottenTomatoesUpcomingSettingsDraft,
+    ) => {
+      const previous = rottenTomatoesUpcomingSettingsDraftRef.current;
+      const next = updater(previous);
+      rottenTomatoesUpcomingSettingsDraftRef.current = next;
+      setRottenTomatoesUpcomingSettingsDraft(next);
+      rottenTomatoesUpcomingSettingsMutation.mutate(next, {
+        onError: () => {
+          rottenTomatoesUpcomingSettingsDraftRef.current = previous;
+          setRottenTomatoesUpcomingSettingsDraft(previous);
+        },
+      });
+    },
+    [rottenTomatoesUpcomingSettingsMutation],
+  );
   const handleToggleTmdbUpcomingRouteViaSeerr = useCallback(
     (event: ReactMouseEvent<HTMLButtonElement>) => {
       event.stopPropagation();
@@ -2588,6 +2676,26 @@ export function TaskManagerPage() {
       openIntegrationSetupDialog,
       tmdbUpcomingSettingsDraft.routeViaSeerr,
       updateTmdbUpcomingSettings,
+    ],
+  );
+  const handleToggleRottenTomatoesUpcomingRouteViaSeerr = useCallback(
+    (event: ReactMouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+      const next = !rottenTomatoesUpcomingSettingsDraft.routeViaSeerr;
+      if (next && !canEnableSeerrTaskToggles) {
+        openIntegrationSetupDialog('seerr');
+        return;
+      }
+      updateRottenTomatoesUpcomingSettings((prev) => ({
+        ...prev,
+        routeViaSeerr: next,
+      }));
+    },
+    [
+      canEnableSeerrTaskToggles,
+      openIntegrationSetupDialog,
+      rottenTomatoesUpcomingSettingsDraft.routeViaSeerr,
+      updateRottenTomatoesUpcomingSettings,
     ],
   );
   const handleTmdbUpcomingGlobalLimitChange = useCallback(
@@ -3505,12 +3613,19 @@ export function TaskManagerPage() {
               const nextRunsOpen = nextRunsPopup[job.id] ?? false;
               const timePickerIsOpen = timePickerOpen[job.id] ?? false;
               const supportsSchedule = !UNSCHEDULABLE_JOB_IDS.has(job.id);
+              const showsAdvancedTaskSettingsWhenDisabled =
+                job.id === 'tmdbUpcomingMovies' ||
+                job.id === 'rottenTomatoesUpcomingMovies';
               const webhookEnabled =
                 webhookAutoRun[job.id] ??
                 (readBool(settingsQuery.data?.settings, `jobs.webhookEnabled.${job.id}`) ??
                   false);
               const iconPulseActive = cardIconPulse?.jobId === job.id;
               const isExpanded = expandedCards[job.id] ?? false;
+              const showSchedulerDrawer =
+                supportsSchedule &&
+                isExpanded &&
+                (draft.enabled || showsAdvancedTaskSettingsWhenDisabled);
               const mediaAddedCleanupAllDisabled =
                 !mediaAddedCleanupDeleteDuplicates &&
                 !mediaAddedCleanupUnmonitorInArr &&
@@ -3633,7 +3748,9 @@ export function TaskManagerPage() {
                               (job.id === 'immaculateTastePoints' &&
                                 immaculateIncludeRefresherMutation.isPending) ||
                               (job.id === 'tmdbUpcomingMovies' &&
-                                tmdbUpcomingSettingsMutation.isPending)
+                                tmdbUpcomingSettingsMutation.isPending) ||
+                              (job.id === 'rottenTomatoesUpcomingMovies' &&
+                                rottenTomatoesUpcomingSettingsMutation.isPending)
                             }
                             className="static shrink-0 hidden md:inline-flex"
                           />
@@ -4569,7 +4686,7 @@ export function TaskManagerPage() {
 
                   {/* Scheduler Drawer */}
                   <AnimatePresence initial={false}>
-                    {supportsSchedule && isExpanded && draft.enabled && (
+                    {showSchedulerDrawer && (
                       <motion.div
                         data-no-card-toggle="true"
                         initial={{ opacity: 0, y: -4 }}
@@ -5461,6 +5578,75 @@ export function TaskManagerPage() {
                                       </div>
                                     )}
                                   </div>
+                                </div>
+                              </div>
+                            )}
+                            {job.id === 'rottenTomatoesUpcomingMovies' && (
+                              <div className="rounded-2xl border border-white/10 bg-[#0F0B15]/45 p-5 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+                                <div className="flex flex-col gap-4">
+                                  <div className="text-xs font-bold text-gray-500 uppercase tracking-wider">
+                                    Rotten Tomatoes upcoming settings
+                                  </div>
+
+                                  <div className="grid grid-cols-1 gap-4">
+                                    <div className="flex min-h-[98px] items-center justify-between gap-4 rounded-xl border border-white/10 bg-[#1a1625]/60 px-4 py-3">
+                                      <div className="min-w-0">
+                                        <div className="text-sm font-semibold text-white">
+                                          Route via Seerr
+                                        </div>
+                                        <div className="mt-1 text-xs text-white/55 leading-relaxed">
+                                          Enable to request matched movies in Seerr instead of
+                                          adding them directly to Radarr.
+                                        </div>
+                                      </div>
+                                      <button
+                                        type="button"
+                                        role="switch"
+                                        aria-checked={
+                                          rottenTomatoesUpcomingSettingsDraft.routeViaSeerr
+                                        }
+                                        onClick={
+                                          handleToggleRottenTomatoesUpcomingRouteViaSeerr
+                                        }
+                                        onPointerDown={handleStopPropagationPointer}
+                                        disabled={
+                                          settingsQuery.isLoading ||
+                                          rottenTomatoesUpcomingSettingsMutation.isPending
+                                        }
+                                        className={cn(
+                                          'relative inline-flex h-7 w-12 shrink-0 items-center overflow-hidden rounded-full transition-colors active:scale-95',
+                                          rottenTomatoesUpcomingSettingsDraft.routeViaSeerr
+                                            ? 'bg-cyan-400'
+                                            : 'bg-[#2a2438] border-2 border-white/10',
+                                        )}
+                                        aria-label="Toggle route via Seerr for Rotten Tomatoes Upcoming Movies"
+                                      >
+                                        <span
+                                          className={cn(
+                                            'inline-flex h-5 w-5 transform items-center justify-center rounded-full bg-white transition-transform',
+                                            rottenTomatoesUpcomingSettingsDraft.routeViaSeerr
+                                              ? 'translate-x-6'
+                                              : 'translate-x-1',
+                                          )}
+                                        >
+                                          {rottenTomatoesUpcomingSettingsMutation.isPending && (
+                                            <Loader2 className="h-3 w-3 animate-spin text-black/70" />
+                                          )}
+                                        </span>
+                                      </button>
+                                    </div>
+                                  </div>
+
+                                  {rottenTomatoesUpcomingSettingsMutation.isError && (
+                                    <div className="flex items-center gap-2 text-sm text-red-300">
+                                      <CircleAlert className="w-4 h-4" />
+                                      {
+                                        (
+                                          rottenTomatoesUpcomingSettingsMutation.error as Error
+                                        ).message
+                                      }
+                                    </div>
+                                  )}
                                 </div>
                               </div>
                             )}

--- a/apps/web/src/pages/TaskManagerPage.tsx
+++ b/apps/web/src/pages/TaskManagerPage.tsx
@@ -191,7 +191,7 @@ const JOB_CONFIG: Record<
     icon: <Sparkles className="w-8 h-8" />,
     color: 'text-yellow-300',
     description:
-      'Updates your Immaculate Taste collection after you finish watching, and can send missing titles to Radarr/Sonarr/Seerr.',
+      'Updates your Immaculate Taste collection after a newly completed movie or episode, and can send missing titles to Radarr/Sonarr/Seerr.',
   },
   immaculateTasteRefresher: {
     icon: <RotateCw className="w-8 h-8" />,
@@ -203,7 +203,7 @@ const JOB_CONFIG: Record<
     icon: <Sparkles className="w-8 h-8" />,
     color: 'text-violet-400',
     description:
-      'Generates fresh recommendations after you finish a movie.',
+      'Generates fresh recommendations after a newly completed movie or episode.',
   },
   importNetflixHistory: {
     icon: <FileUp className="w-8 h-8" />,
@@ -6255,8 +6255,8 @@ export function TaskManagerPage() {
                     </h2>
                     <p className="mt-2 text-sm text-white/70 leading-relaxed">
                       This will tell Radarr/Sonarr to start searching as soon as titles are added by
-                      the Immaculate Taste job (after each watch event). If you prefer off-peak
-                      execution, schedule the monitored search instead.
+                      the Immaculate Taste job after a newly completed movie or episode. If you
+                      prefer off-peak execution, schedule the monitored search instead.
                     </p>
                   </div>
                   <button

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -38,6 +38,10 @@ Pick a feature area first, then jump into the full section below.
 > [How does TMDB Upcoming Movies work?](#how-does-tmdb-upcoming-movies-work) · [What are the defaults if I do not create custom filters?](#what-are-the-defaults-if-i-do-not-create-custom-filters) · [How do I set custom filters on this card?](#how-do-i-set-custom-filters-on-this-card)
 > + 1 more answer in the section below.
 
+> ### [Rotten Tomatoes Upcoming Movies](#rotten-tomatoes-upcoming-movies)
+> Fixed-source Rotten Tomatoes discovery that routes safe matches to Radarr or Seerr.
+> [How does Rotten Tomatoes Upcoming Movies work?](#how-does-rotten-tomatoes-upcoming-movies-work) · [What sources does it check?](#what-sources-does-it-check) · [What does the Route via Seerr toggle do?](#what-does-the-route-via-seerr-toggle-do) · [What results should I expect after a run?](#what-results-should-i-expect-after-a-run)
+
 > ### [Immaculate Taste Collection](#immaculate-taste-collection)
 > Watch-triggered Immaculate Taste updates and missing-item routing.
 > [What does Immaculate Taste Collection do?](#what-does-immaculate-taste-collection-do) · [What does the Immaculate Taste Refresher toggle do?](#what-does-the-immaculate-taste-refresher-toggle-do) · [What does Fetch Missing items do on this card?](#what-does-fetch-missing-items-do-on-this-card)
@@ -357,6 +361,41 @@ Each enabled filter gets part of the global limit. All candidates are then merge
 - If all custom filters are disabled, the hidden baseline runs instead.
 - Rewind shows per-filter discovered/selected counts and destination outcomes.
 - Rewind keeps the run title as **TMDB Upcoming Movies** for this job.
+
+## Rotten Tomatoes Upcoming Movies
+
+Open in app: [Task Manager -> Rotten Tomatoes Upcoming Movies](/task-manager#job-rottenTomatoesUpcomingMovies)
+
+### How does Rotten Tomatoes Upcoming Movies work?
+
+This task scrapes fixed Rotten Tomatoes upcoming and newest movie pages, merges the results, and routes safe matches to Radarr or, when enabled, to Seerr.
+
+Run flow:
+
+1. Immaculaterr fetches each built-in Rotten Tomatoes source page.
+2. Movie cards are parsed from the page HTML, then deduplicated by normalized title and year.
+3. Radarr is checked once up front, then each candidate is matched conservatively before it is added to Radarr or requested in Seerr.
+
+### What sources does it check?
+
+- One Rotten Tomatoes in-theaters newest page.
+- Eleven Rotten Tomatoes at-home newest pages for Fandango at Home, Apple TV+, Netflix, Prime Video, Disney+, Max, Peacock, Hulu, Paramount+, AMC+, and Acorn TV.
+- These URLs are fixed in code for this task, so there is no custom source editor on the card.
+- If one source page fails, the run keeps going and reports that source as skipped.
+
+### What does the Route via Seerr toggle do?
+
+- When the toggle is off, matched movies are added directly to Radarr with the app's saved Radarr defaults.
+- When the toggle is on, matched movies are requested in Seerr instead of being added directly to Radarr.
+- Rotten Tomatoes titles are still matched conservatively through Radarr lookup first, so Seerr requests only happen for safe title and year matches.
+- If Seerr routing is enabled but Seerr is not configured, discovery still completes and the destination step is marked skipped.
+
+### What results should I expect after a run?
+
+- Movies already present in Radarr, or already present/requested in Seerr, are counted as existing instead of surfacing as hard failures.
+- If Radarr is not configured, discovery still completes and the destination step is marked skipped. If Seerr routing is enabled but Seerr is not configured, the routing step is skipped too.
+- Rewind shows source-page counts plus destination outcomes for attempted, requested or added, existing, failed, and skipped movies.
+- This task does not use TMDB filters. Seerr routing is optional, but safe matching still relies on Radarr lookup.
 
 ## Immaculate Taste Collection
 

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -642,6 +642,7 @@ Plex-Triggered Auto-Run means the job waits for Plex activity instead of a clock
 
 - These jobs do not run on a timer. They wait for the matching Plex event.
 - **Watched trigger (~60% / ~70%)**: these are default Plex polling thresholds—~60% for "Based on your recently watched" and ~70% for Immaculate Taste. Immaculate Taste can also trigger via Plex webhooks at Plex scrobble timing.
+- **Repeat-watch dedupe**: once one of these auto-runs completes successfully for the same Plex user, library, and exact movie/episode, repeated watches of that same item are skipped automatically. Manual runs still work any time.
 - **New content trigger**: when a new movie or show episode is added, the cleanup task can trigger to scan for duplicates.
 
 You can still run these tasks manually any time from Task Manager.

--- a/doc/README.md
+++ b/doc/README.md
@@ -27,8 +27,8 @@ Major Features Include
   - Pending work survives restarts, duplicate auto-runs are skipped cleanly, and Rewind shows queued/running status with ETA context.
 - **Curated Movies and TV Shows collections**:
   - Inspired by your Immaculate Taste (long term collection)
-  - Based on your recently watched (refreshes on every watch)
-  - Change of Taste (refreshes on every watch)
+  - Based on your recently watched (auto-refreshes for newly completed movies/episodes)
+  - Change of Taste (auto-refreshes for newly completed movies/episodes)
   - Fresh Out Of The Oven (recent-release movies you have not watched yet, per Plex user)
   - Fresh Out Of The Oven (last 3 months, unseen per Plex user)
 - **Recommendation engine**:

--- a/doc/README.md
+++ b/doc/README.md
@@ -36,6 +36,10 @@ Major Features Include
   - Optional - Google + OpenAI 
 - **TMDB Upcoming Movies task filters**:
   - Build custom filter sets with where-to-watch, genre, language, certification, and score controls.
+- **Rotten Tomatoes Upcoming Movies task**:
+  - Scrapes fixed Rotten Tomatoes upcoming and newest movie pages, deduplicates safe matches, and routes them to Radarr or Seerr.
+  - Includes a `Route via Seerr` toggle in Task Manager. Off adds matched movies to Radarr; on requests matched movies in Seerr instead.
+  - Matching still uses the same conservative Radarr lookup step first, so only safe title/year matches are routed.
 - **Keeps a snapshot database:**
   - Recommmended database for refresher task to monitor titles as they become available in Plex.
 - **Radarr + Sonarr integration**:

--- a/doc/Version_History.md
+++ b/doc/Version_History.md
@@ -3,7 +3,7 @@ Version History
 
 This file tracks notable changes by version.
 
-1.7.7
+1.7.7-beta-1
 ---
 
 - What's new since 1.7.6:

--- a/doc/Version_History.md
+++ b/doc/Version_History.md
@@ -3,6 +3,22 @@ Version History
 
 This file tracks notable changes by version.
 
+1.7.7
+---
+
+- What's new since 1.7.6:
+- Rotten Tomatoes Upcoming Movies:
+  - Adds a new Task Manager job that scrapes fixed Rotten Tomatoes upcoming and newest movie pages.
+  - Deduplicates discovered titles, applies conservative title-and-year matching, and only routes safe matches onward.
+  - Can send matched movies directly to Radarr or, when enabled, route them through Seerr instead.
+  - Reports include discovery, routing, and skip details so you can see exactly what happened during the run.
+- Durable repeat-watch dedupe for Plex auto-runs:
+  - Based on your recently watched and Change of Taste now remember successful auto-runs per Plex user, library, and exact movie or episode.
+  - Repeat scrobbles of the same item are skipped as already processed instead of re-running the same automation again.
+  - The same durable dedupe applies across Plex polling and the existing Immaculate Taste webhook trigger so both paths stay aligned.
+  - Manual and scheduled runs still work normally, and only new successful auto-runs start building this dedupe history.
+
+
 1.7.6
 ---
 
@@ -196,8 +212,8 @@ This file tracks notable changes by version.
   - Off hours fetching media or refreshing the Plex home screen.
 - Curated Movies and TV Shows collections:
   - Inspired by your Immaculate Taste (long term collection)
-  - Based on your recently watched (refreshes on every watch)
-  - Change of Taste (refreshes on every watch)
+  - Based on your recently watched (auto-refreshes for newly completed movies/episodes)
+  - Change of Taste (auto-refreshes for newly completed movies/episodes)
 - Recommendation engine:
   - TMDB-powered suggestions
   - Optional - Google + OpenAI

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "2028",
+  "message": "2032",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "2050",
+  "message": "2052",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "2034",
+  "message": "2036",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "2044",
+  "message": "2046",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "2048",
+  "message": "2050",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "2024",
+  "message": "2028",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "2032",
+  "message": "2034",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "2040",
+  "message": "2044",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "2056",
+  "message": "2060",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "2052",
+  "message": "2056",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "2046",
+  "message": "2048",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "2036",
+  "message": "2040",
   "color": "blue"
 }

--- a/scripts/test-publish-workflow.mjs
+++ b/scripts/test-publish-workflow.mjs
@@ -120,7 +120,19 @@ const requiredSnippets = [
   },
   {
     name: 'release notes include full changelog link',
-    snippet: '**Full Changelog**:',
+    snippet: 'Full Changelog:',
+  },
+  {
+    name: 'release notes include NAS/Unraid update note',
+    snippet: 'If you are running NAS or Unraid please check their specific documentation for update',
+  },
+  {
+    name: 'release notes include NAS link',
+    snippet: '[NAS](https://github.com/ohmzi/Immaculaterr/blob/master/doc/setup-truenas.md)',
+  },
+  {
+    name: 'release notes include Unraid link',
+    snippet: '[Unraid](https://github.com/ohmzi/Immaculaterr/blob/master/doc/setup-unraid.md)',
   },
   {
     name: 'release notes fallback to PR title when feature lines are unavailable',
@@ -135,8 +147,8 @@ const requiredSnippets = [
     snippet: '### Docker',
   },
   {
-    name: 'release notes include required HTTP-only label',
-    snippet: 'HTTP-only update (required)',
+    name: 'release notes include https-with-sidecar label',
+    snippet: 'HTTPS update which includes sidecar',
   },
   {
     name: 'release notes include ghcr latest image variable',
@@ -163,8 +175,8 @@ const requiredSnippets = [
     snippet: '-e TRUST_PROXY=1 \\',
   },
   {
-    name: 'release notes include optional HTTPS sidecar label',
-    snippet: 'Optional HTTPS sidecar (can run anytime later)',
+    name: 'release notes include http-only label',
+    snippet: 'HTTP-only update',
   },
   {
     name: 'release notes include sidecar container name',
@@ -209,7 +221,7 @@ const requiredSnippets = [
   },
   {
     name: 'release notes include portainer recreate flow',
-    snippet: '1. In Portainer: **Containers** → select **Immaculaterr**',
+    snippet: '1. In Portainer: **Containers** -> select **Immaculaterr**',
   },
 ];
 


### PR DESCRIPTION
## What changed

- adds the Rotten Tomatoes upcoming movies task and related job wiring
- implements durable repeat-watch deduplication and auto-run media history support for Plex-driven runs
- hardens the April 2026 migration repair path so existing SQLite installs can recover cleanly when migration artifacts already exist
- bumps the app version to `1.7.7-beta-1`
- updates release-note templates and generated release-note workflow content so Docker update instructions stay consistent

## Why

- upcoming movie discovery and repeat-watch handling extend scheduled automation without breaking existing job flows
- the migration repair changes address upgrade failures on existing installs where tables or indexes may already be present
- the release-note updates keep future `develop -> master` release PRs aligned with the intended HTTPS-first Docker update path

## Impact

- backend job scheduling and webhook/polling flows gain the new task and more durable history handling
- existing Docker/SQLite users should have a safer upgrade path through the repaired migrations
- future release notes should present clearer update instructions for Docker, HTTPS sidecar, NAS, and Unraid users

## Validation

- `npm run test`
- `npm run security:ci`
- `docker build -f docker/immaculaterr/Dockerfile .`
- `npm -w apps/web run build`
- `npm -w apps/web exec eslint -- src/pages/SetupPage.tsx`
- `node scripts/test-publish-workflow.mjs`

## Root cause for the upgrade fix

The failing upgrades came from migration steps that assumed the April 2026 tables and indexes were always absent. On existing SQLite installs, that assumption could be false, which caused migration and repair failures during update. The repair script and migration SQL now handle those pre-existing artifacts safely.
