### PR TITLE
Release 1.7.7 to master

### DIFF
--- a/apps/api/src/app.constants.ts
+++ b/apps/api/src/app.constants.ts
@@ -84,7 +84,7 @@ export const COLLECTION_RECENT_RELEASE_MONTHS = 3;
 export const PLEX_OAUTH_POLL_HEADER_VALUE = '1';
 
 /** Maximum time a job run may stay in RUNNING before the watchdog marks it FAILED. */
-export const JOB_RUN_TIMEOUT_MS = 30 * 60_000;
+export const JOB_RUN_TIMEOUT_MS = 60 * 60_000;
 
 /** Minimum delay between consecutive job executions to avoid hammering external APIs. */
 export const QUEUE_COOLDOWN_MS = 60_000;

--- a/apps/api/src/version.ts
+++ b/apps/api/src/version.ts
@@ -1,6 +1,6 @@
 // Single source of truth for the app version.
 // Bump this constant only.
 
-export const APP_VERSION = '1.7.7-beta-3' as const;
+export const APP_VERSION = '1.7.7' as const;
 
 export const APP_VERSION_TAG = `v${APP_VERSION}` as const;

--- a/apps/web/src/lib/version-history.ts
+++ b/apps/web/src/lib/version-history.ts
@@ -37,12 +37,13 @@ export function splitVersionHistoryLabel(
 
 export const VERSION_HISTORY_ENTRIES: VersionHistoryEntry[] = [
   {
-    version: '1.7.7-beta-3',
+    version: '1.7.7',
     popupHighlights: [
-      'This beta combines the earlier beta-2 work into one beta-3 release.',
+      'This release rolls the earlier 1.7.7 prerelease work into the final 1.7.7 update.',
       'Recommendations now use a smarter ranking engine with wildcard picks for global-language standouts and hidden gems.',
       'Netflix CSV imports are more reliable on larger uploads and now show friendlier timeout errors.',
-      'Rotten Tomatoes Upcoming Movies and repeat-watch dedupe for Plex auto-runs are both included in this beta.',
+      'Fresh Out Of The Oven now supports TV premieres, not just movies.',
+      'Rotten Tomatoes Upcoming Movies and repeat-watch dedupe for Plex auto-runs are both included in 1.7.7.',
     ],
     sections: [
       {
@@ -59,6 +60,12 @@ export const VERSION_HISTORY_ENTRIES: VersionHistoryEntry[] = [
           'Batches Netflix CSV persistence before queueing follow-up processing so larger imports stop hammering SQLite one row at a time.',
           'Keeps duplicate detection intact while falling back safely if a concurrent insert races the batch write.',
           'Shows a friendlier import error instead of raw proxy HTML when an upstream timeout page is returned.',
+        ],
+      },
+      {
+        title: 'Fresh Out Of The Oven',
+        bullets: [
+          'Fresh Out Of The Oven now supports TV premieres, not just movies.',
         ],
       },
       {

--- a/apps/web/src/lib/version-history.ts
+++ b/apps/web/src/lib/version-history.ts
@@ -39,11 +39,10 @@ export const VERSION_HISTORY_ENTRIES: VersionHistoryEntry[] = [
   {
     version: '1.7.7',
     popupHighlights: [
-      'This release rolls the earlier 1.7.7 prerelease work into the final 1.7.7 update.',
       'Recommendations now use a smarter ranking engine with wildcard picks for global-language standouts and hidden gems.',
       'Netflix CSV imports are more reliable on larger uploads and now show friendlier timeout errors.',
       'Fresh Out Of The Oven now supports TV premieres, not just movies.',
-      'Rotten Tomatoes Upcoming Movies and repeat-watch dedupe for Plex auto-runs are both included in 1.7.7.',
+      'Rotten Tomatoes Upcoming Movies and repeat-watch dedupe for Plex auto-runs are both included.',
     ],
     sections: [
       {

--- a/doc/Version_History.md
+++ b/doc/Version_History.md
@@ -3,10 +3,10 @@ Version History
 
 This file tracks notable changes by version.
 
-1.7.7-beta-3
+1.7.7
 ---
 
-- What's new in this combined beta 3 release:
+- What's new in 1.7.7:
 - Smarter recommendations:
   - Replaced the older heuristic scoring with a multi-factor ranking engine that balances similarity, quality, novelty, and indie or popularity signals.
   - Added a wildcard lane for global-language standouts and hidden gems, then mixed those picks into the main set without overwhelming the core recommendations.
@@ -15,6 +15,8 @@ This file tracks notable changes by version.
   - Batches Netflix CSV persistence before queueing follow-up processing so larger imports stop hammering SQLite one row at a time.
   - Preserves duplicate detection while falling back safely if a concurrent insert races the batch write.
   - Returns a friendlier import error in the UI instead of surfacing raw proxy HTML when an upstream timeout page is encountered.
+- Fresh Out Of The Oven:
+  - Fresh Out Of The Oven now supports TV premieres, not just movies.
 - Rotten Tomatoes Upcoming Movies:
   - Adds a new Task Manager job that scrapes fixed Rotten Tomatoes upcoming and newest movie pages.
   - Deduplicates discovered titles, applies conservative title-and-year matching, and only routes safe matches onward.

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "3167",
+  "message": "3169",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "2109",
+  "message": "2110",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "3149",
+  "message": "3150",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "2110",
+  "message": "2111",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "2104",
+  "message": "2105",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "2095",
+  "message": "2096",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "3150",
+  "message": "3153",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "2103",
+  "message": "2104",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "3155",
+  "message": "3159",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "3159",
+  "message": "3160",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "3169",
+  "message": "3172",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "2108",
+  "message": "2109",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "2100",
+  "message": "2101",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "3160",
+  "message": "3162",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "3164",
+  "message": "3165",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "3153",
+  "message": "3154",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "2096",
+  "message": "2099",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "2107",
+  "message": "2108",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "2105",
+  "message": "2107",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "3162",
+  "message": "3164",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "2099",
+  "message": "2100",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "2092",
+  "message": "2094",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "3154",
+  "message": "3155",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "2111",
+  "message": "3148",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "3148",
+  "message": "3149",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "2091",
+  "message": "2092",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "2094",
+  "message": "2095",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "3165",
+  "message": "3167",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "2101",
+  "message": "2103",
   "color": "blue"
 }


### PR DESCRIPTION
## Summary
- release the current `develop` branch to `master`
- promote version metadata from `1.7.7-beta-3` to stable `1.7.7`
- refresh Version History and in-app What's New copy, including Fresh Out Of The Oven TV premiere support and cleaned-up release-note messaging
- carry the current 60-minute API job watchdog timeout and the latest GHCR badge metadata that are already on `develop`

## Validation
- `npm run security:ci`
- refreshed the local `Immaculaterr` Docker container from the validated build and verified `http://127.0.0.1:5454/api/meta` returns `1.7.7`
