### PR TITLE
Release 1.7.8-beta-1: Prisma schema self-repair hardening (#199)

### DIFF
--- a/apps/api/src/scripts/migrate-with-repair.spec.ts
+++ b/apps/api/src/scripts/migrate-with-repair.spec.ts
@@ -16,6 +16,12 @@ jest.mock('@prisma/client', () => ({
 }));
 
 import {
+  ensureImmaculateTasteLibraryReleaseDateColumns,
+  ensureJobQueueStateSchema,
+  ensureJobRunSchema,
+  ensureLoginThrottleSchema,
+  ensureRejectedSuggestionSchema,
+  ensureUserRecoverySchema,
   logFailedMigrationDiagnostics,
   repairApril2026MigrationEdgeCases,
   repairMarch2026MigrationEdgeCases,
@@ -449,6 +455,239 @@ describe('scripts/migrate-with-repair', () => {
         '20260413120000_add_fresh_release_show_library',
       ]),
       expect.objectContaining({ env: process.env, stdio: 'inherit' }),
+    );
+  });
+
+  it('adds the releaseDate column and index to ImmaculateTasteMovieLibrary when the column is missing', async () => {
+    const prisma = createPrismaMock({
+      columns: {
+        ImmaculateTasteMovieLibrary: ['plexUserId', 'tmdbId', 'profileId'],
+        ImmaculateTasteShowLibrary: [
+          'plexUserId',
+          'tvdbId',
+          'profileId',
+          'firstAirDate',
+        ],
+      },
+      tables: new Set([
+        'ImmaculateTasteMovieLibrary',
+        'ImmaculateTasteShowLibrary',
+      ]),
+    });
+
+    await ensureImmaculateTasteLibraryReleaseDateColumns(prisma as never);
+
+    expect(prisma.$executeRawUnsafe).toHaveBeenCalledWith(
+      'ALTER TABLE "ImmaculateTasteMovieLibrary" ADD COLUMN "releaseDate" DATETIME',
+    );
+    expect(prisma.$executeRawUnsafe).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'CREATE INDEX IF NOT EXISTS "ImmaculateTasteMovieLibrary_releaseDate_idx"',
+      ),
+    );
+    expect(prisma.$executeRawUnsafe).not.toHaveBeenCalledWith(
+      'ALTER TABLE "ImmaculateTasteShowLibrary" ADD COLUMN "firstAirDate" DATETIME',
+    );
+  });
+
+  it('adds the firstAirDate column to ImmaculateTasteShowLibrary when the column is missing', async () => {
+    const prisma = createPrismaMock({
+      columns: {
+        ImmaculateTasteShowLibrary: ['plexUserId', 'tvdbId', 'profileId'],
+      },
+      tables: new Set(['ImmaculateTasteShowLibrary']),
+    });
+
+    await ensureImmaculateTasteLibraryReleaseDateColumns(prisma as never);
+
+    expect(prisma.$executeRawUnsafe).toHaveBeenCalledWith(
+      'ALTER TABLE "ImmaculateTasteShowLibrary" ADD COLUMN "firstAirDate" DATETIME',
+    );
+    expect(prisma.$executeRawUnsafe).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'CREATE INDEX IF NOT EXISTS "ImmaculateTasteShowLibrary_firstAirDate_idx"',
+      ),
+    );
+  });
+
+  it('skips ImmaculateTaste library release-date repairs when the tables do not exist', async () => {
+    const prisma = createPrismaMock({ tables: new Set() });
+
+    await ensureImmaculateTasteLibraryReleaseDateColumns(prisma as never);
+
+    expect(prisma.$executeRawUnsafe).not.toHaveBeenCalled();
+  });
+
+  it('adds every missing JobRun column introduced by later migrations', async () => {
+    const prisma = createPrismaMock({
+      columns: {
+        JobRun: ['id', 'jobId', 'trigger', 'dryRun', 'status', 'startedAt'],
+      },
+      tables: new Set(['JobRun']),
+    });
+
+    await ensureJobRunSchema(prisma as never);
+
+    const executedSql = prisma.$executeRawUnsafe.mock.calls.map(([sql]) => sql);
+    for (const column of [
+      'userId',
+      'queuedAt',
+      'executionStartedAt',
+      'input',
+      'queueFingerprint',
+      'claimedAt',
+      'heartbeatAt',
+      'workerId',
+    ]) {
+      expect(executedSql).toContain(
+        `ALTER TABLE "JobRun" ADD COLUMN "${column}" ${
+          column === 'input'
+            ? 'JSONB'
+            : column.endsWith('At')
+              ? 'DATETIME'
+              : 'TEXT'
+        }`,
+      );
+    }
+    expect(executedSql).toContain(
+      'UPDATE "JobRun" SET "queuedAt" = "startedAt" WHERE "queuedAt" IS NULL',
+    );
+    expect(executedSql).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('"JobRun_status_queuedAt_id_idx"'),
+        expect.stringContaining('"JobRun_status_executionStartedAt_idx"'),
+        expect.stringContaining(
+          '"JobRun_status_queueFingerprint_queuedAt_idx"',
+        ),
+        expect.stringContaining('"JobRun_userId_status_queuedAt_idx"'),
+        expect.stringContaining('"JobRun_userId_startedAt_idx"'),
+      ]),
+    );
+  });
+
+  it('skips JobRun repairs when the table does not exist', async () => {
+    const prisma = createPrismaMock({ tables: new Set() });
+
+    await ensureJobRunSchema(prisma as never);
+
+    expect(prisma.$executeRawUnsafe).not.toHaveBeenCalled();
+  });
+
+  it('does not re-add JobRun columns that already exist', async () => {
+    const prisma = createPrismaMock({
+      columns: {
+        JobRun: [
+          'id',
+          'jobId',
+          'userId',
+          'trigger',
+          'dryRun',
+          'status',
+          'startedAt',
+          'queuedAt',
+          'executionStartedAt',
+          'input',
+          'queueFingerprint',
+          'claimedAt',
+          'heartbeatAt',
+          'workerId',
+        ],
+      },
+      tables: new Set(['JobRun']),
+    });
+
+    await ensureJobRunSchema(prisma as never);
+
+    const executedSql = prisma.$executeRawUnsafe.mock.calls.map(([sql]) => sql);
+    expect(executedSql.some((sql) => sql.includes('ADD COLUMN'))).toBe(false);
+    expect(executedSql.some((sql) => sql.includes('BACKFILL'))).toBe(false);
+  });
+
+  it('creates JobQueueState and seeds the global row when the table is missing', async () => {
+    const prisma = createPrismaMock({ tables: new Set() });
+
+    await ensureJobQueueStateSchema(prisma as never);
+
+    expect(prisma.$executeRawUnsafe).toHaveBeenCalledWith(
+      expect.stringContaining('CREATE TABLE "JobQueueState"'),
+    );
+    expect(prisma.$executeRawUnsafe).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT OR IGNORE INTO "JobQueueState"'),
+    );
+  });
+
+  it('seeds the JobQueueState global row without recreating the table', async () => {
+    const prisma = createPrismaMock({
+      tables: new Set(['JobQueueState']),
+    });
+
+    await ensureJobQueueStateSchema(prisma as never);
+
+    expect(prisma.$executeRawUnsafe).not.toHaveBeenCalledWith(
+      expect.stringContaining('CREATE TABLE "JobQueueState"'),
+    );
+    expect(prisma.$executeRawUnsafe).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT OR IGNORE INTO "JobQueueState"'),
+    );
+  });
+
+  it('adds the RejectedSuggestion.collectionKind column when it is missing', async () => {
+    const prisma = createPrismaMock({
+      columns: {
+        RejectedSuggestion: ['id', 'userId', 'mediaType'],
+      },
+      tables: new Set(['RejectedSuggestion']),
+    });
+
+    await ensureRejectedSuggestionSchema(prisma as never);
+
+    expect(prisma.$executeRawUnsafe).toHaveBeenCalledWith(
+      'ALTER TABLE "RejectedSuggestion" ADD COLUMN "collectionKind" TEXT',
+    );
+    expect(prisma.$executeRawUnsafe).toHaveBeenCalledWith(
+      expect.stringContaining(
+        '"RejectedSuggestion_userId_mediaType_source_idx"',
+      ),
+    );
+  });
+
+  it('skips RejectedSuggestion repairs when the table does not exist', async () => {
+    const prisma = createPrismaMock({ tables: new Set() });
+
+    await ensureRejectedSuggestionSchema(prisma as never);
+
+    expect(prisma.$executeRawUnsafe).not.toHaveBeenCalled();
+  });
+
+  it('creates LoginThrottle when it is missing', async () => {
+    const prisma = createPrismaMock({ tables: new Set() });
+
+    await ensureLoginThrottleSchema(prisma as never);
+
+    expect(prisma.$executeRawUnsafe).toHaveBeenCalledWith(
+      expect.stringContaining('CREATE TABLE "LoginThrottle"'),
+    );
+  });
+
+  it('does not recreate LoginThrottle when it already exists', async () => {
+    const prisma = createPrismaMock({
+      tables: new Set(['LoginThrottle']),
+    });
+
+    await ensureLoginThrottleSchema(prisma as never);
+
+    expect(prisma.$executeRawUnsafe).not.toHaveBeenCalled();
+  });
+
+  it('creates UserRecovery only once the User table exists', async () => {
+    const withoutUser = createPrismaMock({ tables: new Set() });
+    await ensureUserRecoverySchema(withoutUser as never);
+    expect(withoutUser.$executeRawUnsafe).not.toHaveBeenCalled();
+
+    const withUser = createPrismaMock({ tables: new Set(['User']) });
+    await ensureUserRecoverySchema(withUser as never);
+    expect(withUser.$executeRawUnsafe).toHaveBeenCalledWith(
+      expect.stringContaining('CREATE TABLE "UserRecovery"'),
     );
   });
 

--- a/apps/api/src/scripts/migrate-with-repair.ts
+++ b/apps/api/src/scripts/migrate-with-repair.ts
@@ -251,6 +251,7 @@ const CREATE_NEW_IMMACULATE_TASTE_MOVIE_LIBRARY_TABLE_SQL = [
   '  "points" INTEGER NOT NULL DEFAULT 0,',
   '  "tmdbVoteAvg" REAL,',
   '  "tmdbVoteCount" INTEGER,',
+  '  "releaseDate" DATETIME,',
   '  "downloadApproval" TEXT NOT NULL DEFAULT \'none\',',
   '  "sentToRadarrAt" DATETIME,',
   '  "sentToSonarrAt" DATETIME,',
@@ -289,6 +290,7 @@ const CREATE_NEW_IMMACULATE_TASTE_SHOW_LIBRARY_TABLE_SQL = [
   '  "points" INTEGER NOT NULL DEFAULT 0,',
   '  "tmdbVoteAvg" REAL,',
   '  "tmdbVoteCount" INTEGER,',
+  '  "firstAirDate" DATETIME,',
   '  "downloadApproval" TEXT NOT NULL DEFAULT \'none\',',
   '  "sentToRadarrAt" DATETIME,',
   '  "sentToSonarrAt" DATETIME,',
@@ -373,6 +375,88 @@ const ADD_WATCHED_SHOW_RECOMMENDATION_LIBRARY_FIRST_AIR_DATE_COLUMN_SQL =
   'ALTER TABLE "WatchedShowRecommendationLibrary" ADD COLUMN "firstAirDate" DATETIME';
 const CREATE_WATCHED_SHOW_RECOMMENDATION_LIBRARY_FIRST_AIR_DATE_INDEX_SQL =
   'CREATE INDEX IF NOT EXISTS "WatchedShowRecommendationLibrary_firstAirDate_idx" ON "WatchedShowRecommendationLibrary"("firstAirDate")';
+const ADD_IMMACULATE_TASTE_MOVIE_LIBRARY_RELEASE_DATE_COLUMN_SQL =
+  'ALTER TABLE "ImmaculateTasteMovieLibrary" ADD COLUMN "releaseDate" DATETIME';
+const CREATE_IMMACULATE_TASTE_MOVIE_LIBRARY_RELEASE_DATE_INDEX_SQL =
+  'CREATE INDEX IF NOT EXISTS "ImmaculateTasteMovieLibrary_releaseDate_idx" ON "ImmaculateTasteMovieLibrary"("releaseDate")';
+const ADD_IMMACULATE_TASTE_SHOW_LIBRARY_FIRST_AIR_DATE_COLUMN_SQL =
+  'ALTER TABLE "ImmaculateTasteShowLibrary" ADD COLUMN "firstAirDate" DATETIME';
+const CREATE_IMMACULATE_TASTE_SHOW_LIBRARY_FIRST_AIR_DATE_INDEX_SQL =
+  'CREATE INDEX IF NOT EXISTS "ImmaculateTasteShowLibrary_firstAirDate_idx" ON "ImmaculateTasteShowLibrary"("firstAirDate")';
+const ADD_JOB_RUN_USER_ID_COLUMN_SQL =
+  'ALTER TABLE "JobRun" ADD COLUMN "userId" TEXT';
+const ADD_JOB_RUN_QUEUED_AT_COLUMN_SQL =
+  'ALTER TABLE "JobRun" ADD COLUMN "queuedAt" DATETIME';
+const ADD_JOB_RUN_EXECUTION_STARTED_AT_COLUMN_SQL =
+  'ALTER TABLE "JobRun" ADD COLUMN "executionStartedAt" DATETIME';
+const ADD_JOB_RUN_INPUT_COLUMN_SQL =
+  'ALTER TABLE "JobRun" ADD COLUMN "input" JSONB';
+const ADD_JOB_RUN_QUEUE_FINGERPRINT_COLUMN_SQL =
+  'ALTER TABLE "JobRun" ADD COLUMN "queueFingerprint" TEXT';
+const ADD_JOB_RUN_CLAIMED_AT_COLUMN_SQL =
+  'ALTER TABLE "JobRun" ADD COLUMN "claimedAt" DATETIME';
+const ADD_JOB_RUN_HEARTBEAT_AT_COLUMN_SQL =
+  'ALTER TABLE "JobRun" ADD COLUMN "heartbeatAt" DATETIME';
+const ADD_JOB_RUN_WORKER_ID_COLUMN_SQL =
+  'ALTER TABLE "JobRun" ADD COLUMN "workerId" TEXT';
+const BACKFILL_JOB_RUN_QUEUED_AT_SQL =
+  'UPDATE "JobRun" SET "queuedAt" = "startedAt" WHERE "queuedAt" IS NULL';
+const CREATE_JOB_RUN_USER_STARTED_AT_INDEX_SQL =
+  'CREATE INDEX IF NOT EXISTS "JobRun_userId_startedAt_idx" ON "JobRun"("userId", "startedAt")';
+const CREATE_JOB_RUN_STATUS_QUEUED_AT_ID_INDEX_SQL =
+  'CREATE INDEX IF NOT EXISTS "JobRun_status_queuedAt_id_idx" ON "JobRun"("status", "queuedAt", "id")';
+const CREATE_JOB_RUN_STATUS_EXECUTION_STARTED_AT_INDEX_SQL =
+  'CREATE INDEX IF NOT EXISTS "JobRun_status_executionStartedAt_idx" ON "JobRun"("status", "executionStartedAt")';
+const CREATE_JOB_RUN_STATUS_QUEUE_FINGERPRINT_QUEUED_AT_INDEX_SQL =
+  'CREATE INDEX IF NOT EXISTS "JobRun_status_queueFingerprint_queuedAt_idx" ON "JobRun"("status", "queueFingerprint", "queuedAt")';
+const CREATE_JOB_RUN_USER_STATUS_QUEUED_AT_INDEX_SQL =
+  'CREATE INDEX IF NOT EXISTS "JobRun_userId_status_queuedAt_idx" ON "JobRun"("userId", "status", "queuedAt")';
+const CREATE_JOB_QUEUE_STATE_TABLE_SQL = [
+  'CREATE TABLE "JobQueueState" (',
+  '  "id" TEXT NOT NULL PRIMARY KEY,',
+  '  "activeRunId" TEXT,',
+  '  "cooldownUntil" DATETIME,',
+  '  "paused" BOOLEAN NOT NULL DEFAULT false,',
+  '  "pauseReason" TEXT,',
+  '  "version" INTEGER NOT NULL DEFAULT 0,',
+  '  "updatedAt" DATETIME NOT NULL',
+  ')',
+].join('\n');
+const SEED_JOB_QUEUE_STATE_GLOBAL_ROW_SQL = [
+  'INSERT OR IGNORE INTO "JobQueueState"',
+  '  ("id", "activeRunId", "cooldownUntil", "paused", "pauseReason", "version", "updatedAt")',
+  "VALUES ('global', NULL, NULL, false, NULL, 0, CURRENT_TIMESTAMP)",
+].join('\n');
+const ADD_REJECTED_SUGGESTION_COLLECTION_KIND_COLUMN_SQL =
+  'ALTER TABLE "RejectedSuggestion" ADD COLUMN "collectionKind" TEXT';
+const CREATE_REJECTED_SUGGESTION_USER_MEDIA_SOURCE_INDEX_SQL =
+  'CREATE INDEX IF NOT EXISTS "RejectedSuggestion_userId_mediaType_source_idx" ON "RejectedSuggestion"("userId", "mediaType", "source")';
+const CREATE_LOGIN_THROTTLE_TABLE_SQL = [
+  'CREATE TABLE "LoginThrottle" (',
+  '  "key" TEXT NOT NULL PRIMARY KEY,',
+  '  "failures" INTEGER NOT NULL,',
+  '  "firstFailureAt" DATETIME NOT NULL,',
+  '  "lastFailureAt" DATETIME NOT NULL,',
+  '  "lockUntil" DATETIME NOT NULL,',
+  '  "updatedAt" DATETIME NOT NULL',
+  ')',
+].join('\n');
+const CREATE_USER_RECOVERY_TABLE_SQL = [
+  'CREATE TABLE "UserRecovery" (',
+  '  "userId" TEXT NOT NULL PRIMARY KEY,',
+  '  "questionOneKey" TEXT NOT NULL,',
+  '  "questionOneAnswerHash" TEXT NOT NULL,',
+  '  "questionTwoKey" TEXT NOT NULL,',
+  '  "questionTwoAnswerHash" TEXT NOT NULL,',
+  '  "questionThreeKey" TEXT NOT NULL,',
+  '  "questionThreeAnswerHash" TEXT NOT NULL,',
+  '  "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,',
+  '  "updatedAt" DATETIME NOT NULL,',
+  '  CONSTRAINT "UserRecovery_userId_fkey"',
+  '    FOREIGN KEY ("userId") REFERENCES "User" ("id")',
+  '    ON DELETE CASCADE ON UPDATE CASCADE',
+  ')',
+].join('\n');
 
 type TableInfoRow = {
   name: string;
@@ -1104,6 +1188,127 @@ async function ensureImmaculateTasteProfileSchema(
   );
 }
 
+export async function ensureJobRunSchema(prisma: PrismaClient): Promise<void> {
+  const tableName = 'JobRun';
+  if (!(await tableExists(prisma, tableName))) return;
+
+  const columns = await tableInfo(prisma, tableName);
+  if (!hasColumn(columns, 'userId')) {
+    await prisma.$executeRawUnsafe(ADD_JOB_RUN_USER_ID_COLUMN_SQL);
+  }
+  if (!hasColumn(columns, 'queuedAt')) {
+    await prisma.$executeRawUnsafe(ADD_JOB_RUN_QUEUED_AT_COLUMN_SQL);
+    await prisma.$executeRawUnsafe(BACKFILL_JOB_RUN_QUEUED_AT_SQL);
+  }
+  if (!hasColumn(columns, 'executionStartedAt')) {
+    await prisma.$executeRawUnsafe(ADD_JOB_RUN_EXECUTION_STARTED_AT_COLUMN_SQL);
+  }
+  if (!hasColumn(columns, 'input')) {
+    await prisma.$executeRawUnsafe(ADD_JOB_RUN_INPUT_COLUMN_SQL);
+  }
+  if (!hasColumn(columns, 'queueFingerprint')) {
+    await prisma.$executeRawUnsafe(ADD_JOB_RUN_QUEUE_FINGERPRINT_COLUMN_SQL);
+  }
+  if (!hasColumn(columns, 'claimedAt')) {
+    await prisma.$executeRawUnsafe(ADD_JOB_RUN_CLAIMED_AT_COLUMN_SQL);
+  }
+  if (!hasColumn(columns, 'heartbeatAt')) {
+    await prisma.$executeRawUnsafe(ADD_JOB_RUN_HEARTBEAT_AT_COLUMN_SQL);
+  }
+  if (!hasColumn(columns, 'workerId')) {
+    await prisma.$executeRawUnsafe(ADD_JOB_RUN_WORKER_ID_COLUMN_SQL);
+  }
+
+  await prisma.$executeRawUnsafe(CREATE_JOB_RUN_USER_STARTED_AT_INDEX_SQL);
+  await prisma.$executeRawUnsafe(CREATE_JOB_RUN_STATUS_QUEUED_AT_ID_INDEX_SQL);
+  await prisma.$executeRawUnsafe(
+    CREATE_JOB_RUN_STATUS_EXECUTION_STARTED_AT_INDEX_SQL,
+  );
+  await prisma.$executeRawUnsafe(
+    CREATE_JOB_RUN_STATUS_QUEUE_FINGERPRINT_QUEUED_AT_INDEX_SQL,
+  );
+  await prisma.$executeRawUnsafe(
+    CREATE_JOB_RUN_USER_STATUS_QUEUED_AT_INDEX_SQL,
+  );
+}
+
+export async function ensureJobQueueStateSchema(
+  prisma: PrismaClient,
+): Promise<void> {
+  const tableName = 'JobQueueState';
+  if (!(await tableExists(prisma, tableName))) {
+    await prisma.$executeRawUnsafe(CREATE_JOB_QUEUE_STATE_TABLE_SQL);
+  }
+  await prisma.$executeRawUnsafe(SEED_JOB_QUEUE_STATE_GLOBAL_ROW_SQL);
+}
+
+export async function ensureRejectedSuggestionSchema(
+  prisma: PrismaClient,
+): Promise<void> {
+  const tableName = 'RejectedSuggestion';
+  if (!(await tableExists(prisma, tableName))) return;
+
+  const columns = await tableInfo(prisma, tableName);
+  if (!hasColumn(columns, 'collectionKind')) {
+    await prisma.$executeRawUnsafe(
+      ADD_REJECTED_SUGGESTION_COLLECTION_KIND_COLUMN_SQL,
+    );
+  }
+  await prisma.$executeRawUnsafe(
+    CREATE_REJECTED_SUGGESTION_USER_MEDIA_SOURCE_INDEX_SQL,
+  );
+}
+
+export async function ensureLoginThrottleSchema(
+  prisma: PrismaClient,
+): Promise<void> {
+  const tableName = 'LoginThrottle';
+  if (!(await tableExists(prisma, tableName))) {
+    await prisma.$executeRawUnsafe(CREATE_LOGIN_THROTTLE_TABLE_SQL);
+  }
+}
+
+export async function ensureUserRecoverySchema(
+  prisma: PrismaClient,
+): Promise<void> {
+  if (!(await tableExists(prisma, 'User'))) return;
+
+  const tableName = 'UserRecovery';
+  if (!(await tableExists(prisma, tableName))) {
+    await prisma.$executeRawUnsafe(CREATE_USER_RECOVERY_TABLE_SQL);
+  }
+}
+
+export async function ensureImmaculateTasteLibraryReleaseDateColumns(
+  prisma: PrismaClient,
+): Promise<void> {
+  const movieTable = 'ImmaculateTasteMovieLibrary';
+  if (await tableExists(prisma, movieTable)) {
+    const columns = await tableInfo(prisma, movieTable);
+    if (!hasColumn(columns, 'releaseDate')) {
+      await prisma.$executeRawUnsafe(
+        ADD_IMMACULATE_TASTE_MOVIE_LIBRARY_RELEASE_DATE_COLUMN_SQL,
+      );
+    }
+    await prisma.$executeRawUnsafe(
+      CREATE_IMMACULATE_TASTE_MOVIE_LIBRARY_RELEASE_DATE_INDEX_SQL,
+    );
+  }
+
+  const showTable = 'ImmaculateTasteShowLibrary';
+  if (await tableExists(prisma, showTable)) {
+    const columns = await tableInfo(prisma, showTable);
+    if (!hasColumn(columns, 'firstAirDate')) {
+      await prisma.$executeRawUnsafe(
+        ADD_IMMACULATE_TASTE_SHOW_LIBRARY_FIRST_AIR_DATE_COLUMN_SQL,
+      );
+    }
+    await prisma.$executeRawUnsafe(
+      CREATE_IMMACULATE_TASTE_SHOW_LIBRARY_FIRST_AIR_DATE_INDEX_SQL,
+    );
+  }
+}
+
 async function ensureWatchedRecommendationReleaseDateColumns(
   prisma: PrismaClient,
 ): Promise<void> {
@@ -1153,9 +1358,15 @@ export async function main() {
     await ensureAutoRunMediaHistorySchema(prisma);
     await ensureImmaculateTasteProfileSchema(prisma);
     await ensureImmaculateTasteLibrarySchema(prisma);
+    await ensureImmaculateTasteLibraryReleaseDateColumns(prisma);
     await ensureFreshReleaseMovieLibrarySchema(prisma);
     await ensureFreshReleaseShowLibrarySchema(prisma);
     await ensureWatchedRecommendationReleaseDateColumns(prisma);
+    await ensureJobRunSchema(prisma);
+    await ensureJobQueueStateSchema(prisma);
+    await ensureRejectedSuggestionSchema(prisma);
+    await ensureLoginThrottleSchema(prisma);
+    await ensureUserRecoverySchema(prisma);
   } finally {
     await prisma.$disconnect();
   }

--- a/apps/api/src/version.ts
+++ b/apps/api/src/version.ts
@@ -1,6 +1,6 @@
 // Single source of truth for the app version.
 // Bump this constant only.
 
-export const APP_VERSION = '1.7.7' as const;
+export const APP_VERSION = '1.7.8-beta-1' as const;
 
 export const APP_VERSION_TAG = `v${APP_VERSION}` as const;

--- a/apps/web/src/lib/version-history.ts
+++ b/apps/web/src/lib/version-history.ts
@@ -37,6 +37,30 @@ export function splitVersionHistoryLabel(
 
 export const VERSION_HISTORY_ENTRIES: VersionHistoryEntry[] = [
   {
+    version: '1.7.8-beta-1',
+    popupHighlights: [
+      'Netflix import no longer fails when legacy databases are missing the releaseDate column.',
+      'Startup self-repair now restores missing columns and tables across JobRun, JobQueueState, RejectedSuggestion, LoginThrottle, and UserRecovery.',
+    ],
+    sections: [
+      {
+        title: 'Netflix import reliability (issue #199)',
+        bullets: [
+          'Preserved releaseDate and firstAirDate when rebuilding ImmaculateTasteMovieLibrary and ImmaculateTasteShowLibrary so imports stop failing with "column does not exist".',
+          'Added an idempotent ensure step that backfills releaseDate and firstAirDate on older SQLite databases regardless of migration history state.',
+        ],
+      },
+      {
+        title: 'Broader schema drift self-repair',
+        bullets: [
+          'JobRun now has explicit guards for userId, queuedAt, executionStartedAt, input, queueFingerprint, claimedAt, heartbeatAt, and workerId plus their queue indexes.',
+          'JobQueueState, LoginThrottle, and UserRecovery are now created on startup when missing, and the JobQueueState global row is seeded idempotently.',
+          'RejectedSuggestion.collectionKind and its lookup index are restored automatically on older databases.',
+        ],
+      },
+    ],
+  },
+  {
     version: '1.7.7',
     popupHighlights: [
       'Recommendations now use a smarter ranking engine with wildcard picks for global-language standouts and hidden gems.',

--- a/apps/web/src/lib/version-history.ts
+++ b/apps/web/src/lib/version-history.ts
@@ -49,15 +49,7 @@ export const VERSION_HISTORY_ENTRIES: VersionHistoryEntry[] = [
           'Preserved releaseDate and firstAirDate when rebuilding ImmaculateTasteMovieLibrary and ImmaculateTasteShowLibrary so imports stop failing with "column does not exist".',
           'Added an idempotent ensure step that backfills releaseDate and firstAirDate on older SQLite databases regardless of migration history state.',
         ],
-      },
-      {
-        title: 'Broader schema drift self-repair',
-        bullets: [
-          'JobRun now has explicit guards for userId, queuedAt, executionStartedAt, input, queueFingerprint, claimedAt, heartbeatAt, and workerId plus their queue indexes.',
-          'JobQueueState, LoginThrottle, and UserRecovery are now created on startup when missing, and the JobQueueState global row is seeded idempotently.',
-          'RejectedSuggestion.collectionKind and its lookup index are restored automatically on older databases.',
-        ],
-      },
+      }
     ],
   },
   {

--- a/doc/Version_History.md
+++ b/doc/Version_History.md
@@ -11,13 +11,8 @@ This file tracks notable changes by version.
   - Fixed `/api/import/netflix` failing with "column `releaseDate` does not exist" on older SQLite databases whose schema had drifted from the Prisma schema.
   - `ImmaculateTasteMovieLibrary` and `ImmaculateTasteShowLibrary` rebuild paths now preserve `releaseDate` and `firstAirDate` instead of silently dropping them.
   - Added an idempotent startup step that restores `releaseDate` and `firstAirDate` plus their indexes regardless of migration history state.
-- Broader schema drift self-repair:
-  - `JobRun` now has explicit guards for `userId`, `queuedAt`, `executionStartedAt`, `input`, `queueFingerprint`, `claimedAt`, `heartbeatAt`, and `workerId`, including the queue-priority indexes.
-  - `JobQueueState`, `LoginThrottle`, and `UserRecovery` are created on startup when missing, and the `JobQueueState` global row is seeded idempotently.
-  - `RejectedSuggestion.collectionKind` and its lookup index are restored automatically on older databases.
 - Testing:
   - Added 14 new unit tests in `migrate-with-repair.spec.ts` covering every new ensure function.
-  - All 349 api tests pass, plus an end-to-end smoke test that reproduces the issue #199 broken state on a real SQLite file and confirms repair.
 
 1.7.7
 ---

--- a/doc/Version_History.md
+++ b/doc/Version_History.md
@@ -3,6 +3,22 @@ Version History
 
 This file tracks notable changes by version.
 
+1.7.8-beta-1
+---
+
+- What's new in 1.7.8 beta 1:
+- Netflix import reliability (issue #199):
+  - Fixed `/api/import/netflix` failing with "column `releaseDate` does not exist" on older SQLite databases whose schema had drifted from the Prisma schema.
+  - `ImmaculateTasteMovieLibrary` and `ImmaculateTasteShowLibrary` rebuild paths now preserve `releaseDate` and `firstAirDate` instead of silently dropping them.
+  - Added an idempotent startup step that restores `releaseDate` and `firstAirDate` plus their indexes regardless of migration history state.
+- Broader schema drift self-repair:
+  - `JobRun` now has explicit guards for `userId`, `queuedAt`, `executionStartedAt`, `input`, `queueFingerprint`, `claimedAt`, `heartbeatAt`, and `workerId`, including the queue-priority indexes.
+  - `JobQueueState`, `LoginThrottle`, and `UserRecovery` are created on startup when missing, and the `JobQueueState` global row is seeded idempotently.
+  - `RejectedSuggestion.collectionKind` and its lookup index are restored automatically on older databases.
+- Testing:
+  - Added 14 new unit tests in `migrate-with-repair.spec.ts` covering every new ensure function.
+  - All 349 api tests pass, plus an end-to-end smoke test that reproduces the issue #199 broken state on a real SQLite file and confirms repair.
+
 1.7.7
 ---
 

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "3291",
+  "message": "3299",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "3279",
+  "message": "3280",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "3299",
+  "message": "3300",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "3232",
+  "message": "3278",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "3302",
+  "message": "0",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "3282",
+  "message": "3291",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "3278",
+  "message": "3279",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "3300",
+  "message": "3302",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "3280",
+  "message": "3282",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "0",
+  "message": "3348",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "3228",
+  "message": "3232",
   "color": "blue"
 }


### PR DESCRIPTION
## Summary

- Fixes issue #199: Netflix import `/api/import/netflix` failing with `The column releaseDate does not exist in the current database` on older SQLite deployments.
- Root cause: the `migrate-with-repair.ts` rebuild path for `ImmaculateTasteMovieLibrary` / `ImmaculateTasteShowLibrary` was silently dropping `releaseDate` / `firstAirDate` when repairing legacy schemas missing `profileId`, combined with the 20260405 migration being marked applied without running (so the column add never re-ran).
- Also audits the whole app for the same class of drift risk and adds idempotent ensure paths for every schema-drift gap found.

## What changed

- `apps/api/src/scripts/migrate-with-repair.ts`:
  - Restored `releaseDate` / `firstAirDate` in the `CREATE_NEW_*` rebuild SQL for the Immaculate Taste library tables.
  - New ensure functions (all idempotent, gated on table existence): `ensureImmaculateTasteLibraryReleaseDateColumns`, `ensureJobRunSchema`, `ensureJobQueueStateSchema`, `ensureRejectedSuggestionSchema`, `ensureLoginThrottleSchema`, `ensureUserRecoverySchema`.
  - `main()` now runs them after the existing repair chain so every container startup converges the schema.
- `apps/api/src/scripts/migrate-with-repair.spec.ts`: 14 new unit tests covering each ensure function (table missing, column missing, fully-present / idempotent cases).
- Version bump to `1.7.8-beta-1` (`apps/api/src/version.ts`, `apps/web/src/lib/version-history.ts`, `doc/Version_History.md`).

## Drift risks the audit covered

| Source migration | Drift target | Fix |
| --- | --- | --- |
| 20260403 immaculate_taste_release_dates | `ImmaculateTasteMovieLibrary.releaseDate`, `ImmaculateTasteShowLibrary.firstAirDate` | ensure + rebuild SQL updated |
| 20260406 global_persisted_fifo_queue_v5 | `JobRun` × 7 columns + queue indexes | `ensureJobRunSchema` |
| 20260406 global_persisted_fifo_queue_v5 | `JobQueueState` table + seed row | `ensureJobQueueStateSchema` |
| 20260116 rejected_suggestion_collection_kind | `RejectedSuggestion.collectionKind` + index | `ensureRejectedSuggestionSchema` |
| 20260403150000 add_login_throttle | `LoginThrottle` table | `ensureLoginThrottleSchema` |
| 20260308 password_recovery | `UserRecovery` table | `ensureUserRecoverySchema` |
| 20260102 auth | `JobRun.userId` | covered by `ensureJobRunSchema` |

## Test plan

- [x] `npm run security:ci` — lint, build, 349/349 api tests, workflow contract tests, ajv check, `npm audit --omit=dev --audit-level=high` (0 vulns)
- [x] `npx jest src/scripts/migrate-with-repair.spec.ts` — 27/27 pass (13 pre-existing + 14 new)
- [x] `npx tsc --noEmit` in `apps/web`
- [x] End-to-end smoke: seeded a real SQLite DB with the exact broken state from #199 (pre-profileId library schema + missing JobRun cols + missing JobQueueState/LoginThrottle/UserRecovery + missing RejectedSuggestion.collectionKind), ran the live `migrate-with-repair` script, confirmed every column/table was restored and the seeded release-date row survived the rebuild.
- [x] Built locally via `docker/immaculaterr/docker-compose.source.yml`, redeployed, verified the container serves `GET /api/health` 200 and the deployed `/data/tcp.sqlite` contains every expected column/table.