### PR TITLE
Release 1.7.8-beta-5 to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@
 - **Includes discovery and maintenance jobs**
   - `Fresh Out Of The Oven` builds recent-release movie and TV rows for titles a user has not watched yet.
   - `TMDB Upcoming Movies` finds upcoming movies with filter sets and routes matches to Radarr or Seerr.
-  - `Rotten Tomatoes Upcoming Movies` scrapes fixed Rotten Tomatoes pages and routes safe matches to Radarr or Seerr.
+  - `Rotten Tomatoes Upcoming Movies` scrapes fixed Rotten Tomatoes movie and TV pages, uses a saved TV Top count, and routes through Radarr or Sonarr directly or through Seerr for both media types.
   - Cleanup and ARR sync jobs help keep Plex, Radarr, and Sonarr tidy after imports and downloads, including season-aware Sonarr monitoring cleanup.
 
 - **Supports history imports from day one**

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@
 - **Includes discovery and maintenance jobs**
   - `Fresh Out Of The Oven` builds recent-release movie and TV rows for titles a user has not watched yet.
   - `TMDB Upcoming Movies` finds upcoming movies with filter sets and routes matches to Radarr or Seerr.
-  - `Rotten Tomatoes Upcoming Movies` scrapes fixed Rotten Tomatoes movie and TV pages, uses a saved TV Top count, and routes through Radarr or Sonarr directly or through Seerr for both media types.
+  - `Rotten Tomatoes Upcoming Movies + TV Shows` scrapes fixed Rotten Tomatoes movie and TV pages, uses separate saved Movie Top 20 and TV Top 10 counts, and routes through Radarr or Sonarr directly or through Seerr for both media types.
   - Cleanup and ARR sync jobs help keep Plex, Radarr, and Sonarr tidy after imports and downloads, including season-aware Sonarr monitoring cleanup.
 
 - **Supports history imports from day one**

--- a/apps/api/src/jobs/job-registry.ts
+++ b/apps/api/src/jobs/job-registry.ts
@@ -274,7 +274,7 @@ export const JOB_DEFINITIONS: JobDefinitionInfo[] = [
     id: 'rottenTomatoesUpcomingMovies',
     name: 'Rotten Tomatoes Upcoming Movies',
     description:
-      'Scrapes fixed Rotten Tomatoes upcoming and newest movie pages, deduplicates safe matches, and routes them to Radarr or Seerr.',
+      'Scrapes fixed Rotten Tomatoes movie and TV pages, routes safe movie matches to Radarr or Seerr, and sends TV picks to Sonarr or Seerr using the saved Top count.',
     defaultScheduleCron: '0 5 * * 0',
     defaultEstimatedRuntimeMs: 14 * 60_000,
     dedupePolicy: 'schedule_singleton',

--- a/apps/api/src/jobs/job-registry.ts
+++ b/apps/api/src/jobs/job-registry.ts
@@ -272,9 +272,9 @@ export const JOB_DEFINITIONS: JobDefinitionInfo[] = [
   }),
   defineJob({
     id: 'rottenTomatoesUpcomingMovies',
-    name: 'Rotten Tomatoes Upcoming Movies',
+    name: 'Rotten Tomatoes Upcoming Movies + TV Shows',
     description:
-      'Scrapes fixed Rotten Tomatoes movie and TV pages, routes safe movie matches to Radarr or Seerr, and sends TV picks to Sonarr or Seerr using the saved Top count.',
+      'Scrapes fixed Rotten Tomatoes movie and TV pages, uses separate saved movie and TV Top counts, and routes picks to Radarr, Sonarr, or Seerr.',
     defaultScheduleCron: '0 5 * * 0',
     defaultEstimatedRuntimeMs: 14 * 60_000,
     dedupePolicy: 'schedule_singleton',

--- a/apps/api/src/jobs/rotten-tomatoes-upcoming-movies.job.spec.ts
+++ b/apps/api/src/jobs/rotten-tomatoes-upcoming-movies.job.spec.ts
@@ -403,7 +403,7 @@ describe('RottenTomatoesUpcomingMoviesJob', () => {
     expect(index.titleYearKeys.has('touch me|2025')).toBe(true);
   });
 
-  it('normalizes missing Rotten Tomatoes settings to movie-on, show-off, top-10, Seerr-off', async () => {
+  it('normalizes missing Rotten Tomatoes settings to movie-on, show-off, top-20 movies, top-10 TV, Seerr-off', async () => {
     const { job, settings } = createJob();
     const ctx = createContext({ dryRun: true });
     const fetchMock = jest.spyOn(globalThis, 'fetch');
@@ -424,11 +424,12 @@ describe('RottenTomatoesUpcomingMoviesJob', () => {
 
     expect(raw.effectiveIncludeMovies).toBe(true);
     expect(raw.effectiveIncludeShows).toBe(false);
+    expect(raw.effectiveMovieLimit).toBe(20);
     expect(raw.effectiveShowLimit).toBe(10);
     expect(raw.routeViaSeerr).toBe(false);
   });
 
-  it('clamps the saved TV show limit to the supported range', async () => {
+  it('clamps the saved movie and TV limits to the supported range', async () => {
     const { job, settings } = createJob();
     const ctx = createContext({ dryRun: true });
     const fetchMock = jest.spyOn(globalThis, 'fetch');
@@ -437,6 +438,7 @@ describe('RottenTomatoesUpcomingMoviesJob', () => {
       settings: {
         jobs: {
           rottenTomatoesUpcomingMovies: {
+            movieLimit: 999,
             showLimit: 999,
           },
         },
@@ -453,6 +455,7 @@ describe('RottenTomatoesUpcomingMoviesJob', () => {
     const summary = result.summary as Record<string, unknown>;
     const raw = summary.raw as Record<string, unknown>;
 
+    expect(raw.effectiveMovieLimit).toBe(100);
     expect(raw.effectiveShowLimit).toBe(100);
   });
 
@@ -580,6 +583,116 @@ describe('RottenTomatoesUpcomingMoviesJob', () => {
     await job.run(ctx);
 
     expect(tvFetchCount).toBe(1);
+  });
+
+  it('stops fetching movie sources once the manual movie Top count is reached', async () => {
+    const { job, settings } = createJob();
+    const ctx = createContext({
+      dryRun: true,
+      input: { category: 'movies', topCount: 1 },
+    });
+    let movieFetchCount = 0;
+
+    settings.getInternalSettings.mockResolvedValue({
+      settings: {
+        jobs: {
+          rottenTomatoesUpcomingMovies: {
+            movieLimit: 20,
+          },
+        },
+      },
+      secrets: {},
+    });
+    settings.readServiceSecret.mockReturnValue('');
+    jest.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const url = toFetchUrl(input);
+      if (url.includes('/browse/movies_')) {
+        movieFetchCount += 1;
+        return Promise.resolve({
+          ok: true,
+          text: () =>
+            Promise.resolve(
+              createMovieSourceHtml([
+                {
+                  title: 'Touch Me',
+                  href: '/m/touch_me_2025',
+                  startDate: 'Streaming Apr 7, 2025',
+                },
+              ]),
+            ),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        text: () => Promise.resolve(''),
+      } as Response);
+    });
+
+    const result = await job.run(ctx);
+    const summary = result.summary as Record<string, unknown>;
+    const raw = summary.raw as Record<string, unknown>;
+    const movies = raw.movies as Record<string, unknown>;
+    const sampleCandidates = movies.sampleCandidates as Array<
+      Record<string, unknown>
+    >;
+
+    expect(movieFetchCount).toBe(1);
+    expect(raw.effectiveMovieLimit).toBe(1);
+    expect(sampleCandidates).toHaveLength(1);
+    expect(sampleCandidates[0]?.title).toBe('Touch Me');
+  });
+
+  it('uses the manual Top count for TV runs instead of the saved TV limit', async () => {
+    const { job, settings } = createJob();
+    const ctx = createContext({
+      dryRun: true,
+      input: { category: 'shows', topCount: 1 },
+    });
+    let tvFetchCount = 0;
+
+    settings.getInternalSettings.mockResolvedValue({
+      settings: {
+        jobs: {
+          rottenTomatoesUpcomingMovies: {
+            showLimit: 5,
+          },
+        },
+      },
+      secrets: {},
+    });
+    settings.readServiceSecret.mockReturnValue('');
+    jest.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const url = toFetchUrl(input);
+      if (url.includes('/browse/tv_series_browse')) {
+        tvFetchCount += 1;
+        return Promise.resolve({
+          ok: true,
+          text: () =>
+            Promise.resolve(
+              createShowSourceHtml([
+                {
+                  title: 'The Studio',
+                  href: '/tv/the_studio/s01',
+                  startDate: 'Premiered Mar 26, 2025',
+                  criticsScore: 94,
+                  audienceScore: 71,
+                },
+              ]),
+            ),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        text: () => Promise.resolve(''),
+      } as Response);
+    });
+
+    const result = await job.run(ctx);
+    const summary = result.summary as Record<string, unknown>;
+    const raw = summary.raw as Record<string, unknown>;
+
+    expect(tvFetchCount).toBe(1);
+    expect(raw.effectiveShowLimit).toBe(1);
   });
 
   it('routes matched TV shows to Sonarr directly when Seerr mode is off', async () => {
@@ -725,6 +838,84 @@ describe('RottenTomatoesUpcomingMoviesJob', () => {
     expect(sonarr.addSeries).not.toHaveBeenCalled();
     expect(destinationStats.requested).toBe(1);
     expect(destinationStats.failed).toBe(0);
+  });
+
+  it('uses the manual Seerr override for a single TV run', async () => {
+    const { job, settings, sonarr, seerr, tmdb } = createJob();
+    const ctx = createContext({
+      dryRun: false,
+      input: { category: 'shows', routeViaSeerr: true, topCount: 1 },
+    });
+
+    settings.getInternalSettings.mockResolvedValue({
+      settings: {
+        jobs: {
+          rottenTomatoesUpcomingMovies: {
+            routeViaSeerr: false,
+            showLimit: 5,
+          },
+        },
+        sonarr: {
+          enabled: true,
+          baseUrl: 'http://sonarr.local:8989',
+          defaultRootFolderPath: '/shows',
+          defaultQualityProfileId: 4,
+        },
+        seerr: {
+          enabled: true,
+          baseUrl: 'http://seerr.local:5055',
+        },
+      },
+      secrets: {
+        sonarr: { apiKey: 'sonarr-key' },
+        seerr: { apiKey: 'seerr-key' },
+        tmdb: { apiKey: 'tmdb-key' },
+      },
+    });
+    settings.readServiceSecret.mockImplementation((service) => {
+      if (service === 'sonarr') return 'sonarr-key';
+      if (service === 'seerr') return 'seerr-key';
+      if (service === 'tmdb') return 'tmdb-key';
+      return '';
+    });
+    mockFetchWithMovieAndShowPages({
+      showHtml: createShowSourceHtml([
+        {
+          title: 'The Studio',
+          href: '/tv/the_studio/s01',
+          startDate: 'Premiered Mar 26, 2025',
+          criticsScore: 94,
+          audienceScore: 71,
+        },
+      ]),
+    });
+    sonarr.listSeries.mockResolvedValue([]);
+    seerr.requestTvAllSeasons.mockResolvedValue({
+      status: 'requested',
+      requestId: 42,
+      error: null,
+    });
+    tmdb.searchTv.mockResolvedValue([
+      { id: 1001, name: 'The Studio', first_air_date: '2025-03-26' },
+    ]);
+    tmdb.getTvExternalIds.mockResolvedValue({ tvdb_id: 2001 });
+
+    const result = await job.run(ctx);
+    const summary = result.summary as Record<string, unknown>;
+    const raw = summary.raw as Record<string, unknown>;
+    const shows = raw.shows as Record<string, unknown>;
+    const destinationStats = shows.destinationStats as Record<string, unknown>;
+
+    expect(raw.routeViaSeerr).toBe(true);
+    expect(raw.effectiveShowLimit).toBe(1);
+    expect(seerr.requestTvAllSeasons).toHaveBeenCalledWith({
+      baseUrl: 'http://seerr.local:5055',
+      apiKey: 'seerr-key',
+      tmdbId: 1001,
+      tvdbId: 2001,
+    });
+    expect(sonarr.addSeries).not.toHaveBeenCalled();
+    expect(destinationStats.requested).toBe(1);
   });
 
   it('runs the movie branch before the TV branch when both are enabled', async () => {

--- a/apps/api/src/jobs/rotten-tomatoes-upcoming-movies.job.spec.ts
+++ b/apps/api/src/jobs/rotten-tomatoes-upcoming-movies.job.spec.ts
@@ -87,13 +87,16 @@ function createJob() {
 
 function createSourceHtml(
   entries: Array<{ title: string; href: string; startDate: string }>,
+  options?: { textTag?: 'span' | 'rt-text' },
 ): string {
+  const textTag = options?.textTag ?? 'span';
+
   return entries
     .map(
       (entry) => `
         <a data-qa="discovery-media-list-item-caption" href="${entry.href}">
-          <span data-qa="discovery-media-list-item-title">${entry.title}</span>
-          <span data-qa="discovery-media-list-item-start-date">${entry.startDate}</span>
+          <${textTag} data-qa="discovery-media-list-item-title">${entry.title}</${textTag}>
+          <${textTag} data-qa="discovery-media-list-item-start-date">${entry.startDate}</${textTag}>
         </a>
       `,
     )
@@ -109,13 +112,16 @@ describe('RottenTomatoesUpcomingMoviesJob', () => {
     const parsed = parseRottenTomatoesMoviesFromHtml({
       sourceUrl:
         'https://www.rottentomatoes.com/browse/movies_in_theaters/sort:newest',
-      html: createSourceHtml([
-        {
-          title: 'The Example',
-          href: '/m/the_example_2026',
-          startDate: 'Streaming Apr 7, 2025',
-        },
-      ]),
+      html: createSourceHtml(
+        [
+          {
+            title: 'The Example',
+            href: '/m/the_example_2026',
+            startDate: 'Streaming Apr 7, 2025',
+          },
+        ],
+        { textTag: 'rt-text' },
+      ),
     });
 
     expect(parsed.discoveredEntries).toBe(1);
@@ -125,6 +131,30 @@ describe('RottenTomatoesUpcomingMoviesJob', () => {
         title: 'The Example',
         year: '2026',
         href: '/m/the_example_2026',
+      }),
+    ]);
+  });
+
+  it('keeps parsing legacy span-based Rotten Tomatoes cards', () => {
+    const parsed = parseRottenTomatoesMoviesFromHtml({
+      sourceUrl:
+        'https://www.rottentomatoes.com/browse/movies_in_theaters/sort:newest',
+      html: createSourceHtml([
+        {
+          title: 'Legacy Example',
+          href: '/m/legacy_example_2025',
+          startDate: 'Streaming Apr 7, 2025',
+        },
+      ]),
+    });
+
+    expect(parsed.discoveredEntries).toBe(1);
+    expect(parsed.skippedNoYear).toBe(0);
+    expect(parsed.movies).toEqual([
+      expect.objectContaining({
+        title: 'Legacy Example',
+        year: '2025',
+        href: '/m/legacy_example_2025',
       }),
     ]);
   });

--- a/apps/api/src/jobs/rotten-tomatoes-upcoming-movies.job.spec.ts
+++ b/apps/api/src/jobs/rotten-tomatoes-upcoming-movies.job.spec.ts
@@ -1,18 +1,34 @@
+import type { PlexVerifiedEpisodeAvailability } from '../plex/plex-server.service';
 import type { JobContext, JobRunTrigger, JsonObject } from './jobs.types';
 import {
   RottenTomatoesUpcomingMoviesJob,
   buildRadarrMovieIndex,
   dedupeScrapedMovies,
+  dedupeScrapedShows,
   parseRottenTomatoesMoviesFromHtml,
+  parseRottenTomatoesShowsFromHtml,
   selectLookupMovie,
 } from './rotten-tomatoes-upcoming-movies.job';
-import { SettingsService } from '../settings/settings.service';
+import { PlexServerService } from '../plex/plex-server.service';
 import { RadarrService } from '../radarr/radarr.service';
 import { SeerrService } from '../seerr/seerr.service';
+import { SettingsService } from '../settings/settings.service';
+import {
+  SonarrService,
+  type SonarrEpisode,
+  type SonarrSeries,
+} from '../sonarr/sonarr.service';
+import { TmdbService } from '../tmdb/tmdb.service';
 
 type SettingsMock = Pick<
   SettingsService,
   'getInternalSettings' | 'readServiceSecret'
+>;
+type PlexMock = Pick<
+  PlexServerService,
+  | 'getSections'
+  | 'getTvdbShowRatingKeysMapForSectionKey'
+  | 'getVerifiedEpisodeAvailabilityForShowRatingKey'
 >;
 type RadarrMock = Pick<
   RadarrService,
@@ -23,11 +39,24 @@ type RadarrMock = Pick<
   | 'listTags'
   | 'addMovie'
 >;
-type SeerrMock = Pick<SeerrService, 'requestMovie'>;
+type SonarrMock = Pick<
+  SonarrService,
+  | 'listSeries'
+  | 'getEpisodesBySeries'
+  | 'setEpisodeMonitored'
+  | 'updateSeries'
+  | 'listRootFolders'
+  | 'listQualityProfiles'
+  | 'listTags'
+  | 'addSeries'
+>;
+type SeerrMock = Pick<SeerrService, 'requestMovie' | 'requestTvAllSeasons'>;
+type TmdbMock = Pick<TmdbService, 'searchTv' | 'getTvExternalIds'>;
 
 function createContext(params?: {
   trigger?: JobRunTrigger;
   dryRun?: boolean;
+  input?: JsonObject;
 }): JobContext {
   const trigger = params?.trigger ?? 'manual';
   const dryRun = params?.dryRun ?? false;
@@ -48,6 +77,7 @@ function createContext(params?: {
     userId: 'user-1',
     trigger,
     dryRun,
+    input: params?.input,
     getSummary: () => currentSummary,
     setSummary,
     patchSummary,
@@ -64,6 +94,11 @@ function createJob() {
     getInternalSettings: jest.fn(),
     readServiceSecret: jest.fn(),
   };
+  const plex: jest.Mocked<PlexMock> = {
+    getSections: jest.fn(),
+    getTvdbShowRatingKeysMapForSectionKey: jest.fn(),
+    getVerifiedEpisodeAvailabilityForShowRatingKey: jest.fn(),
+  };
   const radarr: jest.Mocked<RadarrMock> = {
     listMovies: jest.fn(),
     lookupMovies: jest.fn(),
@@ -72,20 +107,38 @@ function createJob() {
     listTags: jest.fn(),
     addMovie: jest.fn(),
   };
+  const sonarr: jest.Mocked<SonarrMock> = {
+    listSeries: jest.fn(),
+    getEpisodesBySeries: jest.fn(),
+    setEpisodeMonitored: jest.fn(),
+    updateSeries: jest.fn(),
+    listRootFolders: jest.fn(),
+    listQualityProfiles: jest.fn(),
+    listTags: jest.fn(),
+    addSeries: jest.fn(),
+  };
   const seerr: jest.Mocked<SeerrMock> = {
     requestMovie: jest.fn(),
+    requestTvAllSeasons: jest.fn(),
+  };
+  const tmdb: jest.Mocked<TmdbMock> = {
+    searchTv: jest.fn(),
+    getTvExternalIds: jest.fn(),
   };
 
   const job = new RottenTomatoesUpcomingMoviesJob(
     settings as unknown as SettingsService,
+    plex as unknown as PlexServerService,
     radarr as unknown as RadarrService,
+    sonarr as unknown as SonarrService,
     seerr as unknown as SeerrService,
+    tmdb as unknown as TmdbService,
   );
 
-  return { job, settings, radarr, seerr };
+  return { job, settings, plex, radarr, sonarr, seerr, tmdb };
 }
 
-function createSourceHtml(
+function createMovieSourceHtml(
   entries: Array<{ title: string; href: string; startDate: string }>,
   options?: { textTag?: 'span' | 'rt-text' },
 ): string {
@@ -103,16 +156,93 @@ function createSourceHtml(
     .join('\n');
 }
 
+function createShowSourceHtml(
+  entries: Array<{
+    title: string;
+    href: string;
+    startDate: string;
+    criticsScore: number | null;
+    audienceScore: number | null;
+  }>,
+  options?: { textTag?: 'span' | 'rt-text' },
+): string {
+  const textTag = options?.textTag ?? 'rt-text';
+
+  return entries
+    .map((entry) => {
+      const criticsMarkup =
+        entry.criticsScore === null
+          ? ''
+          : `<rt-text slot="criticsScore">${entry.criticsScore}%</rt-text>`;
+      const audienceMarkup =
+        entry.audienceScore === null
+          ? ''
+          : `<rt-text slot="audienceScore">${entry.audienceScore}%</rt-text>`;
+
+      return `
+        <a data-qa="discovery-media-list-item-caption" href="${entry.href}">
+          <${textTag} data-qa="discovery-media-list-item-title">${entry.title}</${textTag}>
+          <${textTag} data-qa="discovery-media-list-item-start-date">${entry.startDate}</${textTag}>
+          ${criticsMarkup}
+          ${audienceMarkup}
+        </a>
+      `;
+    })
+    .join('\n');
+}
+
+function toFetchUrl(input: unknown): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.toString();
+  if (input instanceof Request) return input.url;
+  return '';
+}
+
+function mockFetchWithMovieAndShowPages(params?: {
+  movieHtml?: string;
+  showHtml?: string;
+}) {
+  return jest.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+    const url = toFetchUrl(input);
+    if (url.includes('/browse/movies_')) {
+      return Promise.resolve({
+        ok: true,
+        text: () => Promise.resolve(params?.movieHtml ?? ''),
+      } as Response);
+    }
+    if (url.includes('/browse/tv_series_browse')) {
+      return Promise.resolve({
+        ok: true,
+        text: () => Promise.resolve(params?.showHtml ?? ''),
+      } as Response);
+    }
+    return Promise.resolve({
+      ok: true,
+      text: () => Promise.resolve(''),
+    } as Response);
+  });
+}
+
+function createVerifiedAvailability(
+  verifiedEpisodes: string[],
+): PlexVerifiedEpisodeAvailability {
+  return {
+    verifiedEpisodes: new Set(verifiedEpisodes),
+    metadataEpisodes: new Set(verifiedEpisodes),
+    probeFailureCount: 0,
+  };
+}
+
 describe('RottenTomatoesUpcomingMoviesJob', () => {
   afterEach(() => {
     jest.restoreAllMocks();
   });
 
-  it('parses Rotten Tomatoes cards and prefers year from slug before start-date', () => {
+  it('parses Rotten Tomatoes movie cards and prefers year from slug before start-date', () => {
     const parsed = parseRottenTomatoesMoviesFromHtml({
       sourceUrl:
         'https://www.rottentomatoes.com/browse/movies_in_theaters/sort:newest',
-      html: createSourceHtml(
+      html: createMovieSourceHtml(
         [
           {
             title: 'The Example',
@@ -135,26 +265,28 @@ describe('RottenTomatoesUpcomingMoviesJob', () => {
     ]);
   });
 
-  it('keeps parsing legacy span-based Rotten Tomatoes cards', () => {
-    const parsed = parseRottenTomatoesMoviesFromHtml({
+  it('parses Rotten Tomatoes TV cards with critic and audience scores', () => {
+    const parsed = parseRottenTomatoesShowsFromHtml({
       sourceUrl:
-        'https://www.rottentomatoes.com/browse/movies_in_theaters/sort:newest',
-      html: createSourceHtml([
+        'https://www.rottentomatoes.com/browse/tv_series_browse/sort:newest?hl=en_US',
+      html: createShowSourceHtml([
         {
-          title: 'Legacy Example',
-          href: '/m/legacy_example_2025',
-          startDate: 'Streaming Apr 7, 2025',
+          title: 'The Studio',
+          href: '/tv/the_studio/s01',
+          startDate: 'Premiered Mar 26, 2025',
+          criticsScore: 94,
+          audienceScore: 71,
         },
       ]),
     });
 
     expect(parsed.discoveredEntries).toBe(1);
-    expect(parsed.skippedNoYear).toBe(0);
-    expect(parsed.movies).toEqual([
+    expect(parsed.shows).toEqual([
       expect.objectContaining({
-        title: 'Legacy Example',
+        title: 'The Studio',
         year: '2025',
-        href: '/m/legacy_example_2025',
+        criticsScore: 94,
+        audienceScore: 71,
       }),
     ]);
   });
@@ -191,6 +323,53 @@ describe('RottenTomatoesUpcomingMoviesJob', () => {
     ]);
   });
 
+  it('dedupes scraped TV shows by normalized title and year or slug', () => {
+    const deduped = dedupeScrapedShows([
+      {
+        title: 'The Studio',
+        year: '2025',
+        href: '/tv/the_studio/s01',
+        slugKey: '/tv/the_studio/s01',
+        startDate: 'Premiered Mar 26, 2025',
+        criticsScore: 94,
+        audienceScore: 71,
+        sourceUrl: 'source-a',
+      },
+      {
+        title: 'The Studio',
+        year: '2025',
+        href: '/tv/the_studio/s01',
+        slugKey: '/tv/the_studio/s01',
+        startDate: 'Premiered Mar 26, 2025',
+        criticsScore: 94,
+        audienceScore: 71,
+        sourceUrl: 'source-b',
+      },
+      {
+        title: 'Murderbot',
+        year: null,
+        href: '/tv/murderbot/s01',
+        slugKey: '/tv/murderbot/s01',
+        startDate: 'Premiered May 16, 2025',
+        criticsScore: 96,
+        audienceScore: 79,
+        sourceUrl: 'source-c',
+      },
+      {
+        title: 'Murderbot',
+        year: null,
+        href: '/tv/murderbot/s01',
+        slugKey: '/tv/murderbot/s01',
+        startDate: 'Premiered May 16, 2025',
+        criticsScore: 96,
+        audienceScore: 79,
+        sourceUrl: 'source-d',
+      },
+    ]);
+
+    expect(deduped).toHaveLength(2);
+  });
+
   it('selects conservative title-only lookup matches and rejects unrelated same-title years', () => {
     const safeMatch = selectLookupMovie(
       [
@@ -224,7 +403,7 @@ describe('RottenTomatoesUpcomingMoviesJob', () => {
     expect(index.titleYearKeys.has('touch me|2025')).toBe(true);
   });
 
-  it('continues when one Rotten Tomatoes source fails', async () => {
+  it('normalizes missing Rotten Tomatoes settings to movie-on, show-off, top-10, Seerr-off', async () => {
     const { job, settings } = createJob();
     const ctx = createContext({ dryRun: true });
     const fetchMock = jest.spyOn(globalThis, 'fetch');
@@ -234,22 +413,159 @@ describe('RottenTomatoesUpcomingMoviesJob', () => {
       secrets: {},
     });
     settings.readServiceSecret.mockReturnValue('');
-    let callCount = 0;
-    fetchMock.mockImplementation(() => {
-      callCount += 1;
-      if (callCount === 1) {
-        return Promise.reject(new Error('boom'));
-      }
-      if (callCount === 2) {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(''),
+    } as Response);
+
+    const result = await job.run(ctx);
+    const summary = result.summary as Record<string, unknown>;
+    const raw = summary.raw as Record<string, unknown>;
+
+    expect(raw.effectiveIncludeMovies).toBe(true);
+    expect(raw.effectiveIncludeShows).toBe(false);
+    expect(raw.effectiveShowLimit).toBe(10);
+    expect(raw.routeViaSeerr).toBe(false);
+  });
+
+  it('clamps the saved TV show limit to the supported range', async () => {
+    const { job, settings } = createJob();
+    const ctx = createContext({ dryRun: true });
+    const fetchMock = jest.spyOn(globalThis, 'fetch');
+
+    settings.getInternalSettings.mockResolvedValue({
+      settings: {
+        jobs: {
+          rottenTomatoesUpcomingMovies: {
+            showLimit: 999,
+          },
+        },
+      },
+      secrets: {},
+    });
+    settings.readServiceSecret.mockReturnValue('');
+    fetchMock.mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(''),
+    } as Response);
+
+    const result = await job.run(ctx);
+    const summary = result.summary as Record<string, unknown>;
+    const raw = summary.raw as Record<string, unknown>;
+
+    expect(raw.effectiveShowLimit).toBe(100);
+  });
+
+  it('rejects invalid manual categories clearly', async () => {
+    const { job, settings } = createJob();
+    const ctx = createContext({
+      dryRun: true,
+      input: { category: 'books' },
+    });
+
+    settings.getInternalSettings.mockResolvedValue({
+      settings: {},
+      secrets: {},
+    });
+
+    await expect(job.run(ctx)).rejects.toThrow(
+      'Rotten Tomatoes Upcoming category must be either "movies" or "shows".',
+    );
+  });
+
+  it('filters TV candidates to shows with both scores at least 60 and allows manual shows when saved TV is off', async () => {
+    const { job, settings } = createJob();
+    const ctx = createContext({
+      dryRun: true,
+      input: { category: 'shows' },
+    });
+
+    settings.getInternalSettings.mockResolvedValue({
+      settings: {
+        jobs: {
+          rottenTomatoesUpcomingMovies: {
+            includeShows: false,
+            showLimit: 1,
+          },
+        },
+      },
+      secrets: {},
+    });
+    settings.readServiceSecret.mockReturnValue('');
+    mockFetchWithMovieAndShowPages({
+      showHtml: createShowSourceHtml([
+        {
+          title: 'The Studio',
+          href: '/tv/the_studio/s01',
+          startDate: 'Premiered Mar 26, 2025',
+          criticsScore: 94,
+          audienceScore: 71,
+        },
+        {
+          title: 'Half Safe',
+          href: '/tv/half_safe/s01',
+          startDate: 'Premiered Apr 10, 2025',
+          criticsScore: 94,
+          audienceScore: 41,
+        },
+        {
+          title: 'No Critics Yet',
+          href: '/tv/no_critics_yet/s01',
+          startDate: 'Premiered Apr 11, 2025',
+          criticsScore: null,
+          audienceScore: 85,
+        },
+      ]),
+    });
+
+    const result = await job.run(ctx);
+    const summary = result.summary as Record<string, unknown>;
+    const raw = summary.raw as Record<string, unknown>;
+    const shows = raw.shows as Record<string, unknown>;
+    const candidates = shows.sampleCandidates as Array<Record<string, unknown>>;
+
+    expect(raw.effectiveIncludeMovies).toBe(false);
+    expect(raw.effectiveIncludeShows).toBe(true);
+    expect(raw.effectiveShowLimit).toBe(1);
+    expect(shows.scoreFilteredOut).toBe(2);
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.title).toBe('The Studio');
+  });
+
+  it('stops fetching TV sources once the deduped qualified pool reaches the saved show limit', async () => {
+    const { job, settings } = createJob();
+    const ctx = createContext({
+      dryRun: true,
+      input: { category: 'shows' },
+    });
+    let tvFetchCount = 0;
+
+    settings.getInternalSettings.mockResolvedValue({
+      settings: {
+        jobs: {
+          rottenTomatoesUpcomingMovies: {
+            showLimit: 1,
+          },
+        },
+      },
+      secrets: {},
+    });
+    settings.readServiceSecret.mockReturnValue('');
+    jest.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const url = toFetchUrl(input);
+      if (url.includes('/browse/tv_series_browse')) {
+        tvFetchCount += 1;
         return Promise.resolve({
           ok: true,
           text: () =>
             Promise.resolve(
-              createSourceHtml([
+              createShowSourceHtml([
                 {
-                  title: 'Touch Me',
-                  href: '/m/touch_me_2025',
-                  startDate: 'Streaming Apr 7, 2025',
+                  title: 'The Studio',
+                  href: '/tv/the_studio/s01',
+                  startDate: 'Premiered Mar 26, 2025',
+                  criticsScore: 94,
+                  audienceScore: 71,
                 },
               ]),
             ),
@@ -261,117 +577,101 @@ describe('RottenTomatoesUpcomingMoviesJob', () => {
       } as Response);
     });
 
-    const result = await job.run(ctx);
-    const summary = result.summary as Record<string, unknown>;
-    const raw = summary.raw as Record<string, unknown>;
-    const sourceStats = raw.sourceStats as Array<Record<string, unknown>>;
-    const destinationStats = raw.destinationStats as Record<string, unknown>;
+    await job.run(ctx);
 
-    expect(sourceStats.some((row) => row.failed === true)).toBe(true);
-    expect((raw.sampleCandidates as Array<unknown>).length).toBe(1);
-    expect(destinationStats.skipped).toBe(1);
+    expect(tvFetchCount).toBe(1);
   });
 
-  it('fails discovery clearly when all Rotten Tomatoes sources fail', async () => {
-    const { job, settings } = createJob();
-    const ctx = createContext({ dryRun: true });
-    const fetchMock = jest.spyOn(globalThis, 'fetch');
-
-    settings.getInternalSettings.mockResolvedValue({
-      settings: {},
-      secrets: {},
+  it('routes matched TV shows to Sonarr directly when Seerr mode is off', async () => {
+    const { job, settings, sonarr, seerr, tmdb } = createJob();
+    const ctx = createContext({
+      dryRun: false,
+      input: { category: 'shows' },
     });
-    settings.readServiceSecret.mockReturnValue('');
-    fetchMock.mockRejectedValue(new Error('network down'));
-
-    const result = await job.run(ctx);
-    const summary = result.summary as Record<string, unknown>;
-    const tasks = summary.tasks as Array<Record<string, unknown>>;
-    const scrapeTask = tasks.find((task) => task.id === 'scrape_sources');
-    const issues = summary.issues as Array<Record<string, unknown>>;
-
-    expect(scrapeTask?.status).toBe('failed');
-    expect(
-      issues.some(
-        (issue) =>
-          typeof issue.message === 'string' &&
-          issue.message.includes('Rotten Tomatoes discovery failed'),
-      ),
-    ).toBe(true);
-  });
-
-  it('treats Radarr prechecked duplicates as exists instead of add failures', async () => {
-    const { job, settings, radarr } = createJob();
-    const ctx = createContext({ dryRun: false });
-    const fetchMock = jest.spyOn(globalThis, 'fetch');
 
     settings.getInternalSettings.mockResolvedValue({
       settings: {
-        radarr: {
+        jobs: {
+          rottenTomatoesUpcomingMovies: {
+            includeShows: true,
+            showLimit: 1,
+          },
+        },
+        sonarr: {
           enabled: true,
-          baseUrl: 'http://radarr.local:7878',
-          defaultRootFolderPath: '/movies',
-          defaultQualityProfileId: 1,
+          baseUrl: 'http://sonarr.local:8989',
+          defaultRootFolderPath: '/shows',
+          defaultQualityProfileId: 4,
         },
       },
       secrets: {
-        radarr: { apiKey: 'radarr-key' },
+        sonarr: { apiKey: 'sonarr-key' },
+        tmdb: { apiKey: 'tmdb-key' },
       },
     });
-    settings.readServiceSecret.mockImplementation((service) =>
-      service === 'radarr' ? 'radarr-key' : '',
-    );
-    fetchMock.mockResolvedValue({
-      ok: true,
-      text: () =>
-        Promise.resolve(
-          createSourceHtml([
-            {
-              title: 'Avatar: Fire and Ash',
-              href: '/m/avatar_fire_and_ash_2026',
-              startDate: 'In Theaters Dec 18, 2026',
-            },
-          ]),
-        ),
-    } as Response);
-    radarr.listMovies.mockResolvedValue([]);
-    radarr.listRootFolders.mockResolvedValue([{ id: 1, path: '/movies' }]);
-    radarr.listQualityProfiles.mockResolvedValue([{ id: 1, name: 'Any' }]);
-    radarr.listTags.mockResolvedValue([]);
-    radarr.lookupMovies
-      .mockResolvedValueOnce([
-        { id: 11, title: 'Avatar: Fire and Ash', year: 2025, tmdbId: 83533 },
-      ])
-      .mockResolvedValueOnce([
-        { id: 11, title: 'Avatar: Fire and Ash', year: 2025, tmdbId: 83533 },
-      ]);
-    radarr.addMovie.mockResolvedValue({ status: 'exists', movie: null });
+    settings.readServiceSecret.mockImplementation((service) => {
+      if (service === 'sonarr') return 'sonarr-key';
+      if (service === 'tmdb') return 'tmdb-key';
+      return '';
+    });
+    mockFetchWithMovieAndShowPages({
+      showHtml: createShowSourceHtml([
+        {
+          title: 'The Studio',
+          href: '/tv/the_studio/s01',
+          startDate: 'Premiered Mar 26, 2025',
+          criticsScore: 94,
+          audienceScore: 71,
+        },
+      ]),
+    });
+    sonarr.listSeries.mockResolvedValue([]);
+    sonarr.listRootFolders.mockResolvedValue([{ id: 1, path: '/shows' }]);
+    sonarr.listQualityProfiles.mockResolvedValue([{ id: 4, name: 'HD' }]);
+    sonarr.listTags.mockResolvedValue([]);
+    sonarr.addSeries.mockResolvedValue({ status: 'added', series: null });
+    tmdb.searchTv.mockResolvedValue([
+      { id: 1001, name: 'The Studio', first_air_date: '2025-03-26' },
+    ]);
+    tmdb.getTvExternalIds.mockResolvedValue({ tvdb_id: 2001 });
 
     const result = await job.run(ctx);
     const summary = result.summary as Record<string, unknown>;
     const raw = summary.raw as Record<string, unknown>;
-    const destinationStats = raw.destinationStats as Record<string, unknown>;
+    const shows = raw.shows as Record<string, unknown>;
+    const destinationStats = shows.destinationStats as Record<string, unknown>;
 
-    expect(radarr.addMovie).toHaveBeenCalledTimes(1);
-    expect(destinationStats.exists).toBe(1);
+    expect(sonarr.addSeries).toHaveBeenCalledWith({
+      baseUrl: 'http://sonarr.local:8989',
+      apiKey: 'sonarr-key',
+      title: 'The Studio',
+      tvdbId: 2001,
+      qualityProfileId: 4,
+      rootFolderPath: '/shows',
+      tags: [],
+      monitored: true,
+      searchForMissingEpisodes: true,
+      searchForCutoffUnmetEpisodes: true,
+    });
+    expect(seerr.requestTvAllSeasons).not.toHaveBeenCalled();
+    expect(destinationStats.added).toBe(1);
     expect(destinationStats.failed).toBe(0);
   });
 
-  it('routes matched movies to Seerr when enabled', async () => {
-    const { job, settings, radarr, seerr } = createJob();
-    const ctx = createContext({ dryRun: false });
-    const fetchMock = jest.spyOn(globalThis, 'fetch');
+  it('routes matched TV shows to Seerr when Seerr mode is on', async () => {
+    const { job, settings, sonarr, seerr, tmdb } = createJob();
+    const ctx = createContext({
+      dryRun: false,
+      input: { category: 'shows' },
+    });
 
     settings.getInternalSettings.mockResolvedValue({
       settings: {
         jobs: {
           rottenTomatoesUpcomingMovies: {
             routeViaSeerr: true,
+            showLimit: 1,
           },
-        },
-        radarr: {
-          enabled: true,
-          baseUrl: 'http://radarr.local:7878',
         },
         seerr: {
           enabled: true,
@@ -379,148 +679,248 @@ describe('RottenTomatoesUpcomingMoviesJob', () => {
         },
       },
       secrets: {
-        radarr: { apiKey: 'radarr-key' },
         seerr: { apiKey: 'seerr-key' },
+        tmdb: { apiKey: 'tmdb-key' },
       },
     });
     settings.readServiceSecret.mockImplementation((service) => {
-      if (service === 'radarr') return 'radarr-key';
       if (service === 'seerr') return 'seerr-key';
+      if (service === 'tmdb') return 'tmdb-key';
       return '';
     });
-    fetchMock.mockResolvedValue({
-      ok: true,
-      text: () =>
-        Promise.resolve(
-          createSourceHtml([
-            {
-              title: 'Touch Me',
-              href: '/m/touch_me_2025',
-              startDate: 'Streaming Apr 7, 2025',
-            },
-          ]),
-        ),
-    } as Response);
-    radarr.listMovies.mockResolvedValue([]);
-    radarr.lookupMovies.mockResolvedValue([
-      { id: 21, title: 'Touch Me', year: 2025, tmdbId: 1400763 },
-    ]);
-    seerr.requestMovie.mockResolvedValue({
+    mockFetchWithMovieAndShowPages({
+      showHtml: createShowSourceHtml([
+        {
+          title: 'The Studio',
+          href: '/tv/the_studio/s01',
+          startDate: 'Premiered Mar 26, 2025',
+          criticsScore: 94,
+          audienceScore: 71,
+        },
+      ]),
+    });
+    sonarr.listSeries.mockResolvedValue([]);
+    seerr.requestTvAllSeasons.mockResolvedValue({
       status: 'requested',
-      requestId: 77,
+      requestId: 42,
       error: null,
     });
+    tmdb.searchTv.mockResolvedValue([
+      { id: 1001, name: 'The Studio', first_air_date: '2025-03-26' },
+    ]);
+    tmdb.getTvExternalIds.mockResolvedValue({ tvdb_id: 2001 });
 
     const result = await job.run(ctx);
     const summary = result.summary as Record<string, unknown>;
     const raw = summary.raw as Record<string, unknown>;
-    const destinationStats = raw.destinationStats as Record<string, unknown>;
+    const shows = raw.shows as Record<string, unknown>;
+    const destinationStats = shows.destinationStats as Record<string, unknown>;
 
-    expect(seerr.requestMovie).toHaveBeenCalledWith({
+    expect(seerr.requestTvAllSeasons).toHaveBeenCalledWith({
       baseUrl: 'http://seerr.local:5055',
       apiKey: 'seerr-key',
-      tmdbId: 1400763,
+      tmdbId: 1001,
+      tvdbId: 2001,
     });
-    expect(radarr.addMovie).not.toHaveBeenCalled();
-    expect(radarr.listRootFolders).not.toHaveBeenCalled();
-    expect(radarr.listQualityProfiles).not.toHaveBeenCalled();
-    expect(radarr.listTags).not.toHaveBeenCalled();
-    expect(destinationStats.attempted).toBe(1);
+    expect(sonarr.addSeries).not.toHaveBeenCalled();
     expect(destinationStats.requested).toBe(1);
     expect(destinationStats.failed).toBe(0);
   });
 
-  it('skips Seerr routing gracefully when Seerr is not configured', async () => {
-    const { job, settings, radarr, seerr } = createJob();
-    const ctx = createContext({ dryRun: false });
-    const fetchMock = jest.spyOn(globalThis, 'fetch');
+  it('runs the movie branch before the TV branch when both are enabled', async () => {
+    const { job, settings, radarr, sonarr, tmdb } = createJob();
+    const ctx = createContext({ dryRun: false, trigger: 'auto' });
+
+    settings.getInternalSettings.mockResolvedValue({
+      settings: {
+        jobs: {
+          rottenTomatoesUpcomingMovies: {
+            includeMovies: true,
+            includeShows: true,
+            showLimit: 1,
+          },
+        },
+        radarr: {
+          enabled: true,
+          baseUrl: 'http://radarr.local:7878',
+          defaultRootFolderPath: '/movies',
+          defaultQualityProfileId: 1,
+        },
+        sonarr: {
+          enabled: true,
+          baseUrl: 'http://sonarr.local:8989',
+          defaultRootFolderPath: '/shows',
+          defaultQualityProfileId: 4,
+        },
+      },
+      secrets: {
+        radarr: { apiKey: 'radarr-key' },
+        sonarr: { apiKey: 'sonarr-key' },
+        tmdb: { apiKey: 'tmdb-key' },
+      },
+    });
+    settings.readServiceSecret.mockImplementation((service) => {
+      if (service === 'radarr') return 'radarr-key';
+      if (service === 'sonarr') return 'sonarr-key';
+      if (service === 'tmdb') return 'tmdb-key';
+      return '';
+    });
+    mockFetchWithMovieAndShowPages({
+      movieHtml: createMovieSourceHtml([
+        {
+          title: 'Touch Me',
+          href: '/m/touch_me_2025',
+          startDate: 'Streaming Apr 7, 2025',
+        },
+      ]),
+      showHtml: createShowSourceHtml([
+        {
+          title: 'The Studio',
+          href: '/tv/the_studio/s01',
+          startDate: 'Premiered Mar 26, 2025',
+          criticsScore: 94,
+          audienceScore: 71,
+        },
+      ]),
+    });
+    radarr.listMovies.mockResolvedValue([]);
+    radarr.listRootFolders.mockResolvedValue([{ id: 1, path: '/movies' }]);
+    radarr.listQualityProfiles.mockResolvedValue([{ id: 1, name: 'Any' }]);
+    radarr.listTags.mockResolvedValue([]);
+    radarr.lookupMovies.mockResolvedValue([
+      { id: 21, title: 'Touch Me', year: 2025, tmdbId: 1400763 },
+    ]);
+    radarr.addMovie.mockResolvedValue({ status: 'added', movie: null });
+    sonarr.listSeries.mockResolvedValue([]);
+    sonarr.listRootFolders.mockResolvedValue([{ id: 1, path: '/shows' }]);
+    sonarr.listQualityProfiles.mockResolvedValue([{ id: 4, name: 'HD' }]);
+    sonarr.listTags.mockResolvedValue([]);
+    sonarr.addSeries.mockResolvedValue({ status: 'added', series: null });
+    tmdb.searchTv.mockResolvedValue([
+      { id: 1001, name: 'The Studio', first_air_date: '2025-03-26' },
+    ]);
+    tmdb.getTvExternalIds.mockResolvedValue({ tvdb_id: 2001 });
+
+    await job.run(ctx);
+
+    expect(radarr.lookupMovies.mock.invocationCallOrder[0]).toBeLessThan(
+      tmdb.searchTv.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('reconciles existing Sonarr series in Seerr mode without directly adding the show to Sonarr', async () => {
+    const { job, settings, plex, sonarr, seerr, tmdb } = createJob();
+    const ctx = createContext({
+      dryRun: false,
+      input: { category: 'shows' },
+    });
+    const existingSeries: SonarrSeries = {
+      id: 10,
+      title: 'The Studio',
+      tvdbId: 2001,
+      monitored: false,
+      seasons: [{ seasonNumber: 1, monitored: false }],
+    };
+    const episodes: SonarrEpisode[] = [
+      { id: 101, seasonNumber: 1, episodeNumber: 1, monitored: true },
+      { id: 102, seasonNumber: 1, episodeNumber: 2, monitored: false },
+    ];
+    const availability = createVerifiedAvailability(['1:1']);
 
     settings.getInternalSettings.mockResolvedValue({
       settings: {
         jobs: {
           rottenTomatoesUpcomingMovies: {
             routeViaSeerr: true,
+            showLimit: 1,
           },
         },
-        radarr: {
+        sonarr: {
           enabled: true,
-          baseUrl: 'http://radarr.local:7878',
+          baseUrl: 'http://sonarr.local:8989',
+        },
+        seerr: {
+          enabled: true,
+          baseUrl: 'http://seerr.local:5055',
+        },
+        plex: {
+          baseUrl: 'http://plex.local:32400',
         },
       },
       secrets: {
-        radarr: { apiKey: 'radarr-key' },
+        sonarr: { apiKey: 'sonarr-key' },
+        seerr: { apiKey: 'seerr-key' },
+        tmdb: { apiKey: 'tmdb-key' },
+        plex: { token: 'plex-token' },
       },
     });
-    settings.readServiceSecret.mockImplementation((service) =>
-      service === 'radarr' ? 'radarr-key' : '',
-    );
-    fetchMock.mockResolvedValue({
-      ok: true,
-      text: () =>
-        Promise.resolve(
-          createSourceHtml([
-            {
-              title: 'Touch Me',
-              href: '/m/touch_me_2025',
-              startDate: 'Streaming Apr 7, 2025',
-            },
-          ]),
-        ),
-    } as Response);
-    radarr.listMovies.mockResolvedValue([]);
-
-    const result = await job.run(ctx);
-    const summary = result.summary as Record<string, unknown>;
-    const tasks = summary.tasks as Array<Record<string, unknown>>;
-    const prepareTask = tasks.find((task) => task.id === 'prepare_radarr');
-    const routeTask = tasks.find((task) => task.id === 'route_movies');
-    const raw = summary.raw as Record<string, unknown>;
-    const destinationStats = raw.destinationStats as Record<string, unknown>;
-
-    expect(prepareTask?.status).toBe('skipped');
-    expect(routeTask?.status).toBe('skipped');
-    expect(destinationStats.skipped).toBe(1);
-    expect(radarr.lookupMovies).not.toHaveBeenCalled();
-    expect(radarr.addMovie).not.toHaveBeenCalled();
-    expect(seerr.requestMovie).not.toHaveBeenCalled();
-  });
-
-  it('skips destination gracefully when Radarr is not configured', async () => {
-    const { job, settings, radarr } = createJob();
-    const ctx = createContext({ dryRun: false });
-    const fetchMock = jest.spyOn(globalThis, 'fetch');
-
-    settings.getInternalSettings.mockResolvedValue({
-      settings: {},
-      secrets: {},
+    settings.readServiceSecret.mockImplementation((service) => {
+      if (service === 'sonarr') return 'sonarr-key';
+      if (service === 'seerr') return 'seerr-key';
+      if (service === 'tmdb') return 'tmdb-key';
+      if (service === 'plex') return 'plex-token';
+      return '';
     });
-    settings.readServiceSecret.mockReturnValue('');
-    fetchMock.mockResolvedValue({
-      ok: true,
-      text: () =>
-        Promise.resolve(
-          createSourceHtml([
-            {
-              title: 'Touch Me',
-              href: '/m/touch_me_2025',
-              startDate: 'Streaming Apr 7, 2025',
-            },
-          ]),
-        ),
-    } as Response);
+    mockFetchWithMovieAndShowPages({
+      showHtml: createShowSourceHtml([
+        {
+          title: 'The Studio',
+          href: '/tv/the_studio/s01',
+          startDate: 'Premiered Mar 26, 2025',
+          criticsScore: 94,
+          audienceScore: 71,
+        },
+      ]),
+    });
+    sonarr.listSeries.mockResolvedValue([existingSeries]);
+    sonarr.getEpisodesBySeries.mockResolvedValue(episodes);
+    sonarr.setEpisodeMonitored.mockResolvedValue(true);
+    sonarr.updateSeries.mockResolvedValue(true);
+    seerr.requestTvAllSeasons.mockResolvedValue({
+      status: 'requested',
+      requestId: 42,
+      error: null,
+    });
+    tmdb.searchTv.mockResolvedValue([
+      { id: 1001, name: 'The Studio', first_air_date: '2025-03-26' },
+    ]);
+    tmdb.getTvExternalIds.mockResolvedValue({ tvdb_id: 2001 });
+    plex.getSections.mockResolvedValue([
+      { key: '1', title: 'TV', type: 'show' },
+    ]);
+    plex.getTvdbShowRatingKeysMapForSectionKey.mockResolvedValue(
+      new Map([[2001, ['show-rating-key-1']]]),
+    );
+    plex.getVerifiedEpisodeAvailabilityForShowRatingKey.mockResolvedValue(
+      availability,
+    );
 
     const result = await job.run(ctx);
     const summary = result.summary as Record<string, unknown>;
-    const tasks = summary.tasks as Array<Record<string, unknown>>;
-    const prepareTask = tasks.find((task) => task.id === 'prepare_radarr');
-    const routeTask = tasks.find((task) => task.id === 'route_movies');
     const raw = summary.raw as Record<string, unknown>;
-    const destinationStats = raw.destinationStats as Record<string, unknown>;
+    const shows = raw.shows as Record<string, unknown>;
+    const reconciliation = shows.reconciliation as Record<string, unknown>;
+    const firstEpisodeUpdate = sonarr.setEpisodeMonitored.mock
+      .calls[0]?.[0] as {
+      monitored: boolean;
+      episode: SonarrEpisode;
+    };
+    const secondEpisodeUpdate = sonarr.setEpisodeMonitored.mock
+      .calls[1]?.[0] as {
+      monitored: boolean;
+      episode: SonarrEpisode;
+    };
 
-    expect(prepareTask?.status).toBe('skipped');
-    expect(routeTask?.status).toBe('skipped');
-    expect(destinationStats.skipped).toBe(1);
-    expect(radarr.lookupMovies).not.toHaveBeenCalled();
-    expect(radarr.addMovie).not.toHaveBeenCalled();
+    expect(seerr.requestTvAllSeasons).not.toHaveBeenCalled();
+    expect(sonarr.addSeries).not.toHaveBeenCalled();
+    expect(sonarr.setEpisodeMonitored).toHaveBeenCalledTimes(2);
+    expect(firstEpisodeUpdate.monitored).toBe(false);
+    expect(firstEpisodeUpdate.episode.id).toBe(101);
+    expect(secondEpisodeUpdate.monitored).toBe(true);
+    expect(secondEpisodeUpdate.episode.id).toBe(102);
+    expect(sonarr.updateSeries).toHaveBeenCalledTimes(1);
+    expect(reconciliation.reconciledSeries).toBe(1);
+    expect(reconciliation.episodesMonitored).toBe(1);
+    expect(reconciliation.episodesLeftUnmonitored).toBe(1);
   });
 });

--- a/apps/api/src/jobs/rotten-tomatoes-upcoming-movies.job.ts
+++ b/apps/api/src/jobs/rotten-tomatoes-upcoming-movies.job.ts
@@ -146,6 +146,20 @@ function stripTags(value: string): string {
     .trim();
 }
 
+function extractDataQaText(cardHtml: string, dataQa: string): string {
+  const safeDataQa = dataQa.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = cardHtml.match(
+    new RegExp(
+      `<([a-z0-9-]+)\\b[^>]*data-qa="${safeDataQa}"[^>]*>([\\s\\S]*?)<\\/\\1>`,
+      'i',
+    ),
+  );
+
+  return normalizeTitleForMatching(
+    stripTags(decodeHtmlEntities(match?.[2] ?? '')),
+  );
+}
+
 function parsePositiveInt(value: unknown): number | null {
   if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
     return Math.trunc(value);
@@ -209,20 +223,16 @@ export function parseRottenTomatoesMoviesFromHtml(params: {
   for (const match of html.matchAll(cardRegex)) {
     const href = decodeHtmlEntities(match[1] ?? '').trim();
     const cardHtml = match[2] ?? '';
-    const titleMatch = cardHtml.match(
-      /data-qa="discovery-media-list-item-title"[^>]*>([\s\S]*?)<\/span>/i,
-    );
-    const title = normalizeTitleForMatching(
-      stripTags(decodeHtmlEntities(titleMatch?.[1] ?? '')),
+    const title = extractDataQaText(
+      cardHtml,
+      'discovery-media-list-item-title',
     );
     if (!title) continue;
 
     discoveredEntries += 1;
-    const startDateMatch = cardHtml.match(
-      /data-qa="discovery-media-list-item-start-date"[^>]*>([\s\S]*?)<\/span>/i,
-    );
-    const startDate = normalizeTitleForMatching(
-      stripTags(decodeHtmlEntities(startDateMatch?.[1] ?? '')),
+    const startDate = extractDataQaText(
+      cardHtml,
+      'discovery-media-list-item-start-date',
     );
     const year = extractYearFromText(href, startDate);
     if (!year) {

--- a/apps/api/src/jobs/rotten-tomatoes-upcoming-movies.job.ts
+++ b/apps/api/src/jobs/rotten-tomatoes-upcoming-movies.job.ts
@@ -28,6 +28,7 @@ type RottenTomatoesUpcomingSettings = {
   routeViaSeerr: boolean;
   includeMovies: boolean;
   includeShows: boolean;
+  movieLimit: number;
   showLimit: number;
 };
 
@@ -164,7 +165,7 @@ type ShowBranchCaches = {
 };
 
 const ROTTEN_TOMATOES_UPCOMING_JOB_HEADLINE =
-  'Rotten Tomatoes Upcoming Movies + TV';
+  'Rotten Tomatoes Upcoming Movies + TV Shows';
 const ROTTEN_TOMATOES_MOVIE_SOURCE_URLS = [
   'https://www.rottentomatoes.com/browse/movies_in_theaters/sort:newest',
   'https://www.rottentomatoes.com/browse/movies_at_home/affiliates:fandango-at-home~sort:newest',
@@ -195,6 +196,7 @@ const ROTTEN_TOMATOES_SHOW_SOURCE_URLS = [
 const REQUEST_TIMEOUT_MS = 30_000;
 const MAX_REPORT_TITLE_ITEMS = 100;
 const CLOSE_YEAR_MATCH_DELTA = 1;
+const DEFAULT_MOVIE_LIMIT = 20;
 const DEFAULT_SHOW_LIMIT = 10;
 const MIN_SHOW_LIMIT = 1;
 const MAX_SHOW_LIMIT = 100;
@@ -726,6 +728,12 @@ function normalizeRottenTomatoesUpcomingSettings(
     includeShows:
       pickBool(settings, 'jobs.rottenTomatoesUpcomingMovies.includeShows') ??
       false,
+    movieLimit: clampInt(
+      pickNumber(settings, 'jobs.rottenTomatoesUpcomingMovies.movieLimit'),
+      MIN_SHOW_LIMIT,
+      MAX_SHOW_LIMIT,
+      DEFAULT_MOVIE_LIMIT,
+    ),
     showLimit: clampInt(
       pickNumber(settings, 'jobs.rottenTomatoesUpcomingMovies.showLimit'),
       MIN_SHOW_LIMIT,
@@ -775,6 +783,8 @@ export class RottenTomatoesUpcomingMoviesJob {
     const normalizedSettings =
       normalizeRottenTomatoesUpcomingSettings(settings);
     const manualCategory = this.readManualCategory(ctx.input ?? null);
+    const manualRouteViaSeerr = this.readManualRouteViaSeerr(ctx.input ?? null);
+    const manualTopCount = this.readManualTopCount(ctx.input ?? null);
     if (
       ctx.input &&
       Object.prototype.hasOwnProperty.call(ctx.input, 'category') &&
@@ -800,6 +810,16 @@ export class RottenTomatoesUpcomingMoviesJob {
         : manualCategory === 'movies'
           ? false
           : normalizedSettings.includeShows;
+    const effectiveRouteViaSeerr =
+      manualRouteViaSeerr ?? normalizedSettings.routeViaSeerr;
+    const effectiveMovieLimit =
+      manualCategory === 'movies' && manualTopCount !== null
+        ? manualTopCount
+        : normalizedSettings.movieLimit;
+    const effectiveShowLimit =
+      manualCategory === 'shows' && manualTopCount !== null
+        ? manualTopCount
+        : normalizedSettings.showLimit;
 
     const reportIssues: JobReportV1['issues'] = [];
     if (!effectiveIncludeMovies && !effectiveIncludeShows) {
@@ -816,7 +836,8 @@ export class RottenTomatoesUpcomingMoviesJob {
           ctx,
           settings,
           secrets,
-          routeViaSeerr: normalizedSettings.routeViaSeerr,
+          routeViaSeerr: effectiveRouteViaSeerr,
+          movieLimit: effectiveMovieLimit,
           setProgress,
           reportIssues,
         })
@@ -835,8 +856,8 @@ export class RottenTomatoesUpcomingMoviesJob {
           ctx,
           settings,
           secrets,
-          routeViaSeerr: normalizedSettings.routeViaSeerr,
-          showLimit: normalizedSettings.showLimit,
+          routeViaSeerr: effectiveRouteViaSeerr,
+          showLimit: effectiveShowLimit,
           setProgress,
           reportIssues,
         })
@@ -906,8 +927,9 @@ export class RottenTomatoesUpcomingMoviesJob {
       manualCategory,
       effectiveIncludeMovies,
       effectiveIncludeShows,
-      effectiveShowLimit: normalizedSettings.showLimit,
-      routeViaSeerr: normalizedSettings.routeViaSeerr,
+      effectiveMovieLimit,
+      effectiveShowLimit,
+      routeViaSeerr: effectiveRouteViaSeerr,
       movieBranch,
       showBranch,
       reportIssues,
@@ -921,13 +943,18 @@ export class RottenTomatoesUpcomingMoviesJob {
           manualCategory,
           effectiveIncludeMovies,
           effectiveIncludeShows,
-          effectiveShowLimit: normalizedSettings.showLimit,
+          effectiveMovieLimit,
+          effectiveShowLimit,
+          routeViaSeerr: effectiveRouteViaSeerr,
         },
       );
       await ctx.info('rottenTomatoesUpcomingMovies: failed', {
         manualCategory,
         effectiveIncludeMovies,
         effectiveIncludeShows,
+        effectiveMovieLimit,
+        effectiveShowLimit,
+        routeViaSeerr: effectiveRouteViaSeerr,
       });
       return {
         summary: report as unknown as JsonObject,
@@ -938,7 +965,9 @@ export class RottenTomatoesUpcomingMoviesJob {
       manualCategory,
       effectiveIncludeMovies,
       effectiveIncludeShows,
-      effectiveShowLimit: normalizedSettings.showLimit,
+      effectiveMovieLimit,
+      effectiveShowLimit,
+      routeViaSeerr: effectiveRouteViaSeerr,
       movieCandidates: movieBranch.dedupedMovies.length,
       showCandidates: showBranch.dedupedShows.length,
     });
@@ -946,6 +975,9 @@ export class RottenTomatoesUpcomingMoviesJob {
       manualCategory,
       effectiveIncludeMovies,
       effectiveIncludeShows,
+      effectiveMovieLimit,
+      effectiveShowLimit,
+      routeViaSeerr: effectiveRouteViaSeerr,
       movieDestinationStats: movieBranch.destinationStats,
       showDestinationStats: showBranch.destinationStats,
       showReconciliation: showBranch.reconciliation,
@@ -965,11 +997,36 @@ export class RottenTomatoesUpcomingMoviesJob {
     return null;
   }
 
+  private readManualRouteViaSeerr(input: JsonObject | null): boolean | null {
+    const raw = input?.['routeViaSeerr'];
+    return typeof raw === 'boolean' ? raw : null;
+  }
+
+  private readManualTopCount(input: JsonObject | null): number | null {
+    const raw = input?.['topCount'];
+    if (typeof raw === 'number' && Number.isFinite(raw)) {
+      return clampInt(raw, MIN_SHOW_LIMIT, MAX_SHOW_LIMIT, DEFAULT_SHOW_LIMIT);
+    }
+    if (typeof raw === 'string' && raw.trim()) {
+      const parsed = Number.parseFloat(raw.trim());
+      if (Number.isFinite(parsed)) {
+        return clampInt(
+          parsed,
+          MIN_SHOW_LIMIT,
+          MAX_SHOW_LIMIT,
+          DEFAULT_SHOW_LIMIT,
+        );
+      }
+    }
+    return null;
+  }
+
   private async runMovieBranch(params: {
     ctx: JobContext;
     settings: Record<string, unknown>;
     secrets: Record<string, unknown>;
     routeViaSeerr: boolean;
+    movieLimit: number;
     setProgress: (
       step: string,
       message: string,
@@ -977,14 +1034,22 @@ export class RottenTomatoesUpcomingMoviesJob {
     ) => Promise<void>;
     reportIssues: JobReportV1['issues'];
   }): Promise<MovieBranchResult> {
-    const { ctx, settings, secrets, routeViaSeerr, setProgress, reportIssues } =
-      params;
+    const {
+      ctx,
+      settings,
+      secrets,
+      routeViaSeerr,
+      movieLimit,
+      setProgress,
+      reportIssues,
+    } = params;
 
     await setProgress(
       'scrape_movies',
       'Scraping Rotten Tomatoes movie sources…',
       {
         totalSources: ROTTEN_TOMATOES_MOVIE_SOURCE_URLS.length,
+        movieLimit,
       },
     );
 
@@ -1008,6 +1073,9 @@ export class RottenTomatoesUpcomingMoviesJob {
           failed: false,
           error: null,
         });
+        if (dedupeScrapedMovies(scrapedMovies).length >= movieLimit) {
+          break;
+        }
       } catch (err) {
         const error = errToMessage(err);
         sourceFailureCount += 1;
@@ -1035,7 +1103,10 @@ export class RottenTomatoesUpcomingMoviesJob {
       }
     }
 
-    const dedupedMovies = dedupeScrapedMovies(scrapedMovies);
+    const dedupedMovies = dedupeScrapedMovies(scrapedMovies).slice(
+      0,
+      movieLimit,
+    );
     if (
       sourceFailureCount === ROTTEN_TOMATOES_MOVIE_SOURCE_URLS.length ||
       dedupedMovies.length === 0
@@ -1088,6 +1159,7 @@ export class RottenTomatoesUpcomingMoviesJob {
       {
         candidates: dedupedMovies.length,
         routeViaSeerr,
+        movieLimit,
       },
     );
 
@@ -2449,6 +2521,7 @@ export class RottenTomatoesUpcomingMoviesJob {
     manualCategory: ManualCategory | null;
     effectiveIncludeMovies: boolean;
     effectiveIncludeShows: boolean;
+    effectiveMovieLimit: number;
     effectiveShowLimit: number;
     routeViaSeerr: boolean;
     movieBranch: MovieBranchResult;
@@ -2537,6 +2610,7 @@ export class RottenTomatoesUpcomingMoviesJob {
               changed: params.movieBranch.dedupedMovies.length,
               end: params.movieBranch.dedupedMovies.length,
               unit: 'movies',
+              note: `Limit: ${params.effectiveMovieLimit}`,
             }),
             metricRow({
               label: 'Attempted',
@@ -2729,6 +2803,10 @@ export class RottenTomatoesUpcomingMoviesJob {
               value: params.effectiveIncludeShows,
             },
             {
+              label: 'Movie limit',
+              value: params.effectiveMovieLimit,
+            },
+            {
               label: 'TV limit',
               value: params.effectiveShowLimit,
             },
@@ -2914,6 +2992,7 @@ export class RottenTomatoesUpcomingMoviesJob {
         manualCategory: params.manualCategory,
         effectiveIncludeMovies: params.effectiveIncludeMovies,
         effectiveIncludeShows: params.effectiveIncludeShows,
+        effectiveMovieLimit: params.effectiveMovieLimit,
         effectiveShowLimit: params.effectiveShowLimit,
         routeViaSeerr: params.routeViaSeerr,
         movies: {

--- a/apps/api/src/jobs/rotten-tomatoes-upcoming-movies.job.ts
+++ b/apps/api/src/jobs/rotten-tomatoes-upcoming-movies.job.ts
@@ -1,7 +1,18 @@
 import { Injectable } from '@nestjs/common';
+import {
+  PlexServerService,
+  type PlexPartPlayableProbeResult,
+  type PlexVerifiedEpisodeAvailability,
+} from '../plex/plex-server.service';
 import { RadarrService, type RadarrMovie } from '../radarr/radarr.service';
 import { SeerrService } from '../seerr/seerr.service';
+import {
+  SonarrService,
+  type SonarrEpisode,
+  type SonarrSeries,
+} from '../sonarr/sonarr.service';
 import { SettingsService } from '../settings/settings.service';
+import { TmdbService } from '../tmdb/tmdb.service';
 import {
   decodeHtmlEntities,
   normalizeTitleForMatching,
@@ -11,6 +22,15 @@ import type { JobContext, JobRunResult, JsonObject } from './jobs.types';
 import type { JobReportTaskStatus, JobReportV1 } from './job-report-v1';
 import { issue, metricRow } from './job-report-v1';
 
+type ManualCategory = 'movies' | 'shows';
+
+type RottenTomatoesUpcomingSettings = {
+  routeViaSeerr: boolean;
+  includeMovies: boolean;
+  includeShows: boolean;
+  showLimit: number;
+};
+
 type ScrapedMovie = {
   title: string;
   year: string;
@@ -19,11 +39,31 @@ type ScrapedMovie = {
   sourceUrl: string;
 };
 
-type SourceScrapeStats = {
+type ScrapedShow = {
+  title: string;
+  year: string | null;
+  href: string;
+  slugKey: string;
+  startDate: string;
+  criticsScore: number | null;
+  audienceScore: number | null;
+  sourceUrl: string;
+};
+
+type MovieSourceScrapeStats = {
   url: string;
   discoveredEntries: number;
   parseableEntries: number;
   skippedNoYear: number;
+  failed: boolean;
+  error: string | null;
+};
+
+type ShowSourceScrapeStats = {
+  url: string;
+  discoveredEntries: number;
+  parseableEntries: number;
+  scoreFilteredOut: number;
   failed: boolean;
   error: string | null;
 };
@@ -50,6 +90,46 @@ type LookupSelection = {
   usedTitleOnlyFallback: boolean;
 };
 
+type ResolvedShowIds = {
+  title: string;
+  tmdbId: number;
+  tvdbId: number;
+  year: string | null;
+};
+
+type ShowReconciliationStats = {
+  reconciledSeries: number;
+  episodesMonitored: number;
+  episodesLeftUnmonitored: number;
+  seasonsMonitored: number;
+  seasonsUnmonitored: number;
+  seriesMonitored: number;
+  seriesUnmonitored: number;
+  failures: number;
+};
+
+type MovieBranchResult = {
+  sourceStats: MovieSourceScrapeStats[];
+  dedupedMovies: ScrapedMovie[];
+  destinationStats: DestinationStats;
+  destinationTitles: DestinationTitleBuckets;
+  discoveryStatus: JobReportTaskStatus;
+  routeStatus: JobReportTaskStatus;
+  safeMatchSkipCount: number;
+};
+
+type ShowBranchResult = {
+  sourceStats: ShowSourceScrapeStats[];
+  dedupedShows: ScrapedShow[];
+  destinationStats: DestinationStats;
+  destinationTitles: DestinationTitleBuckets;
+  discoveryStatus: JobReportTaskStatus;
+  routeStatus: JobReportTaskStatus;
+  unresolvedIds: number;
+  scoreFilteredOut: number;
+  reconciliation: ShowReconciliationStats;
+};
+
 type RadarrMovieIndex = {
   titleYearKeys: Set<string>;
   tmdbIds: Set<number>;
@@ -60,13 +140,32 @@ type RadarrConfig = {
   apiKey: string;
 };
 
+type SonarrConfig = {
+  baseUrl: string;
+  apiKey: string;
+};
+
 type SeerrConfig = {
   baseUrl: string;
   apiKey: string;
 };
 
-const ROTTEN_TOMATOES_UPCOMING_JOB_HEADLINE = 'Rotten Tomatoes Upcoming Movies';
-const ROTTEN_TOMATOES_SOURCE_URLS = [
+type PlexConfig = {
+  baseUrl: string;
+  token: string;
+};
+
+type ShowBranchCaches = {
+  sonarrIndexByTvdb: Map<number, SonarrSeries> | null;
+  plexTvdbRatingKeys: Map<number, string[]> | null | undefined;
+  showEpisodeAvailability: Map<string, PlexVerifiedEpisodeAvailability>;
+  partProbeCache: Map<string, PlexPartPlayableProbeResult>;
+  warnedMissingPlexConfig: boolean;
+};
+
+const ROTTEN_TOMATOES_UPCOMING_JOB_HEADLINE =
+  'Rotten Tomatoes Upcoming Movies + TV';
+const ROTTEN_TOMATOES_MOVIE_SOURCE_URLS = [
   'https://www.rottentomatoes.com/browse/movies_in_theaters/sort:newest',
   'https://www.rottentomatoes.com/browse/movies_at_home/affiliates:fandango-at-home~sort:newest',
   'https://www.rottentomatoes.com/browse/movies_at_home/affiliates:apple-tv-plus~sort:newest',
@@ -80,9 +179,26 @@ const ROTTEN_TOMATOES_SOURCE_URLS = [
   'https://www.rottentomatoes.com/browse/movies_at_home/affiliates:amc-plus~sort:newest',
   'https://www.rottentomatoes.com/browse/movies_at_home/affiliates:acorn-tv~sort:newest',
 ] as const;
+const ROTTEN_TOMATOES_SHOW_SOURCE_URLS = [
+  'https://www.rottentomatoes.com/browse/tv_series_browse/sort:newest?hl=en_US',
+  'https://www.rottentomatoes.com/browse/tv_series_browse/affiliates:netflix~sort:newest?hl=en_US',
+  'https://www.rottentomatoes.com/browse/tv_series_browse/affiliates:hulu~sort:newest?hl=en_US',
+  'https://www.rottentomatoes.com/browse/tv_series_browse/affiliates:apple-tv~sort:newest?hl=en_US',
+  'https://www.rottentomatoes.com/browse/tv_series_browse/affiliates:amazon_prime~sort:newest?hl=en_US',
+  'https://www.rottentomatoes.com/browse/tv_series_browse/affiliates:disney-plus~sort:newest?hl=en_US',
+  'https://www.rottentomatoes.com/browse/tv_series_browse/affiliates:max~sort:newest?hl=en_US',
+  'https://www.rottentomatoes.com/browse/tv_series_browse/affiliates:peacock~sort:newest?hl=en_US',
+  'https://www.rottentomatoes.com/browse/tv_series_browse/affiliates:paramount-plus~sort:newest?hl=en_US',
+  'https://www.rottentomatoes.com/browse/tv_series_browse/affiliates:amc-plus~sort:newest?hl=en_US',
+  'https://www.rottentomatoes.com/browse/tv_series_browse/affiliates:acorn-tv~sort:newest?hl=en_US',
+] as const;
 const REQUEST_TIMEOUT_MS = 30_000;
 const MAX_REPORT_TITLE_ITEMS = 100;
 const CLOSE_YEAR_MATCH_DELTA = 1;
+const DEFAULT_SHOW_LIMIT = 10;
+const MIN_SHOW_LIMIT = 1;
+const MAX_SHOW_LIMIT = 100;
+const MINIMUM_RT_SCORE = 60;
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -118,6 +234,16 @@ function pickNumber(obj: Record<string, unknown>, path: string): number | null {
   return null;
 }
 
+function clampInt(
+  value: number | null,
+  min: number,
+  max: number,
+  fallback: number,
+): number {
+  if (value === null || !Number.isFinite(value)) return fallback;
+  return Math.max(min, Math.min(max, Math.trunc(value)));
+}
+
 function normalizeTitleList(titles: string[]): string[] {
   const seen = new Set<string>();
   const out: string[] = [];
@@ -137,6 +263,12 @@ function normalizeTitleList(titles: string[]): string[] {
 
 function buildTitleYearKey(title: string, year: string | number): string {
   return `${normalizeTitleKey(title)}|${String(year ?? '').trim()}`;
+}
+
+function buildTitleVariantKey(title: string, variant: string): string {
+  return `${normalizeTitleKey(title)}|${String(variant ?? '')
+    .trim()
+    .toLowerCase()}`;
 }
 
 function stripTags(value: string): string {
@@ -160,6 +292,25 @@ function extractDataQaText(cardHtml: string, dataQa: string): string {
   );
 }
 
+function extractSlotPercentage(
+  cardHtml: string,
+  slotName: string,
+): number | null {
+  const safeSlot = slotName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = cardHtml.match(
+    new RegExp(
+      `<([a-z0-9-]+)\\b[^>]*slot="${safeSlot}"[^>]*>([\\s\\S]*?)<\\/\\1>`,
+      'i',
+    ),
+  );
+  const text = stripTags(decodeHtmlEntities(match?.[2] ?? ''))
+    .replace(/%/g, '')
+    .trim();
+  if (!text) return null;
+  const parsed = Number.parseInt(text, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
 function parsePositiveInt(value: unknown): number | null {
   if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
     return Math.trunc(value);
@@ -181,6 +332,21 @@ function parseMaybeYear(value: unknown): number | null {
     return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
   }
   return null;
+}
+
+function normalizeHrefKey(href: string): string {
+  const raw = decodeHtmlEntities(String(href ?? '').trim());
+  if (!raw) return '';
+  try {
+    const url = new URL(raw, 'https://www.rottentomatoes.com');
+    return `${url.pathname}${url.search}`.toLowerCase();
+  } catch {
+    return raw.toLowerCase();
+  }
+}
+
+function episodeKey(season: number, episode: number): string {
+  return `${season}:${episode}`;
 }
 
 export function normalizeTitleKey(title: string): string {
@@ -252,6 +418,53 @@ export function parseRottenTomatoesMoviesFromHtml(params: {
   return { movies, discoveredEntries, skippedNoYear };
 }
 
+export function parseRottenTomatoesShowsFromHtml(params: {
+  html: string;
+  sourceUrl: string;
+}): {
+  shows: ScrapedShow[];
+  discoveredEntries: number;
+} {
+  const html = String(params.html ?? '');
+  const sourceUrl = String(params.sourceUrl ?? '').trim();
+  const shows: ScrapedShow[] = [];
+  let discoveredEntries = 0;
+
+  const cardRegex =
+    /<a\b[^>]*data-qa="discovery-media-list-item-caption"[^>]*href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/gi;
+
+  for (const match of html.matchAll(cardRegex)) {
+    const href = decodeHtmlEntities(match[1] ?? '').trim();
+    const cardHtml = match[2] ?? '';
+    const title = extractDataQaText(
+      cardHtml,
+      'discovery-media-list-item-title',
+    );
+    if (!title) continue;
+
+    discoveredEntries += 1;
+    const startDate = extractDataQaText(
+      cardHtml,
+      'discovery-media-list-item-start-date',
+    );
+    const year = extractYearFromText(href, startDate);
+    const slugKey = normalizeHrefKey(href);
+
+    shows.push({
+      title,
+      year,
+      href,
+      slugKey,
+      startDate,
+      criticsScore: extractSlotPercentage(cardHtml, 'criticsScore'),
+      audienceScore: extractSlotPercentage(cardHtml, 'audienceScore'),
+      sourceUrl,
+    });
+  }
+
+  return { shows, discoveredEntries };
+}
+
 export function dedupeScrapedMovies(movies: ScrapedMovie[]): ScrapedMovie[] {
   const seen = new Set<string>();
   const out: ScrapedMovie[] = [];
@@ -261,6 +474,25 @@ export function dedupeScrapedMovies(movies: ScrapedMovie[]): ScrapedMovie[] {
     if (!key || seen.has(key)) continue;
     seen.add(key);
     out.push(movie);
+  }
+
+  return out;
+}
+
+export function dedupeScrapedShows(shows: ScrapedShow[]): ScrapedShow[] {
+  const seen = new Set<string>();
+  const out: ScrapedShow[] = [];
+
+  for (const show of shows) {
+    const key = show.year
+      ? buildTitleYearKey(show.title, show.year)
+      : buildTitleVariantKey(
+          show.title,
+          show.slugKey || show.href || show.title,
+        );
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    out.push(show);
   }
 
   return out;
@@ -287,6 +519,18 @@ export function buildRadarrMovieIndex(movies: RadarrMovie[]): RadarrMovieIndex {
   }
 
   return { titleYearKeys, tmdbIds };
+}
+
+function buildSonarrSeriesIndex(
+  series: SonarrSeries[],
+): Map<number, SonarrSeries> {
+  const index = new Map<number, SonarrSeries>();
+  for (const row of series) {
+    const tvdbId = parsePositiveInt(row?.tvdbId);
+    if (!tvdbId) continue;
+    index.set(tvdbId, row);
+  }
+  return index;
 }
 
 export function selectLookupMovie(
@@ -330,8 +574,69 @@ export function selectLookupMovie(
   return best?.movie ?? null;
 }
 
-function sourceStatsFact(
-  stats: SourceScrapeStats[],
+export function selectTmdbTvMatch(
+  results: Array<{ id: number; name?: string; first_air_date?: string }>,
+  requestedTitle: string,
+  requestedYear?: string | null,
+): { id: number; name: string; first_air_date?: string } | null {
+  const requestedKey = normalizeTitleKey(requestedTitle);
+  const requestedYearInt = parseMaybeYear(requestedYear ?? null);
+  if (!requestedKey) return null;
+
+  const exactMatches = results.filter((result) => {
+    const title =
+      typeof result?.name === 'string'
+        ? normalizeTitleForMatching(result.name)
+        : '';
+    return title ? normalizeTitleKey(title) === requestedKey : false;
+  });
+
+  if (!exactMatches.length) return null;
+
+  if (requestedYearInt === null) {
+    return exactMatches.length === 1
+      ? {
+          id: exactMatches[0].id,
+          name: exactMatches[0].name ?? requestedTitle,
+          first_air_date: exactMatches[0].first_air_date,
+        }
+      : null;
+  }
+
+  let best: {
+    result: { id: number; name?: string; first_air_date?: string };
+    score: number;
+  } | null = null;
+
+  for (const result of exactMatches) {
+    const year = extractYearFromText(result.first_air_date);
+    const yearInt = parseMaybeYear(year);
+    let score: number | null = null;
+    if (yearInt === requestedYearInt) {
+      score = 0;
+    } else if (yearInt === null) {
+      score = 1;
+    } else if (Math.abs(yearInt - requestedYearInt) <= CLOSE_YEAR_MATCH_DELTA) {
+      score = 2;
+    }
+
+    if (score === null) continue;
+    if (!best || score < best.score) {
+      best = { result, score };
+    }
+  }
+
+  return best
+    ? {
+        id: best.result.id,
+        name: best.result.name ?? requestedTitle,
+        first_air_date: best.result.first_air_date,
+      }
+    : null;
+}
+
+function movieSourceStatsFacts(
+  stats: MovieSourceScrapeStats[],
 ): Array<{ label: string; value: JsonObject }> {
   return stats.map((source) => ({
     label: source.url,
@@ -345,12 +650,100 @@ function sourceStatsFact(
   }));
 }
 
+function showSourceStatsFacts(
+  stats: ShowSourceScrapeStats[],
+): Array<{ label: string; value: JsonObject }> {
+  return stats.map((source) => ({
+    label: source.url,
+    value: {
+      discoveredEntries: source.discoveredEntries,
+      parseableEntries: source.parseableEntries,
+      scoreFilteredOut: source.scoreFilteredOut,
+      failed: source.failed,
+      ...(source.error ? { error: source.error } : {}),
+    },
+  }));
+}
+
+function createEmptyDestinationStats(): DestinationStats {
+  return {
+    attempted: 0,
+    requested: 0,
+    added: 0,
+    exists: 0,
+    failed: 0,
+    skipped: 0,
+  };
+}
+
+function createEmptyDestinationTitles(): DestinationTitleBuckets {
+  return {
+    attemptedTitles: [],
+    sentTitles: [],
+    existsTitles: [],
+    failedTitles: [],
+    skippedTitles: [],
+  };
+}
+
+function createEmptyShowReconciliation(): ShowReconciliationStats {
+  return {
+    reconciledSeries: 0,
+    episodesMonitored: 0,
+    episodesLeftUnmonitored: 0,
+    seasonsMonitored: 0,
+    seasonsUnmonitored: 0,
+    seriesMonitored: 0,
+    seriesUnmonitored: 0,
+    failures: 0,
+  };
+}
+
+function addShowReconciliation(
+  target: ShowReconciliationStats,
+  next: ShowReconciliationStats,
+) {
+  target.reconciledSeries += next.reconciledSeries;
+  target.episodesMonitored += next.episodesMonitored;
+  target.episodesLeftUnmonitored += next.episodesLeftUnmonitored;
+  target.seasonsMonitored += next.seasonsMonitored;
+  target.seasonsUnmonitored += next.seasonsUnmonitored;
+  target.seriesMonitored += next.seriesMonitored;
+  target.seriesUnmonitored += next.seriesUnmonitored;
+  target.failures += next.failures;
+}
+
+function normalizeRottenTomatoesUpcomingSettings(
+  settings: Record<string, unknown>,
+): RottenTomatoesUpcomingSettings {
+  return {
+    routeViaSeerr:
+      pickBool(settings, 'jobs.rottenTomatoesUpcomingMovies.routeViaSeerr') ??
+      false,
+    includeMovies:
+      pickBool(settings, 'jobs.rottenTomatoesUpcomingMovies.includeMovies') ??
+      true,
+    includeShows:
+      pickBool(settings, 'jobs.rottenTomatoesUpcomingMovies.includeShows') ??
+      false,
+    showLimit: clampInt(
+      pickNumber(settings, 'jobs.rottenTomatoesUpcomingMovies.showLimit'),
+      MIN_SHOW_LIMIT,
+      MAX_SHOW_LIMIT,
+      DEFAULT_SHOW_LIMIT,
+    ),
+  };
+}
+
 @Injectable()
 export class RottenTomatoesUpcomingMoviesJob {
   constructor(
     private readonly settingsService: SettingsService,
+    private readonly plexServer: PlexServerService,
     private readonly radarr: RadarrService,
+    private readonly sonarr: SonarrService,
     private readonly seerr: SeerrService,
+    private readonly tmdb: TmdbService,
   ) {}
 
   async run(ctx: JobContext): Promise<JobRunResult> {
@@ -373,25 +766,233 @@ export class RottenTomatoesUpcomingMoviesJob {
     await ctx.info('rottenTomatoesUpcomingMovies: start', {
       trigger: ctx.trigger,
       dryRun: ctx.dryRun,
+      input: ctx.input ?? null,
     });
 
     await setProgress('load_settings', 'Loading settings…');
     const { settings, secrets } =
       await this.settingsService.getInternalSettings(ctx.userId);
-    const routeViaSeerr =
-      pickBool(settings, 'jobs.rottenTomatoesUpcomingMovies.routeViaSeerr') ??
-      false;
+    const normalizedSettings =
+      normalizeRottenTomatoesUpcomingSettings(settings);
+    const manualCategory = this.readManualCategory(ctx.input ?? null);
+    if (
+      ctx.input &&
+      Object.prototype.hasOwnProperty.call(ctx.input, 'category') &&
+      manualCategory === null
+    ) {
+      const message =
+        'Rotten Tomatoes Upcoming category must be either "movies" or "shows".';
+      await setProgress('failed', 'Invalid manual category.', {
+        manualCategory: ctx.input['category'] ?? null,
+      });
+      throw new Error(message);
+    }
 
-    await setProgress('scrape_sources', 'Scraping Rotten Tomatoes sources…', {
-      totalSources: ROTTEN_TOMATOES_SOURCE_URLS.length,
+    const effectiveIncludeMovies =
+      manualCategory === 'movies'
+        ? true
+        : manualCategory === 'shows'
+          ? false
+          : normalizedSettings.includeMovies;
+    const effectiveIncludeShows =
+      manualCategory === 'shows'
+        ? true
+        : manualCategory === 'movies'
+          ? false
+          : normalizedSettings.includeShows;
+
+    const reportIssues: JobReportV1['issues'] = [];
+    if (!effectiveIncludeMovies && !effectiveIncludeShows) {
+      reportIssues.push(
+        issue(
+          'warn',
+          'Movies and TV Shows are both disabled for Rotten Tomatoes Upcoming, so this run had nothing to do.',
+        ),
+      );
+    }
+
+    const movieBranch = effectiveIncludeMovies
+      ? await this.runMovieBranch({
+          ctx,
+          settings,
+          secrets,
+          routeViaSeerr: normalizedSettings.routeViaSeerr,
+          setProgress,
+          reportIssues,
+        })
+      : {
+          sourceStats: [],
+          dedupedMovies: [],
+          destinationStats: createEmptyDestinationStats(),
+          destinationTitles: createEmptyDestinationTitles(),
+          discoveryStatus: 'skipped' as JobReportTaskStatus,
+          routeStatus: 'skipped' as JobReportTaskStatus,
+          safeMatchSkipCount: 0,
+        };
+
+    const showBranch = effectiveIncludeShows
+      ? await this.runShowBranch({
+          ctx,
+          settings,
+          secrets,
+          routeViaSeerr: normalizedSettings.routeViaSeerr,
+          showLimit: normalizedSettings.showLimit,
+          setProgress,
+          reportIssues,
+        })
+      : {
+          sourceStats: [],
+          dedupedShows: [],
+          destinationStats: createEmptyDestinationStats(),
+          destinationTitles: createEmptyDestinationTitles(),
+          discoveryStatus: 'skipped' as JobReportTaskStatus,
+          routeStatus: 'skipped' as JobReportTaskStatus,
+          unresolvedIds: 0,
+          scoreFilteredOut: 0,
+          reconciliation: createEmptyShowReconciliation(),
+        };
+
+    if (movieBranch.destinationStats.failed > 0) {
+      reportIssues.push(
+        issue(
+          'warn',
+          `Movie destination reported ${movieBranch.destinationStats.failed} failed operation(s); the run continued.`,
+        ),
+      );
+    }
+    if (movieBranch.safeMatchSkipCount > 0 && !ctx.dryRun) {
+      reportIssues.push(
+        issue(
+          'warn',
+          `Some Rotten Tomatoes movies were skipped because Radarr lookup did not find a safe match (${movieBranch.safeMatchSkipCount}).`,
+        ),
+      );
+    }
+    if (showBranch.destinationStats.failed > 0) {
+      reportIssues.push(
+        issue(
+          'warn',
+          `TV destination reported ${showBranch.destinationStats.failed} failed operation(s); the run continued.`,
+        ),
+      );
+    }
+    if (showBranch.unresolvedIds > 0 && !ctx.dryRun) {
+      reportIssues.push(
+        issue(
+          'warn',
+          `Some Rotten Tomatoes TV shows were skipped because TMDB/TVDB ids could not be resolved safely (${showBranch.unresolvedIds}).`,
+        ),
+      );
+    }
+    if (showBranch.reconciliation.failures > 0) {
+      reportIssues.push(
+        issue(
+          'warn',
+          `Existing Sonarr show reconciliation reported ${showBranch.reconciliation.failures} failed operation(s); the run continued.`,
+        ),
+      );
+    }
+
+    const enabledBranchCount =
+      (effectiveIncludeMovies ? 1 : 0) + (effectiveIncludeShows ? 1 : 0);
+    const successfulDiscoveryCount =
+      (movieBranch.discoveryStatus === 'success' ? 1 : 0) +
+      (showBranch.discoveryStatus === 'success' ? 1 : 0);
+    const overallFailed =
+      enabledBranchCount > 0 && successfulDiscoveryCount === 0;
+
+    const report = this.buildReport({
+      ctx,
+      manualCategory,
+      effectiveIncludeMovies,
+      effectiveIncludeShows,
+      effectiveShowLimit: normalizedSettings.showLimit,
+      routeViaSeerr: normalizedSettings.routeViaSeerr,
+      movieBranch,
+      showBranch,
+      reportIssues,
     });
 
+    if (overallFailed) {
+      await setProgress(
+        'failed',
+        'No usable Rotten Tomatoes candidates were found for the selected branches.',
+        {
+          manualCategory,
+          effectiveIncludeMovies,
+          effectiveIncludeShows,
+          effectiveShowLimit: normalizedSettings.showLimit,
+        },
+      );
+      await ctx.info('rottenTomatoesUpcomingMovies: failed', {
+        manualCategory,
+        effectiveIncludeMovies,
+        effectiveIncludeShows,
+      });
+      return {
+        summary: report as unknown as JsonObject,
+      };
+    }
+
+    await setProgress('done', 'Done.', {
+      manualCategory,
+      effectiveIncludeMovies,
+      effectiveIncludeShows,
+      effectiveShowLimit: normalizedSettings.showLimit,
+      movieCandidates: movieBranch.dedupedMovies.length,
+      showCandidates: showBranch.dedupedShows.length,
+    });
+    await ctx.info('rottenTomatoesUpcomingMovies: done', {
+      manualCategory,
+      effectiveIncludeMovies,
+      effectiveIncludeShows,
+      movieDestinationStats: movieBranch.destinationStats,
+      showDestinationStats: showBranch.destinationStats,
+      showReconciliation: showBranch.reconciliation,
+    });
+
+    return {
+      summary: report as unknown as JsonObject,
+    };
+  }
+
+  private readManualCategory(input: JsonObject | null): ManualCategory | null {
+    const raw = input?.['category'];
+    if (typeof raw !== 'string') return null;
+    const normalized = raw.trim().toLowerCase();
+    if (normalized === 'movies') return 'movies';
+    if (normalized === 'shows') return 'shows';
+    return null;
+  }
+
+  private async runMovieBranch(params: {
+    ctx: JobContext;
+    settings: Record<string, unknown>;
+    secrets: Record<string, unknown>;
+    routeViaSeerr: boolean;
+    setProgress: (
+      step: string,
+      message: string,
+      context?: JsonObject,
+    ) => Promise<void>;
+    reportIssues: JobReportV1['issues'];
+  }): Promise<MovieBranchResult> {
+    const { ctx, settings, secrets, routeViaSeerr, setProgress, reportIssues } =
+      params;
+
+    await setProgress(
+      'scrape_movies',
+      'Scraping Rotten Tomatoes movie sources…',
+      {
+        totalSources: ROTTEN_TOMATOES_MOVIE_SOURCE_URLS.length,
+      },
+    );
+
     const scrapedMovies: ScrapedMovie[] = [];
-    const sourceStats: SourceScrapeStats[] = [];
-    const reportIssues: JobReportV1['issues'] = [];
+    const sourceStats: MovieSourceScrapeStats[] = [];
     let sourceFailureCount = 0;
 
-    for (const sourceUrl of ROTTEN_TOMATOES_SOURCE_URLS) {
+    for (const sourceUrl of ROTTEN_TOMATOES_MOVIE_SOURCE_URLS) {
       try {
         const html = await this.fetchSourceHtml(sourceUrl);
         const parsed = parseRottenTomatoesMoviesFromHtml({
@@ -421,11 +1022,11 @@ export class RottenTomatoesUpcomingMoviesJob {
         reportIssues.push(
           issue(
             'warn',
-            `Rotten Tomatoes source failed and was skipped: ${sourceUrl} (${error})`,
+            `Rotten Tomatoes movie source failed and was skipped: ${sourceUrl} (${error})`,
           ),
         );
         await ctx.warn(
-          'rottenTomatoesUpcomingMovies: source scrape failed (continuing)',
+          'rottenTomatoesUpcomingMovies: movie source scrape failed (continuing)',
           {
             sourceUrl,
             error,
@@ -435,61 +1036,30 @@ export class RottenTomatoesUpcomingMoviesJob {
     }
 
     const dedupedMovies = dedupeScrapedMovies(scrapedMovies);
-    const discoveryFailed =
-      sourceFailureCount === ROTTEN_TOMATOES_SOURCE_URLS.length ||
-      dedupedMovies.length === 0;
-
-    const destinationStats: DestinationStats = {
-      attempted: 0,
-      requested: 0,
-      added: 0,
-      exists: 0,
-      failed: 0,
-      skipped: 0,
-    };
-    const destinationTitles: DestinationTitleBuckets = {
-      attemptedTitles: [],
-      sentTitles: [],
-      existsTitles: [],
-      failedTitles: [],
-      skippedTitles: [],
-    };
-
-    if (discoveryFailed) {
+    if (
+      sourceFailureCount === ROTTEN_TOMATOES_MOVIE_SOURCE_URLS.length ||
+      dedupedMovies.length === 0
+    ) {
       reportIssues.push(
         issue(
           'error',
-          'Rotten Tomatoes discovery failed: all sources failed or no usable movie cards were parsed.',
+          'Rotten Tomatoes movie discovery failed: all movie sources failed or no usable movie cards were parsed.',
         ),
       );
-
-      const report = this.buildReport({
-        ctx,
+      return {
         sourceStats,
-        reportIssues,
         dedupedMovies,
-        destinationStats,
-        destinationTitles,
-        routeViaSeerr,
-        discoveryTaskStatus: 'failed',
-        prepareTaskStatus: 'skipped',
-        routeTaskStatus: 'skipped',
-      });
-
-      await setProgress('failed', 'No usable Rotten Tomatoes movies found.', {
-        sourceFailures: sourceFailureCount,
-        dedupedCandidates: dedupedMovies.length,
-      });
-
-      return { summary: report as unknown as JsonObject };
+        destinationStats: createEmptyDestinationStats(),
+        destinationTitles: createEmptyDestinationTitles(),
+        discoveryStatus: 'failed',
+        routeStatus: 'skipped',
+        safeMatchSkipCount: 0,
+      };
     }
 
-    let prepareTaskStatus: JobReportTaskStatus = ctx.dryRun
-      ? 'skipped'
-      : 'success';
-    let routeTaskStatus: JobReportTaskStatus = ctx.dryRun
-      ? 'skipped'
-      : 'success';
+    const destinationStats = createEmptyDestinationStats();
+    const destinationTitles = createEmptyDestinationTitles();
+    let routeStatus: JobReportTaskStatus = ctx.dryRun ? 'skipped' : 'success';
     let safeMatchSkipCount = 0;
     let radarrIndex: RadarrMovieIndex = {
       titleYearKeys: new Set(),
@@ -501,310 +1071,748 @@ export class RottenTomatoesUpcomingMoviesJob {
       destinationTitles.skippedTitles = normalizeTitleList(
         dedupedMovies.map((movie) => movie.title),
       );
-    } else {
-      await setProgress(
-        'prepare_radarr',
-        routeViaSeerr
-          ? 'Preparing Radarr lookup + Seerr routing…'
-          : 'Preparing Radarr routing…',
-        {
-          candidates: dedupedMovies.length,
-          routeViaSeerr,
-        },
+      return {
+        sourceStats,
+        dedupedMovies,
+        destinationStats,
+        destinationTitles,
+        discoveryStatus: 'success',
+        routeStatus,
+        safeMatchSkipCount,
+      };
+    }
+
+    await setProgress(
+      'route_movies',
+      routeViaSeerr ? 'Sending movies to Seerr…' : 'Sending movies to Radarr…',
+      {
+        candidates: dedupedMovies.length,
+        routeViaSeerr,
+      },
+    );
+
+    const radarrConfig = this.resolveRadarrConfig(settings, secrets);
+    if (!radarrConfig) {
+      destinationStats.skipped = dedupedMovies.length;
+      destinationTitles.skippedTitles = normalizeTitleList(
+        dedupedMovies.map((movie) => movie.title),
       );
+      routeStatus = 'skipped';
+      reportIssues.push(
+        issue(
+          'warn',
+          routeViaSeerr
+            ? 'Radarr lookup is required for Rotten Tomatoes movie Seerr routing, but Radarr is not configured; all movies were skipped.'
+            : 'Radarr is not configured; Rotten Tomatoes movie discovery completed but all movies were skipped.',
+        ),
+      );
+      return {
+        sourceStats,
+        dedupedMovies,
+        destinationStats,
+        destinationTitles,
+        discoveryStatus: 'success',
+        routeStatus,
+        safeMatchSkipCount,
+      };
+    }
 
-      const radarrConfig = this.resolveRadarrConfig(settings, secrets);
+    try {
+      const existingMovies = await this.radarr.listMovies(radarrConfig);
+      radarrIndex = buildRadarrMovieIndex(existingMovies);
+    } catch (err) {
+      const error = errToMessage(err);
+      reportIssues.push(
+        issue(
+          'warn',
+          `Radarr movie library snapshot failed; continuing with lookup/add safeguards only. (${error})`,
+        ),
+      );
+      await ctx.warn(
+        'rottenTomatoesUpcomingMovies: Radarr list movies failed (continuing)',
+        { error },
+      );
+    }
 
-      if (!radarrConfig) {
-        destinationStats.skipped = dedupedMovies.length;
-        destinationTitles.skippedTitles = normalizeTitleList(
-          dedupedMovies.map((movie) => movie.title),
+    const seerrConfig = routeViaSeerr
+      ? this.resolveSeerrConfig(settings, secrets)
+      : null;
+    const radarrDefaults = routeViaSeerr
+      ? null
+      : await this.pickRadarrDefaults({
+          settings,
+          radarrConfig,
+        }).catch((err) => ({ error: errToMessage(err) }));
+
+    if (routeViaSeerr && !seerrConfig) {
+      destinationStats.skipped = dedupedMovies.length;
+      destinationTitles.skippedTitles = normalizeTitleList(
+        dedupedMovies.map((movie) => movie.title),
+      );
+      routeStatus = 'skipped';
+      reportIssues.push(
+        issue(
+          'warn',
+          'Seerr route selected for Rotten Tomatoes movies but Seerr is not configured; all movies were skipped.',
+        ),
+      );
+      return {
+        sourceStats,
+        dedupedMovies,
+        destinationStats,
+        destinationTitles,
+        discoveryStatus: 'success',
+        routeStatus,
+        safeMatchSkipCount,
+      };
+    }
+
+    if (radarrDefaults && 'error' in radarrDefaults) {
+      destinationStats.skipped = dedupedMovies.length;
+      destinationTitles.skippedTitles = normalizeTitleList(
+        dedupedMovies.map((movie) => movie.title),
+      );
+      routeStatus = 'skipped';
+      reportIssues.push(
+        issue(
+          'warn',
+          `Radarr defaults could not be resolved for Rotten Tomatoes movies; all movies were skipped. (${radarrDefaults.error})`,
+        ),
+      );
+      return {
+        sourceStats,
+        dedupedMovies,
+        destinationStats,
+        destinationTitles,
+        discoveryStatus: 'success',
+        routeStatus,
+        safeMatchSkipCount,
+      };
+    }
+
+    for (const movie of dedupedMovies) {
+      const sourceKey = buildTitleYearKey(movie.title, movie.year);
+      if (radarrIndex.titleYearKeys.has(sourceKey)) {
+        destinationStats.exists += 1;
+        destinationTitles.existsTitles.push(movie.title);
+        continue;
+      }
+
+      const lookup = await this.lookupMovieWithFallback({
+        radarrConfig,
+        title: movie.title,
+        year: movie.year,
+      }).catch(async (err) => {
+        const error = errToMessage(err);
+        destinationStats.failed += 1;
+        destinationTitles.failedTitles.push(movie.title);
+        await ctx.warn(
+          'rottenTomatoesUpcomingMovies: Radarr movie lookup failed (continuing)',
+          {
+            title: movie.title,
+            year: movie.year,
+            error,
+          },
         );
-        prepareTaskStatus = 'skipped';
-        routeTaskStatus = 'skipped';
-        reportIssues.push(
-          issue(
-            'warn',
-            routeViaSeerr
-              ? 'Radarr lookup is required for Rotten Tomatoes Seerr routing, but Radarr is not configured; all movies were skipped.'
-              : 'Radarr is not configured; Rotten Tomatoes discovery completed but all movies were skipped.',
-          ),
-        );
-      } else {
-        try {
-          const existingMovies = await this.radarr.listMovies(radarrConfig);
-          radarrIndex = buildRadarrMovieIndex(existingMovies);
-        } catch (err) {
-          const error = errToMessage(err);
-          reportIssues.push(
-            issue(
-              'warn',
-              `Radarr library snapshot failed; continuing with lookup/add safeguards only. (${error})`,
-            ),
-          );
+        return null;
+      });
+
+      if (!lookup) {
+        if (!destinationTitles.failedTitles.includes(movie.title)) {
+          safeMatchSkipCount += 1;
+          destinationStats.skipped += 1;
+          destinationTitles.skippedTitles.push(movie.title);
           await ctx.warn(
-            'rottenTomatoesUpcomingMovies: Radarr list movies failed (continuing)',
-            { error },
-          );
-        }
-
-        const seerrConfig = routeViaSeerr
-          ? this.resolveSeerrConfig(settings, secrets)
-          : null;
-        const radarrDefaults = routeViaSeerr
-          ? null
-          : await this.pickRadarrDefaults({
-              settings,
-              radarrConfig,
-            }).catch((err) => ({ error: errToMessage(err) }));
-
-        if (routeViaSeerr && !seerrConfig) {
-          destinationStats.skipped = dedupedMovies.length;
-          destinationTitles.skippedTitles = normalizeTitleList(
-            dedupedMovies.map((movie) => movie.title),
-          );
-          prepareTaskStatus = 'skipped';
-          routeTaskStatus = 'skipped';
-          reportIssues.push(
-            issue(
-              'warn',
-              'Seerr route selected but Seerr is not configured; all movies were skipped.',
-            ),
-          );
-        } else if (radarrDefaults && 'error' in radarrDefaults) {
-          destinationStats.skipped = dedupedMovies.length;
-          destinationTitles.skippedTitles = normalizeTitleList(
-            dedupedMovies.map((movie) => movie.title),
-          );
-          prepareTaskStatus = 'skipped';
-          routeTaskStatus = 'skipped';
-          reportIssues.push(
-            issue(
-              'warn',
-              `Radarr defaults could not be resolved; all movies were skipped. (${radarrDefaults.error})`,
-            ),
-          );
-        } else {
-          await setProgress(
-            'route_movies',
-            routeViaSeerr
-              ? 'Sending movies to Seerr…'
-              : 'Sending movies to Radarr…',
+            'rottenTomatoesUpcomingMovies: no Radarr movie lookup match found',
             {
-              candidates: dedupedMovies.length,
-              routeViaSeerr,
-            },
-          );
-
-          for (const movie of dedupedMovies) {
-            const sourceKey = buildTitleYearKey(movie.title, movie.year);
-            if (radarrIndex.titleYearKeys.has(sourceKey)) {
-              destinationStats.exists += 1;
-              destinationTitles.existsTitles.push(movie.title);
-              continue;
-            }
-
-            const lookup = await this.lookupMovieWithFallback({
-              radarrConfig,
               title: movie.title,
               year: movie.year,
-            }).catch(async (err) => {
-              const error = errToMessage(err);
-              destinationStats.failed += 1;
-              destinationTitles.failedTitles.push(movie.title);
-              await ctx.warn(
-                'rottenTomatoesUpcomingMovies: Radarr lookup failed (continuing)',
-                {
-                  title: movie.title,
-                  year: movie.year,
-                  error,
-                },
-              );
-              return null;
-            });
-
-            if (!lookup) {
-              if (!destinationTitles.failedTitles.includes(movie.title)) {
-                safeMatchSkipCount += 1;
-                destinationStats.skipped += 1;
-                destinationTitles.skippedTitles.push(movie.title);
-                await ctx.warn(
-                  'rottenTomatoesUpcomingMovies: no Radarr lookup match found',
-                  {
-                    title: movie.title,
-                    year: movie.year,
-                  },
-                );
-              }
-              continue;
-            }
-
-            const lookupTitle =
-              typeof lookup.movie.title === 'string'
-                ? normalizeTitleForMatching(lookup.movie.title)
-                : movie.title;
-            const lookupYear = parseMaybeYear(lookup.movie.year);
-            const lookupTmdbId = parsePositiveInt(lookup.movie.tmdbId);
-            const lookupKey =
-              lookupYear !== null
-                ? buildTitleYearKey(lookupTitle, lookupYear)
-                : '';
-
-            if (lookupTmdbId === null) {
-              safeMatchSkipCount += 1;
-              destinationStats.skipped += 1;
-              destinationTitles.skippedTitles.push(lookupTitle);
-              await ctx.warn(
-                'rottenTomatoesUpcomingMovies: Radarr lookup returned no TMDB id',
-                {
-                  title: lookupTitle,
-                  year: lookupYear,
-                },
-              );
-              continue;
-            }
-
-            if (
-              radarrIndex.tmdbIds.has(lookupTmdbId) ||
-              (lookupKey && radarrIndex.titleYearKeys.has(lookupKey))
-            ) {
-              destinationStats.exists += 1;
-              destinationTitles.existsTitles.push(lookupTitle);
-              radarrIndex.tmdbIds.add(lookupTmdbId);
-              if (lookupKey) {
-                radarrIndex.titleYearKeys.add(lookupKey);
-              }
-              continue;
-            }
-
-            destinationStats.attempted += 1;
-            destinationTitles.attemptedTitles.push(lookupTitle);
-
-            if (routeViaSeerr) {
-              const result = await this.seerr.requestMovie({
-                baseUrl: seerrConfig!.baseUrl,
-                apiKey: seerrConfig!.apiKey,
-                tmdbId: lookupTmdbId,
-              });
-              if (result.status === 'requested') {
-                destinationStats.requested += 1;
-                destinationTitles.sentTitles.push(lookupTitle);
-                radarrIndex.tmdbIds.add(lookupTmdbId);
-                if (lookupKey) {
-                  radarrIndex.titleYearKeys.add(lookupKey);
-                }
-              } else if (result.status === 'exists') {
-                destinationStats.exists += 1;
-                destinationTitles.existsTitles.push(lookupTitle);
-                radarrIndex.tmdbIds.add(lookupTmdbId);
-                if (lookupKey) {
-                  radarrIndex.titleYearKeys.add(lookupKey);
-                }
-              } else {
-                destinationStats.failed += 1;
-                destinationTitles.failedTitles.push(lookupTitle);
-                await ctx.warn(
-                  'rottenTomatoesUpcomingMovies: Seerr request failed (continuing)',
-                  {
-                    title: lookupTitle,
-                    tmdbId: lookupTmdbId,
-                    error: result.error ?? 'unknown',
-                  },
-                );
-              }
-              continue;
-            }
-
-            try {
-              const result = await this.radarr.addMovie({
-                baseUrl: radarrConfig.baseUrl,
-                apiKey: radarrConfig.apiKey,
-                title: lookupTitle,
-                tmdbId: lookupTmdbId,
-                year: lookupYear,
-                qualityProfileId: radarrDefaults!.qualityProfileId,
-                rootFolderPath: radarrDefaults!.rootFolderPath,
-                tags: radarrDefaults!.tagIds,
-                monitored: true,
-                searchForMovie: true,
-              });
-              if (result.status === 'added') {
-                destinationStats.added += 1;
-                destinationTitles.sentTitles.push(lookupTitle);
-              } else {
-                destinationStats.exists += 1;
-                destinationTitles.existsTitles.push(lookupTitle);
-              }
-              radarrIndex.tmdbIds.add(lookupTmdbId);
-              if (lookupYear !== null) {
-                radarrIndex.titleYearKeys.add(
-                  buildTitleYearKey(lookupTitle, lookupYear),
-                );
-              }
-            } catch (err) {
-              destinationStats.failed += 1;
-              destinationTitles.failedTitles.push(lookupTitle);
-              await ctx.warn(
-                'rottenTomatoesUpcomingMovies: Radarr add failed (continuing)',
-                {
-                  title: lookupTitle,
-                  year: lookupYear,
-                  error: errToMessage(err),
-                },
-              );
-            }
-          }
+            },
+          );
         }
+        continue;
+      }
+
+      const lookupTitle =
+        typeof lookup.movie.title === 'string'
+          ? normalizeTitleForMatching(lookup.movie.title)
+          : movie.title;
+      const lookupYear = parseMaybeYear(lookup.movie.year);
+      const lookupTmdbId = parsePositiveInt(lookup.movie.tmdbId);
+      const lookupKey =
+        lookupYear !== null ? buildTitleYearKey(lookupTitle, lookupYear) : '';
+
+      if (lookupTmdbId === null) {
+        safeMatchSkipCount += 1;
+        destinationStats.skipped += 1;
+        destinationTitles.skippedTitles.push(lookupTitle);
+        await ctx.warn(
+          'rottenTomatoesUpcomingMovies: Radarr movie lookup returned no TMDB id',
+          {
+            title: lookupTitle,
+            year: lookupYear,
+          },
+        );
+        continue;
+      }
+
+      if (
+        radarrIndex.tmdbIds.has(lookupTmdbId) ||
+        (lookupKey && radarrIndex.titleYearKeys.has(lookupKey))
+      ) {
+        destinationStats.exists += 1;
+        destinationTitles.existsTitles.push(lookupTitle);
+        radarrIndex.tmdbIds.add(lookupTmdbId);
+        if (lookupKey) {
+          radarrIndex.titleYearKeys.add(lookupKey);
+        }
+        continue;
+      }
+
+      destinationStats.attempted += 1;
+      destinationTitles.attemptedTitles.push(lookupTitle);
+
+      if (routeViaSeerr) {
+        const result = await this.seerr.requestMovie({
+          baseUrl: seerrConfig!.baseUrl,
+          apiKey: seerrConfig!.apiKey,
+          tmdbId: lookupTmdbId,
+        });
+        if (result.status === 'requested') {
+          destinationStats.requested += 1;
+          destinationTitles.sentTitles.push(lookupTitle);
+          radarrIndex.tmdbIds.add(lookupTmdbId);
+          if (lookupKey) {
+            radarrIndex.titleYearKeys.add(lookupKey);
+          }
+        } else if (result.status === 'exists') {
+          destinationStats.exists += 1;
+          destinationTitles.existsTitles.push(lookupTitle);
+          radarrIndex.tmdbIds.add(lookupTmdbId);
+          if (lookupKey) {
+            radarrIndex.titleYearKeys.add(lookupKey);
+          }
+        } else {
+          destinationStats.failed += 1;
+          destinationTitles.failedTitles.push(lookupTitle);
+          await ctx.warn(
+            'rottenTomatoesUpcomingMovies: Seerr movie request failed (continuing)',
+            {
+              title: lookupTitle,
+              tmdbId: lookupTmdbId,
+              error: result.error ?? 'unknown',
+            },
+          );
+        }
+        continue;
+      }
+
+      try {
+        const result = await this.radarr.addMovie({
+          baseUrl: radarrConfig.baseUrl,
+          apiKey: radarrConfig.apiKey,
+          title: lookupTitle,
+          tmdbId: lookupTmdbId,
+          year: lookupYear,
+          qualityProfileId: radarrDefaults!.qualityProfileId,
+          rootFolderPath: radarrDefaults!.rootFolderPath,
+          tags: radarrDefaults!.tagIds,
+          monitored: true,
+          searchForMovie: true,
+        });
+        if (result.status === 'added') {
+          destinationStats.added += 1;
+          destinationTitles.sentTitles.push(lookupTitle);
+        } else {
+          destinationStats.exists += 1;
+          destinationTitles.existsTitles.push(lookupTitle);
+        }
+        radarrIndex.tmdbIds.add(lookupTmdbId);
+        if (lookupYear !== null) {
+          radarrIndex.titleYearKeys.add(
+            buildTitleYearKey(lookupTitle, lookupYear),
+          );
+        }
+      } catch (err) {
+        destinationStats.failed += 1;
+        destinationTitles.failedTitles.push(lookupTitle);
+        await ctx.warn(
+          'rottenTomatoesUpcomingMovies: Radarr movie add failed (continuing)',
+          {
+            title: lookupTitle,
+            year: lookupYear,
+            error: errToMessage(err),
+          },
+        );
       }
     }
 
-    if (destinationStats.failed > 0) {
-      reportIssues.push(
-        issue(
-          'warn',
-          `Destination reported ${destinationStats.failed} failed operation(s); the run continued.`,
-        ),
-      );
-    }
-
-    if (safeMatchSkipCount > 0 && !ctx.dryRun) {
-      reportIssues.push(
-        issue(
-          'warn',
-          `Some Rotten Tomatoes movies were skipped because Radarr lookup did not find a safe match (${safeMatchSkipCount}).`,
-        ),
-      );
-    }
-
-    const report = this.buildReport({
-      ctx,
+    return {
       sourceStats,
-      reportIssues,
       dedupedMovies,
       destinationStats,
       destinationTitles,
+      discoveryStatus: 'success',
+      routeStatus,
+      safeMatchSkipCount,
+    };
+  }
+
+  private async runShowBranch(params: {
+    ctx: JobContext;
+    settings: Record<string, unknown>;
+    secrets: Record<string, unknown>;
+    routeViaSeerr: boolean;
+    showLimit: number;
+    setProgress: (
+      step: string,
+      message: string,
+      context?: JsonObject,
+    ) => Promise<void>;
+    reportIssues: JobReportV1['issues'];
+  }): Promise<ShowBranchResult> {
+    const {
+      ctx,
+      settings,
+      secrets,
       routeViaSeerr,
-      discoveryTaskStatus: 'success',
-      prepareTaskStatus,
-      routeTaskStatus,
+      showLimit,
+      setProgress,
+      reportIssues,
+    } = params;
+
+    await setProgress('scrape_shows', 'Scraping Rotten Tomatoes TV sources…', {
+      totalSources: ROTTEN_TOMATOES_SHOW_SOURCE_URLS.length,
+      showLimit,
     });
 
-    await setProgress('done', 'Done.', {
-      dedupedCandidates: dedupedMovies.length,
-      destinationAttempted: destinationStats.attempted,
-      destinationAdded: destinationStats.added,
-      destinationRequested: destinationStats.requested,
-      destinationExists: destinationStats.exists,
-      destinationFailed: destinationStats.failed,
-      destinationSkipped: destinationStats.skipped,
-    });
-    await ctx.info('rottenTomatoesUpcomingMovies: done', {
-      dedupedCandidates: dedupedMovies.length,
-      destinationStats,
-    });
+    const scrapedShows: ScrapedShow[] = [];
+    const sourceStats: ShowSourceScrapeStats[] = [];
+    let sourceFailureCount = 0;
+    let scoreFilteredOut = 0;
+
+    for (const sourceUrl of ROTTEN_TOMATOES_SHOW_SOURCE_URLS) {
+      try {
+        const html = await this.fetchSourceHtml(sourceUrl);
+        const parsed = parseRottenTomatoesShowsFromHtml({
+          html,
+          sourceUrl,
+        });
+        const qualifiedShows = parsed.shows.filter((show) => {
+          const criticsScore = show.criticsScore;
+          const audienceScore = show.audienceScore;
+          return (
+            criticsScore !== null &&
+            audienceScore !== null &&
+            criticsScore >= MINIMUM_RT_SCORE &&
+            audienceScore >= MINIMUM_RT_SCORE
+          );
+        });
+        const filteredOut = parsed.shows.length - qualifiedShows.length;
+        scoreFilteredOut += filteredOut;
+        scrapedShows.push(...qualifiedShows);
+        sourceStats.push({
+          url: sourceUrl,
+          discoveredEntries: parsed.discoveredEntries,
+          parseableEntries: parsed.shows.length,
+          scoreFilteredOut: filteredOut,
+          failed: false,
+          error: null,
+        });
+
+        if (dedupeScrapedShows(scrapedShows).length >= showLimit) {
+          break;
+        }
+      } catch (err) {
+        const error = errToMessage(err);
+        sourceFailureCount += 1;
+        sourceStats.push({
+          url: sourceUrl,
+          discoveredEntries: 0,
+          parseableEntries: 0,
+          scoreFilteredOut: 0,
+          failed: true,
+          error,
+        });
+        reportIssues.push(
+          issue(
+            'warn',
+            `Rotten Tomatoes TV source failed and was skipped: ${sourceUrl} (${error})`,
+          ),
+        );
+        await ctx.warn(
+          'rottenTomatoesUpcomingMovies: TV source scrape failed (continuing)',
+          {
+            sourceUrl,
+            error,
+          },
+        );
+      }
+    }
+
+    const dedupedShows = dedupeScrapedShows(scrapedShows).slice(0, showLimit);
+    if (
+      sourceFailureCount === ROTTEN_TOMATOES_SHOW_SOURCE_URLS.length ||
+      dedupedShows.length === 0
+    ) {
+      reportIssues.push(
+        issue(
+          'error',
+          'Rotten Tomatoes TV discovery failed: all TV sources failed or no score-qualified TV cards were parsed.',
+        ),
+      );
+      return {
+        sourceStats,
+        dedupedShows,
+        destinationStats: createEmptyDestinationStats(),
+        destinationTitles: createEmptyDestinationTitles(),
+        discoveryStatus: 'failed',
+        routeStatus: 'skipped',
+        unresolvedIds: 0,
+        scoreFilteredOut,
+        reconciliation: createEmptyShowReconciliation(),
+      };
+    }
+
+    const destinationStats = createEmptyDestinationStats();
+    const destinationTitles = createEmptyDestinationTitles();
+    const reconciliation = createEmptyShowReconciliation();
+    let routeStatus: JobReportTaskStatus = ctx.dryRun ? 'skipped' : 'success';
+    let unresolvedIds = 0;
+
+    if (ctx.dryRun) {
+      destinationStats.skipped = dedupedShows.length;
+      destinationTitles.skippedTitles = normalizeTitleList(
+        dedupedShows.map((show) => show.title),
+      );
+      return {
+        sourceStats,
+        dedupedShows,
+        destinationStats,
+        destinationTitles,
+        discoveryStatus: 'success',
+        routeStatus,
+        unresolvedIds,
+        scoreFilteredOut,
+        reconciliation,
+      };
+    }
+
+    await setProgress(
+      'route_shows',
+      routeViaSeerr
+        ? 'Requesting TV shows in Seerr and reconciling existing Sonarr series…'
+        : 'Sending TV shows to Sonarr and reconciling existing series…',
+      {
+        candidates: dedupedShows.length,
+        routeViaSeerr,
+        showLimit,
+      },
+    );
+
+    const tmdbApiKey = this.settingsService.readServiceSecret('tmdb', secrets);
+    if (!tmdbApiKey) {
+      destinationStats.skipped = dedupedShows.length;
+      destinationTitles.skippedTitles = normalizeTitleList(
+        dedupedShows.map((show) => show.title),
+      );
+      routeStatus = 'skipped';
+      reportIssues.push(
+        issue(
+          'warn',
+          'TMDB is not configured; Rotten Tomatoes TV discovery completed but all TV shows were skipped.',
+        ),
+      );
+      return {
+        sourceStats,
+        dedupedShows,
+        destinationStats,
+        destinationTitles,
+        discoveryStatus: 'success',
+        routeStatus,
+        unresolvedIds,
+        scoreFilteredOut,
+        reconciliation,
+      };
+    }
+
+    const sonarrConfig = this.resolveSonarrConfig(settings, secrets);
+    const seerrConfig = routeViaSeerr
+      ? this.resolveSeerrConfig(settings, secrets)
+      : null;
+    const sonarrDefaults =
+      !routeViaSeerr && sonarrConfig
+        ? await this.pickSonarrDefaults({
+            settings,
+            sonarrConfig,
+          }).catch((err) => ({ error: errToMessage(err) }))
+        : null;
+    const plexConfig = this.resolvePlexConfig(settings, secrets);
+    const caches: ShowBranchCaches = {
+      sonarrIndexByTvdb: null,
+      plexTvdbRatingKeys: undefined,
+      showEpisodeAvailability: new Map(),
+      partProbeCache: new Map(),
+      warnedMissingPlexConfig: false,
+    };
+
+    if (routeViaSeerr && !seerrConfig && !sonarrConfig) {
+      destinationStats.skipped = dedupedShows.length;
+      destinationTitles.skippedTitles = normalizeTitleList(
+        dedupedShows.map((show) => show.title),
+      );
+      routeStatus = 'skipped';
+      reportIssues.push(
+        issue(
+          'warn',
+          'Seerr route selected for Rotten Tomatoes TV but neither Seerr nor Sonarr is configured; all TV shows were skipped.',
+        ),
+      );
+      return {
+        sourceStats,
+        dedupedShows,
+        destinationStats,
+        destinationTitles,
+        discoveryStatus: 'success',
+        routeStatus,
+        unresolvedIds,
+        scoreFilteredOut,
+        reconciliation,
+      };
+    }
+
+    if (!routeViaSeerr && !sonarrConfig) {
+      destinationStats.skipped = dedupedShows.length;
+      destinationTitles.skippedTitles = normalizeTitleList(
+        dedupedShows.map((show) => show.title),
+      );
+      routeStatus = 'skipped';
+      reportIssues.push(
+        issue(
+          'warn',
+          'Sonarr is not configured; Rotten Tomatoes TV discovery completed but all TV shows were skipped.',
+        ),
+      );
+      return {
+        sourceStats,
+        dedupedShows,
+        destinationStats,
+        destinationTitles,
+        discoveryStatus: 'success',
+        routeStatus,
+        unresolvedIds,
+        scoreFilteredOut,
+        reconciliation,
+      };
+    }
+
+    if (!routeViaSeerr && sonarrDefaults && 'error' in sonarrDefaults) {
+      reportIssues.push(
+        issue(
+          'warn',
+          `Sonarr defaults could not be resolved for Rotten Tomatoes TV; new-show adds will be skipped. (${sonarrDefaults.error})`,
+        ),
+      );
+    }
+
+    if (routeViaSeerr && !seerrConfig) {
+      reportIssues.push(
+        issue(
+          'warn',
+          'Seerr route selected for Rotten Tomatoes TV but Seerr is not configured; only existing Sonarr series reconciliation can continue.',
+        ),
+      );
+    }
+
+    if (sonarrConfig) {
+      try {
+        const existingSeries = await this.sonarr.listSeries(sonarrConfig);
+        caches.sonarrIndexByTvdb = buildSonarrSeriesIndex(existingSeries);
+      } catch (err) {
+        const error = errToMessage(err);
+        reportIssues.push(
+          issue(
+            'warn',
+            `Sonarr series index failed for Rotten Tomatoes TV; existing-series reconciliation may be limited. (${error})`,
+          ),
+        );
+        await ctx.warn(
+          'rottenTomatoesUpcomingMovies: Sonarr series index failed (continuing)',
+          { error },
+        );
+      }
+    }
+
+    for (const show of dedupedShows) {
+      const resolved = await this.resolveShowIds({
+        ctx,
+        tmdbApiKey,
+        title: show.title,
+        year: show.year,
+      }).catch(async (err) => {
+        await ctx.warn(
+          'rottenTomatoesUpcomingMovies: TMDB TV resolution failed (continuing)',
+          {
+            title: show.title,
+            year: show.year,
+            error: errToMessage(err),
+          },
+        );
+        return null;
+      });
+
+      if (!resolved) {
+        unresolvedIds += 1;
+        destinationStats.skipped += 1;
+        destinationTitles.skippedTitles.push(show.title);
+        await ctx.warn(
+          'rottenTomatoesUpcomingMovies: unresolved TMDB/TVDB ids for TV show',
+          {
+            title: show.title,
+            year: show.year,
+            href: show.href,
+          },
+        );
+        continue;
+      }
+
+      const existingSeries =
+        caches.sonarrIndexByTvdb?.get(resolved.tvdbId) ?? null;
+      if (existingSeries) {
+        destinationStats.exists += 1;
+        destinationTitles.existsTitles.push(resolved.title);
+        if (sonarrConfig) {
+          const stats = await this.reconcileExistingSonarrSeries({
+            ctx,
+            sonarrConfig,
+            plexConfig,
+            series: existingSeries,
+            caches,
+          });
+          addShowReconciliation(reconciliation, stats);
+        }
+        continue;
+      }
+
+      if (routeViaSeerr) {
+        if (!seerrConfig) {
+          destinationStats.skipped += 1;
+          destinationTitles.skippedTitles.push(resolved.title);
+          continue;
+        }
+
+        destinationStats.attempted += 1;
+        destinationTitles.attemptedTitles.push(resolved.title);
+        const result = await this.seerr.requestTvAllSeasons({
+          baseUrl: seerrConfig.baseUrl,
+          apiKey: seerrConfig.apiKey,
+          tmdbId: resolved.tmdbId,
+          tvdbId: resolved.tvdbId,
+        });
+        if (result.status === 'requested') {
+          destinationStats.requested += 1;
+          destinationTitles.sentTitles.push(resolved.title);
+        } else if (result.status === 'exists') {
+          destinationStats.exists += 1;
+          destinationTitles.existsTitles.push(resolved.title);
+        } else {
+          destinationStats.failed += 1;
+          destinationTitles.failedTitles.push(resolved.title);
+          await ctx.warn(
+            'rottenTomatoesUpcomingMovies: Seerr TV request failed (continuing)',
+            {
+              title: resolved.title,
+              tmdbId: resolved.tmdbId,
+              tvdbId: resolved.tvdbId,
+              error: result.error ?? 'unknown',
+            },
+          );
+        }
+        continue;
+      }
+
+      if (!sonarrConfig || !sonarrDefaults || 'error' in sonarrDefaults) {
+        destinationStats.skipped += 1;
+        destinationTitles.skippedTitles.push(resolved.title);
+        continue;
+      }
+
+      destinationStats.attempted += 1;
+      destinationTitles.attemptedTitles.push(resolved.title);
+      try {
+        const result = await this.sonarr.addSeries({
+          baseUrl: sonarrConfig.baseUrl,
+          apiKey: sonarrConfig.apiKey,
+          title: resolved.title,
+          tvdbId: resolved.tvdbId,
+          qualityProfileId: sonarrDefaults.qualityProfileId,
+          rootFolderPath: sonarrDefaults.rootFolderPath,
+          tags: sonarrDefaults.tagIds,
+          monitored: true,
+          searchForMissingEpisodes: true,
+          searchForCutoffUnmetEpisodes: true,
+        });
+        if (result.status === 'added') {
+          destinationStats.added += 1;
+          destinationTitles.sentTitles.push(resolved.title);
+        } else {
+          destinationStats.exists += 1;
+          destinationTitles.existsTitles.push(resolved.title);
+          if (caches.sonarrIndexByTvdb === null) {
+            try {
+              caches.sonarrIndexByTvdb = buildSonarrSeriesIndex(
+                await this.sonarr.listSeries(sonarrConfig),
+              );
+            } catch {
+              caches.sonarrIndexByTvdb = null;
+            }
+          }
+          const refreshedExisting =
+            caches.sonarrIndexByTvdb?.get(resolved.tvdbId) ?? null;
+          if (refreshedExisting) {
+            const stats = await this.reconcileExistingSonarrSeries({
+              ctx,
+              sonarrConfig,
+              plexConfig,
+              series: refreshedExisting,
+              caches,
+            });
+            addShowReconciliation(reconciliation, stats);
+          }
+        }
+      } catch (err) {
+        destinationStats.failed += 1;
+        destinationTitles.failedTitles.push(resolved.title);
+        await ctx.warn(
+          'rottenTomatoesUpcomingMovies: Sonarr TV add failed (continuing)',
+          {
+            title: resolved.title,
+            tvdbId: resolved.tvdbId,
+            error: errToMessage(err),
+          },
+        );
+      }
+    }
+
+    if (
+      destinationStats.attempted === 0 &&
+      destinationStats.exists === 0 &&
+      reconciliation.reconciledSeries === 0 &&
+      destinationStats.failed === 0
+    ) {
+      routeStatus = 'skipped';
+    }
 
     return {
-      summary: report as unknown as JsonObject,
+      sourceStats,
+      dedupedShows,
+      destinationStats,
+      destinationTitles,
+      discoveryStatus: 'success',
+      routeStatus,
+      unresolvedIds,
+      scoreFilteredOut,
+      reconciliation,
     };
   }
 
@@ -850,6 +1858,24 @@ export class RottenTomatoesUpcomingMoviesJob {
     return { baseUrl, apiKey };
   }
 
+  private resolveSonarrConfig(
+    settings: Record<string, unknown>,
+    secrets: Record<string, unknown>,
+  ): SonarrConfig | null {
+    const baseUrl =
+      pickString(settings, 'sonarr.baseUrl') ||
+      pickString(settings, 'sonarr.url');
+    const apiKey = this.settingsService.readServiceSecret('sonarr', secrets);
+    const enabledSetting = pickBool(settings, 'sonarr.enabled');
+    const enabled = (enabledSetting ?? Boolean(apiKey)) === true;
+
+    if (!enabled || !baseUrl || !apiKey) {
+      return null;
+    }
+
+    return { baseUrl, apiKey };
+  }
+
   private resolveSeerrConfig(
     settings: Record<string, unknown>,
     secrets: Record<string, unknown>,
@@ -866,6 +1892,17 @@ export class RottenTomatoesUpcomingMoviesJob {
     }
 
     return { baseUrl, apiKey };
+  }
+
+  private resolvePlexConfig(
+    settings: Record<string, unknown>,
+    secrets: Record<string, unknown>,
+  ): PlexConfig | null {
+    const baseUrl =
+      pickString(settings, 'plex.baseUrl') || pickString(settings, 'plex.url');
+    const token = this.settingsService.readServiceSecret('plex', secrets);
+    if (!baseUrl || !token) return null;
+    return { baseUrl, token };
   }
 
   private async pickRadarrDefaults(params: {
@@ -899,6 +1936,58 @@ export class RottenTomatoesUpcomingMoviesJob {
     const preferredTagId =
       pickNumber(params.settings, 'radarr.defaultTagId') ??
       pickNumber(params.settings, 'radarr.tagId');
+
+    const rootFolder = preferredRootFolderPath
+      ? (rootFolders.find((row) => row.path === preferredRootFolderPath) ??
+        rootFolders[0])
+      : rootFolders[0];
+    const qualityProfile =
+      qualityProfiles.find(
+        (row) => row.id === Math.max(1, Math.trunc(preferredQualityProfileId)),
+      ) ?? qualityProfiles[0];
+    const tag =
+      preferredTagId !== null
+        ? tags.find((row) => row.id === Math.max(1, Math.trunc(preferredTagId)))
+        : null;
+
+    return {
+      rootFolderPath: rootFolder.path,
+      qualityProfileId: qualityProfile.id,
+      tagIds: tag ? [tag.id] : [],
+    };
+  }
+
+  private async pickSonarrDefaults(params: {
+    settings: Record<string, unknown>;
+    sonarrConfig: SonarrConfig;
+  }): Promise<{
+    rootFolderPath: string;
+    qualityProfileId: number;
+    tagIds: number[];
+  }> {
+    const [rootFolders, qualityProfiles, tags] = await Promise.all([
+      this.sonarr.listRootFolders(params.sonarrConfig),
+      this.sonarr.listQualityProfiles(params.sonarrConfig),
+      this.sonarr.listTags(params.sonarrConfig),
+    ]);
+
+    if (!rootFolders.length) {
+      throw new Error('Sonarr has no root folders configured');
+    }
+    if (!qualityProfiles.length) {
+      throw new Error('Sonarr has no quality profiles configured');
+    }
+
+    const preferredRootFolderPath =
+      pickString(params.settings, 'sonarr.defaultRootFolderPath') ||
+      pickString(params.settings, 'sonarr.rootFolderPath');
+    const preferredQualityProfileId =
+      pickNumber(params.settings, 'sonarr.defaultQualityProfileId') ??
+      pickNumber(params.settings, 'sonarr.qualityProfileId') ??
+      1;
+    const preferredTagId =
+      pickNumber(params.settings, 'sonarr.defaultTagId') ??
+      pickNumber(params.settings, 'sonarr.tagId');
 
     const rootFolder = preferredRootFolderPath
       ? (rootFolders.find((row) => row.path === preferredRootFolderPath) ??
@@ -954,44 +2043,458 @@ export class RottenTomatoesUpcomingMoviesJob {
     return { movie: fallbackMatch, usedTitleOnlyFallback: true };
   }
 
+  private async resolveShowIds(params: {
+    ctx: JobContext;
+    tmdbApiKey: string;
+    title: string;
+    year: string | null;
+  }): Promise<ResolvedShowIds | null> {
+    const requestedYear = parseMaybeYear(params.year);
+    const strictResults = await this.tmdb.searchTv({
+      apiKey: params.tmdbApiKey,
+      query: params.title,
+      includeAdult: false,
+      firstAirDateYear: requestedYear,
+    });
+    let match = selectTmdbTvMatch(strictResults, params.title, params.year);
+
+    if (!match && requestedYear !== null) {
+      const fallbackResults = await this.tmdb.searchTv({
+        apiKey: params.tmdbApiKey,
+        query: params.title,
+        includeAdult: false,
+        firstAirDateYear: null,
+      });
+      match = selectTmdbTvMatch(fallbackResults, params.title, params.year);
+    }
+
+    if (!match) return null;
+
+    const externalIds = await this.tmdb.getTvExternalIds({
+      apiKey: params.tmdbApiKey,
+      tmdbId: match.id,
+    });
+    const tvdbId = parsePositiveInt(externalIds?.tvdb_id);
+    if (!tvdbId) return null;
+
+    return {
+      title: normalizeTitleForMatching(match.name),
+      tmdbId: Math.trunc(match.id),
+      tvdbId,
+      year: extractYearFromText(match.first_air_date),
+    };
+  }
+
+  private async ensurePlexTvdbRatingKeys(params: {
+    ctx: JobContext;
+    plexConfig: PlexConfig | null;
+    caches: ShowBranchCaches;
+  }): Promise<Map<number, string[]> | null> {
+    if (params.caches.plexTvdbRatingKeys !== undefined) {
+      return params.caches.plexTvdbRatingKeys ?? null;
+    }
+    if (!params.plexConfig) {
+      params.caches.plexTvdbRatingKeys = null;
+      return null;
+    }
+
+    const sections = await this.plexServer.getSections({
+      baseUrl: params.plexConfig.baseUrl,
+      token: params.plexConfig.token,
+    });
+    const tvSections = sections.filter(
+      (section) => (section.type ?? '').toLowerCase() === 'show',
+    );
+
+    const out = new Map<number, string[]>();
+    for (const section of tvSections) {
+      const map = await this.plexServer.getTvdbShowRatingKeysMapForSectionKey({
+        baseUrl: params.plexConfig.baseUrl,
+        token: params.plexConfig.token,
+        librarySectionKey: section.key,
+        sectionTitle: section.title,
+      });
+      for (const [tvdbId, ratingKeys] of map.entries()) {
+        const previous = out.get(tvdbId) ?? [];
+        for (const ratingKey of ratingKeys) {
+          if (!previous.includes(ratingKey)) previous.push(ratingKey);
+        }
+        out.set(tvdbId, previous);
+      }
+    }
+
+    params.caches.plexTvdbRatingKeys = out;
+    await params.ctx.info(
+      'rottenTomatoesUpcomingMovies: built Plex TVDB show map for TV reconciliation',
+      {
+        tvLibraries: tvSections.map((section) => section.title),
+        tvdbShows: out.size,
+      },
+    );
+    return out;
+  }
+
+  private async getVerifiedEpisodesForShow(params: {
+    ctx: JobContext;
+    plexConfig: PlexConfig;
+    showRatingKey: string;
+    caches: ShowBranchCaches;
+  }): Promise<PlexVerifiedEpisodeAvailability> {
+    const cached = params.caches.showEpisodeAvailability.get(
+      params.showRatingKey,
+    );
+    if (cached) return cached;
+
+    try {
+      const availability =
+        await this.plexServer.getVerifiedEpisodeAvailabilityForShowRatingKey({
+          baseUrl: params.plexConfig.baseUrl,
+          token: params.plexConfig.token,
+          showRatingKey: params.showRatingKey,
+          partProbeCache: params.caches.partProbeCache,
+        });
+      params.caches.showEpisodeAvailability.set(
+        params.showRatingKey,
+        availability,
+      );
+      return availability;
+    } catch (err) {
+      const fallback = {
+        verifiedEpisodes: new Set<string>(),
+        metadataEpisodes: new Set<string>(),
+        probeFailureCount: 1,
+      };
+      params.caches.showEpisodeAvailability.set(params.showRatingKey, fallback);
+      await params.ctx.warn(
+        'rottenTomatoesUpcomingMovies: failed verifying Plex show episode availability',
+        {
+          showRatingKey: params.showRatingKey,
+          error: errToMessage(err),
+        },
+      );
+      return fallback;
+    }
+  }
+
+  private async reconcileExistingSonarrSeries(params: {
+    ctx: JobContext;
+    sonarrConfig: SonarrConfig;
+    plexConfig: PlexConfig | null;
+    series: SonarrSeries;
+    caches: ShowBranchCaches;
+  }): Promise<ShowReconciliationStats> {
+    const out = createEmptyShowReconciliation();
+    out.reconciledSeries = 1;
+
+    if (!params.plexConfig) {
+      if (!params.caches.warnedMissingPlexConfig) {
+        params.caches.warnedMissingPlexConfig = true;
+        await params.ctx.warn(
+          'rottenTomatoesUpcomingMovies: Plex is not configured; existing Sonarr series reconciliation was skipped',
+        );
+      }
+      return out;
+    }
+
+    const tvdbId = parsePositiveInt(params.series.tvdbId);
+    if (!tvdbId) {
+      out.failures += 1;
+      await params.ctx.warn(
+        'rottenTomatoesUpcomingMovies: existing Sonarr series missing tvdbId; skipping reconciliation',
+        {
+          seriesId: params.series.id,
+          title:
+            typeof params.series.title === 'string'
+              ? params.series.title
+              : null,
+        },
+      );
+      return out;
+    }
+
+    const plexTvdbRatingKeys = await this.ensurePlexTvdbRatingKeys({
+      ctx: params.ctx,
+      plexConfig: params.plexConfig,
+      caches: params.caches,
+    }).catch(async (err) => {
+      out.failures += 1;
+      await params.ctx.warn(
+        'rottenTomatoesUpcomingMovies: failed building Plex TVDB index for reconciliation',
+        {
+          tvdbId,
+          error: errToMessage(err),
+        },
+      );
+      return null;
+    });
+    if (!plexTvdbRatingKeys) {
+      return out;
+    }
+
+    const showRatingKeys = plexTvdbRatingKeys.get(tvdbId) ?? [];
+    const verifiedEpisodes = new Set<string>();
+    for (const ratingKey of showRatingKeys) {
+      const availability = await this.getVerifiedEpisodesForShow({
+        ctx: params.ctx,
+        plexConfig: params.plexConfig,
+        showRatingKey: ratingKey,
+        caches: params.caches,
+      });
+      for (const key of availability.verifiedEpisodes) {
+        verifiedEpisodes.add(key);
+      }
+    }
+
+    const episodes = await this.sonarr
+      .getEpisodesBySeries({
+        baseUrl: params.sonarrConfig.baseUrl,
+        apiKey: params.sonarrConfig.apiKey,
+        seriesId: params.series.id,
+      })
+      .catch(async (err) => {
+        out.failures += 1;
+        await params.ctx.warn(
+          'rottenTomatoesUpcomingMovies: failed loading Sonarr episodes for reconciliation',
+          {
+            tvdbId,
+            seriesId: params.series.id,
+            error: errToMessage(err),
+          },
+        );
+        return null;
+      });
+    if (!episodes) {
+      return out;
+    }
+
+    const positiveSeasonNumbers = new Set<number>();
+    const seasonState = new Map<
+      number,
+      { hasEpisodes: boolean; hasMissingEpisodes: boolean }
+    >();
+
+    let seriesHasMissingEpisodes = false;
+
+    for (const episode of episodes) {
+      const season = parsePositiveInt(episode.seasonNumber);
+      const episodeNumber = parsePositiveInt(episode.episodeNumber);
+      if (!season || !episodeNumber) continue;
+
+      positiveSeasonNumbers.add(season);
+      const key = episodeKey(season, episodeNumber);
+      const inPlex = verifiedEpisodes.has(key);
+      const targetMonitored = !inPlex;
+      const currentMonitored = Boolean(episode.monitored);
+      let finalMonitored = currentMonitored;
+
+      const currentSeasonState = seasonState.get(season) ?? {
+        hasEpisodes: false,
+        hasMissingEpisodes: false,
+      };
+      currentSeasonState.hasEpisodes = true;
+      currentSeasonState.hasMissingEpisodes ||= !inPlex;
+      seasonState.set(season, currentSeasonState);
+      seriesHasMissingEpisodes ||= !inPlex;
+
+      if (currentMonitored !== targetMonitored) {
+        if (params.ctx.dryRun) {
+          finalMonitored = targetMonitored;
+        } else {
+          const updated = await this.updateEpisodeMonitoring({
+            ctx: params.ctx,
+            sonarrConfig: params.sonarrConfig,
+            episode,
+            monitored: targetMonitored,
+            series: params.series,
+            tvdbId,
+          });
+          if (updated) {
+            finalMonitored = targetMonitored;
+          } else {
+            out.failures += 1;
+          }
+        }
+      } else {
+        finalMonitored = targetMonitored;
+      }
+
+      if (finalMonitored) {
+        out.episodesMonitored += 1;
+      } else {
+        out.episodesLeftUnmonitored += 1;
+      }
+    }
+
+    if (!positiveSeasonNumbers.size) {
+      return out;
+    }
+
+    const nextSeries: SonarrSeries = {
+      ...params.series,
+      seasons: Array.isArray(params.series.seasons)
+        ? params.series.seasons.map((seasonEntry) => {
+            const seasonNumber = parsePositiveInt(seasonEntry.seasonNumber);
+            if (!seasonNumber || !positiveSeasonNumbers.has(seasonNumber)) {
+              return { ...seasonEntry };
+            }
+            const state = seasonState.get(seasonNumber);
+            const targetMonitored = Boolean(state?.hasMissingEpisodes);
+            return { ...seasonEntry, monitored: targetMonitored };
+          })
+        : params.series.seasons,
+      monitored: seriesHasMissingEpisodes,
+    };
+
+    const seasonsChanged = Array.isArray(params.series.seasons)
+      ? params.series.seasons.some((seasonEntry, index) => {
+          const seasonNumber = parsePositiveInt(seasonEntry.seasonNumber);
+          if (!seasonNumber || !positiveSeasonNumbers.has(seasonNumber)) {
+            return false;
+          }
+          const nextSeason = Array.isArray(nextSeries.seasons)
+            ? nextSeries.seasons[index]
+            : null;
+          return (
+            Boolean(seasonEntry.monitored) !== Boolean(nextSeason?.monitored)
+          );
+        })
+      : false;
+    const seriesChanged =
+      Boolean(params.series.monitored) !== Boolean(nextSeries.monitored);
+
+    let seriesUpdateApplied = !seasonsChanged && !seriesChanged;
+    if ((seasonsChanged || seriesChanged) && !params.ctx.dryRun) {
+      seriesUpdateApplied = await this.sonarr
+        .updateSeries({
+          baseUrl: params.sonarrConfig.baseUrl,
+          apiKey: params.sonarrConfig.apiKey,
+          series: nextSeries,
+        })
+        .then(() => true)
+        .catch(async (err) => {
+          out.failures += 1;
+          await params.ctx.warn(
+            'rottenTomatoesUpcomingMovies: failed updating Sonarr series during reconciliation',
+            {
+              tvdbId,
+              seriesId: params.series.id,
+              error: errToMessage(err),
+            },
+          );
+          return false;
+        });
+    } else if (params.ctx.dryRun && (seasonsChanged || seriesChanged)) {
+      seriesUpdateApplied = true;
+    }
+
+    const finalSeries = seriesUpdateApplied ? nextSeries : params.series;
+    const finalSeasons = Array.isArray(finalSeries.seasons)
+      ? finalSeries.seasons
+      : [];
+
+    for (const seasonNumber of positiveSeasonNumbers) {
+      const seasonEntry = finalSeasons.find(
+        (row) => parsePositiveInt(row.seasonNumber) === seasonNumber,
+      );
+      if (seasonEntry?.monitored) {
+        out.seasonsMonitored += 1;
+      } else {
+        out.seasonsUnmonitored += 1;
+      }
+    }
+
+    if (finalSeries.monitored) {
+      out.seriesMonitored += 1;
+    } else {
+      out.seriesUnmonitored += 1;
+    }
+
+    return out;
+  }
+
+  private async updateEpisodeMonitoring(params: {
+    ctx: JobContext;
+    sonarrConfig: SonarrConfig;
+    episode: SonarrEpisode;
+    monitored: boolean;
+    series: SonarrSeries;
+    tvdbId: number;
+  }): Promise<boolean> {
+    return this.sonarr
+      .setEpisodeMonitored({
+        baseUrl: params.sonarrConfig.baseUrl,
+        apiKey: params.sonarrConfig.apiKey,
+        episode: params.episode,
+        monitored: params.monitored,
+      })
+      .then(() => true)
+      .catch(async (err) => {
+        await params.ctx.warn(
+          'rottenTomatoesUpcomingMovies: failed updating Sonarr episode monitoring during reconciliation',
+          {
+            tvdbId: params.tvdbId,
+            seriesId: params.series.id,
+            season: parsePositiveInt(params.episode.seasonNumber),
+            episode: parsePositiveInt(params.episode.episodeNumber),
+            monitored: params.monitored,
+            error: errToMessage(err),
+          },
+        );
+        return false;
+      });
+  }
+
   private buildReport(params: {
     ctx: JobContext;
-    sourceStats: SourceScrapeStats[];
-    reportIssues: JobReportV1['issues'];
-    dedupedMovies: ScrapedMovie[];
-    destinationStats: DestinationStats;
-    destinationTitles: DestinationTitleBuckets;
+    manualCategory: ManualCategory | null;
+    effectiveIncludeMovies: boolean;
+    effectiveIncludeShows: boolean;
+    effectiveShowLimit: number;
     routeViaSeerr: boolean;
-    discoveryTaskStatus: JobReportTaskStatus;
-    prepareTaskStatus: JobReportTaskStatus;
-    routeTaskStatus: JobReportTaskStatus;
+    movieBranch: MovieBranchResult;
+    showBranch: ShowBranchResult;
+    reportIssues: JobReportV1['issues'];
   }): JobReportV1 {
-    const totalDiscoveredEntries = params.sourceStats.reduce(
+    const movieSourceFailures = params.movieBranch.sourceStats.filter(
+      (source) => source.failed,
+    ).length;
+    const movieDiscoveredEntries = params.movieBranch.sourceStats.reduce(
       (sum, source) => sum + source.discoveredEntries,
       0,
     );
-    const totalParseableEntries = params.sourceStats.reduce(
+    const movieParseableEntries = params.movieBranch.sourceStats.reduce(
       (sum, source) => sum + source.parseableEntries,
       0,
     );
-    const totalSkippedNoYear = params.sourceStats.reduce(
+    const movieSkippedNoYear = params.movieBranch.sourceStats.reduce(
       (sum, source) => sum + source.skippedNoYear,
       0,
     );
-    const totalSourceFailures = params.sourceStats.filter(
+
+    const showSourceFailures = params.showBranch.sourceStats.filter(
       (source) => source.failed,
     ).length;
-    const sourceFacts = sourceStatsFact(params.sourceStats);
-    const destinationName = params.routeViaSeerr ? 'Seerr' : 'Radarr';
-    const destinationSectionTitle = params.routeViaSeerr
-      ? 'Seerr requests'
-      : 'Radarr adds';
-    const destinationSuccessLabel = params.routeViaSeerr
+    const showDiscoveredEntries = params.showBranch.sourceStats.reduce(
+      (sum, source) => sum + source.discoveredEntries,
+      0,
+    );
+    const showParseableEntries = params.showBranch.sourceStats.reduce(
+      (sum, source) => sum + source.parseableEntries,
+      0,
+    );
+
+    const movieDestinationSuccessLabel = params.routeViaSeerr
       ? 'Requested'
       : 'Added';
-    const destinationSuccessCount = params.routeViaSeerr
-      ? params.destinationStats.requested
-      : params.destinationStats.added;
+    const movieDestinationSuccessCount = params.routeViaSeerr
+      ? params.movieBranch.destinationStats.requested
+      : params.movieBranch.destinationStats.added;
+    const showDestinationSuccessLabel = params.routeViaSeerr
+      ? 'Requested'
+      : 'Added';
+    const showDestinationSuccessCount = params.routeViaSeerr
+      ? params.showBranch.destinationStats.requested
+      : params.showBranch.destinationStats.added;
 
     return {
       template: 'jobReportV1',
@@ -1002,79 +2505,207 @@ export class RottenTomatoesUpcomingMoviesJob {
       headline: ROTTEN_TOMATOES_UPCOMING_JOB_HEADLINE,
       sections: [
         {
-          id: 'discovery',
-          title: 'Discovery',
+          id: 'movies',
+          title: 'Movies',
           rows: [
             metricRow({
               label: 'Source pages',
               start: 0,
-              changed: params.sourceStats.length,
-              end: params.sourceStats.length,
+              changed: params.movieBranch.sourceStats.length,
+              end: params.movieBranch.sourceStats.length,
               unit: 'pages',
-              note: `Failures: ${totalSourceFailures}`,
+              note: `Failures: ${movieSourceFailures}`,
             }),
             metricRow({
               label: 'Discovered entries',
               start: 0,
-              changed: totalDiscoveredEntries,
-              end: totalDiscoveredEntries,
+              changed: movieDiscoveredEntries,
+              end: movieDiscoveredEntries,
               unit: 'movies',
             }),
             metricRow({
               label: 'Parseable entries',
               start: 0,
-              changed: totalParseableEntries,
-              end: totalParseableEntries,
+              changed: movieParseableEntries,
+              end: movieParseableEntries,
               unit: 'movies',
-              note: `Skipped without usable year: ${totalSkippedNoYear}`,
+              note: `Skipped without usable year: ${movieSkippedNoYear}`,
             }),
             metricRow({
               label: 'Merged and deduped',
               start: 0,
-              changed: params.dedupedMovies.length,
-              end: params.dedupedMovies.length,
+              changed: params.movieBranch.dedupedMovies.length,
+              end: params.movieBranch.dedupedMovies.length,
               unit: 'movies',
             }),
-          ],
-        },
-        {
-          id: 'destination',
-          title: destinationSectionTitle,
-          rows: [
             metricRow({
               label: 'Attempted',
               start: 0,
-              changed: params.destinationStats.attempted,
-              end: params.destinationStats.attempted,
+              changed: params.movieBranch.destinationStats.attempted,
+              end: params.movieBranch.destinationStats.attempted,
               unit: 'movies',
             }),
             metricRow({
-              label: destinationSuccessLabel,
+              label: movieDestinationSuccessLabel,
               start: 0,
-              changed: destinationSuccessCount,
-              end: destinationSuccessCount,
+              changed: movieDestinationSuccessCount,
+              end: movieDestinationSuccessCount,
               unit: 'movies',
             }),
             metricRow({
               label: 'Already exists',
               start: 0,
-              changed: params.destinationStats.exists,
-              end: params.destinationStats.exists,
+              changed: params.movieBranch.destinationStats.exists,
+              end: params.movieBranch.destinationStats.exists,
               unit: 'movies',
             }),
             metricRow({
               label: 'Failed',
               start: 0,
-              changed: params.destinationStats.failed,
-              end: params.destinationStats.failed,
+              changed: params.movieBranch.destinationStats.failed,
+              end: params.movieBranch.destinationStats.failed,
               unit: 'movies',
             }),
             metricRow({
               label: 'Skipped',
               start: 0,
-              changed: params.destinationStats.skipped,
-              end: params.destinationStats.skipped,
+              changed: params.movieBranch.destinationStats.skipped,
+              end: params.movieBranch.destinationStats.skipped,
               unit: 'movies',
+            }),
+          ],
+        },
+        {
+          id: 'shows',
+          title: 'TV Shows',
+          rows: [
+            metricRow({
+              label: 'Source pages',
+              start: 0,
+              changed: params.showBranch.sourceStats.length,
+              end: params.showBranch.sourceStats.length,
+              unit: 'pages',
+              note: `Failures: ${showSourceFailures}`,
+            }),
+            metricRow({
+              label: 'Discovered entries',
+              start: 0,
+              changed: showDiscoveredEntries,
+              end: showDiscoveredEntries,
+              unit: 'shows',
+            }),
+            metricRow({
+              label: 'Parsed entries',
+              start: 0,
+              changed: showParseableEntries,
+              end: showParseableEntries,
+              unit: 'shows',
+            }),
+            metricRow({
+              label: 'Score-filtered out',
+              start: 0,
+              changed: params.showBranch.scoreFilteredOut,
+              end: params.showBranch.scoreFilteredOut,
+              unit: 'shows',
+            }),
+            metricRow({
+              label: 'Merged and deduped',
+              start: 0,
+              changed: params.showBranch.dedupedShows.length,
+              end: params.showBranch.dedupedShows.length,
+              unit: 'shows',
+              note: `Limit: ${params.effectiveShowLimit}`,
+            }),
+            metricRow({
+              label: 'Attempted',
+              start: 0,
+              changed: params.showBranch.destinationStats.attempted,
+              end: params.showBranch.destinationStats.attempted,
+              unit: 'shows',
+            }),
+            metricRow({
+              label: showDestinationSuccessLabel,
+              start: 0,
+              changed: showDestinationSuccessCount,
+              end: showDestinationSuccessCount,
+              unit: 'shows',
+            }),
+            metricRow({
+              label: 'Already exists',
+              start: 0,
+              changed: params.showBranch.destinationStats.exists,
+              end: params.showBranch.destinationStats.exists,
+              unit: 'shows',
+            }),
+            metricRow({
+              label: 'Unresolved IDs',
+              start: 0,
+              changed: params.showBranch.unresolvedIds,
+              end: params.showBranch.unresolvedIds,
+              unit: 'shows',
+            }),
+            metricRow({
+              label: 'Failed',
+              start: 0,
+              changed: params.showBranch.destinationStats.failed,
+              end: params.showBranch.destinationStats.failed,
+              unit: 'shows',
+            }),
+            metricRow({
+              label: 'Skipped',
+              start: 0,
+              changed: params.showBranch.destinationStats.skipped,
+              end: params.showBranch.destinationStats.skipped,
+              unit: 'shows',
+            }),
+            metricRow({
+              label: 'Reconciled existing series',
+              start: 0,
+              changed: params.showBranch.reconciliation.reconciledSeries,
+              end: params.showBranch.reconciliation.reconciledSeries,
+              unit: 'series',
+            }),
+            metricRow({
+              label: 'Episodes monitored',
+              start: 0,
+              changed: params.showBranch.reconciliation.episodesMonitored,
+              end: params.showBranch.reconciliation.episodesMonitored,
+              unit: 'episodes',
+            }),
+            metricRow({
+              label: 'Episodes left unmonitored',
+              start: 0,
+              changed: params.showBranch.reconciliation.episodesLeftUnmonitored,
+              end: params.showBranch.reconciliation.episodesLeftUnmonitored,
+              unit: 'episodes',
+            }),
+            metricRow({
+              label: 'Seasons monitored',
+              start: 0,
+              changed: params.showBranch.reconciliation.seasonsMonitored,
+              end: params.showBranch.reconciliation.seasonsMonitored,
+              unit: 'seasons',
+            }),
+            metricRow({
+              label: 'Seasons unmonitored',
+              start: 0,
+              changed: params.showBranch.reconciliation.seasonsUnmonitored,
+              end: params.showBranch.reconciliation.seasonsUnmonitored,
+              unit: 'seasons',
+            }),
+            metricRow({
+              label: 'Series monitored',
+              start: 0,
+              changed: params.showBranch.reconciliation.seriesMonitored,
+              end: params.showBranch.reconciliation.seriesMonitored,
+              unit: 'series',
+            }),
+            metricRow({
+              label: 'Series unmonitored',
+              start: 0,
+              changed: params.showBranch.reconciliation.seriesUnmonitored,
+              end: params.showBranch.reconciliation.seriesUnmonitored,
+              unit: 'series',
             }),
           ],
         },
@@ -1084,34 +2715,51 @@ export class RottenTomatoesUpcomingMoviesJob {
           id: 'load_settings',
           title: 'Load settings',
           status: 'success',
+          facts: [
+            {
+              label: 'Manual category',
+              value: params.manualCategory ?? 'scheduled/default',
+            },
+            {
+              label: 'Movies enabled',
+              value: params.effectiveIncludeMovies,
+            },
+            {
+              label: 'TV enabled',
+              value: params.effectiveIncludeShows,
+            },
+            {
+              label: 'TV limit',
+              value: params.effectiveShowLimit,
+            },
+            {
+              label: 'Route via Seerr',
+              value: params.routeViaSeerr,
+            },
+          ],
         },
         {
-          id: 'scrape_sources',
-          title: 'Scrape Rotten Tomatoes sources',
-          status: params.discoveryTaskStatus,
-          facts: sourceFacts,
-        },
-        {
-          id: 'prepare_radarr',
-          title: params.routeViaSeerr
-            ? 'Prepare Radarr lookup + Seerr routing'
-            : 'Prepare Radarr routing',
-          status: params.prepareTaskStatus,
+          id: 'scrape_movies',
+          title: 'Scrape Rotten Tomatoes movie sources',
+          status: params.movieBranch.discoveryStatus,
+          facts: movieSourceStatsFacts(params.movieBranch.sourceStats),
         },
         {
           id: 'route_movies',
-          title: params.routeViaSeerr ? 'Send to Seerr' : 'Send to Radarr',
-          status: params.routeTaskStatus,
+          title: params.routeViaSeerr
+            ? 'Send movies to Seerr'
+            : 'Send movies to Radarr',
+          status: params.movieBranch.routeStatus,
           facts: [
             {
               label: params.routeViaSeerr
                 ? 'Attempted requests'
                 : 'Attempted adds',
               value: {
-                count: params.destinationStats.attempted,
+                count: params.movieBranch.destinationStats.attempted,
                 unit: 'movies',
                 items: normalizeTitleList(
-                  params.destinationTitles.attemptedTitles,
+                  params.movieBranch.destinationTitles.attemptedTitles,
                 ),
               },
             },
@@ -1120,39 +2768,142 @@ export class RottenTomatoesUpcomingMoviesJob {
                 ? 'Requested in Seerr'
                 : 'Added in Radarr',
               value: {
-                count: destinationSuccessCount,
+                count: movieDestinationSuccessCount,
                 unit: 'movies',
-                items: normalizeTitleList(params.destinationTitles.sentTitles),
+                items: normalizeTitleList(
+                  params.movieBranch.destinationTitles.sentTitles,
+                ),
               },
             },
             {
               label: 'Already exists',
               value: {
-                count: params.destinationStats.exists,
+                count: params.movieBranch.destinationStats.exists,
                 unit: 'movies',
                 items: normalizeTitleList(
-                  params.destinationTitles.existsTitles,
+                  params.movieBranch.destinationTitles.existsTitles,
                 ),
               },
             },
             {
-              label: 'Failed adds',
+              label: 'Failed sends',
               value: {
-                count: params.destinationStats.failed,
+                count: params.movieBranch.destinationStats.failed,
                 unit: 'movies',
                 items: normalizeTitleList(
-                  params.destinationTitles.failedTitles,
+                  params.movieBranch.destinationTitles.failedTitles,
                 ),
               },
             },
             {
               label: 'Skipped sends',
               value: {
-                count: params.destinationStats.skipped,
+                count: params.movieBranch.destinationStats.skipped,
                 unit: 'movies',
                 items: normalizeTitleList(
-                  params.destinationTitles.skippedTitles,
+                  params.movieBranch.destinationTitles.skippedTitles,
                 ),
+              },
+            },
+          ],
+        },
+        {
+          id: 'scrape_shows',
+          title: 'Scrape Rotten Tomatoes TV sources',
+          status: params.showBranch.discoveryStatus,
+          facts: showSourceStatsFacts(params.showBranch.sourceStats),
+        },
+        {
+          id: 'route_shows',
+          title: params.routeViaSeerr
+            ? 'Request TV shows in Seerr + reconcile existing Sonarr series'
+            : 'Send TV shows to Sonarr + reconcile existing series',
+          status: params.showBranch.routeStatus,
+          facts: [
+            {
+              label: params.routeViaSeerr
+                ? 'Attempted requests'
+                : 'Attempted adds',
+              value: {
+                count: params.showBranch.destinationStats.attempted,
+                unit: 'shows',
+                items: normalizeTitleList(
+                  params.showBranch.destinationTitles.attemptedTitles,
+                ),
+              },
+            },
+            {
+              label: params.routeViaSeerr
+                ? 'Requested in Seerr'
+                : 'Added in Sonarr',
+              value: {
+                count: showDestinationSuccessCount,
+                unit: 'shows',
+                items: normalizeTitleList(
+                  params.showBranch.destinationTitles.sentTitles,
+                ),
+              },
+            },
+            {
+              label: 'Already exists',
+              value: {
+                count: params.showBranch.destinationStats.exists,
+                unit: 'shows',
+                items: normalizeTitleList(
+                  params.showBranch.destinationTitles.existsTitles,
+                ),
+              },
+            },
+            {
+              label: 'Unresolved IDs',
+              value: {
+                count: params.showBranch.unresolvedIds,
+                unit: 'shows',
+                items: [],
+              },
+            },
+            {
+              label: 'Failed sends',
+              value: {
+                count: params.showBranch.destinationStats.failed,
+                unit: 'shows',
+                items: normalizeTitleList(
+                  params.showBranch.destinationTitles.failedTitles,
+                ),
+              },
+            },
+            {
+              label: 'Skipped sends',
+              value: {
+                count: params.showBranch.destinationStats.skipped,
+                unit: 'shows',
+                items: normalizeTitleList(
+                  params.showBranch.destinationTitles.skippedTitles,
+                ),
+              },
+            },
+            {
+              label: 'Reconciled series',
+              value: {
+                count: params.showBranch.reconciliation.reconciledSeries,
+                unit: 'series',
+                items: [],
+              },
+            },
+            {
+              label: 'Episodes monitored',
+              value: {
+                count: params.showBranch.reconciliation.episodesMonitored,
+                unit: 'episodes',
+                items: [],
+              },
+            },
+            {
+              label: 'Episodes left unmonitored',
+              value: {
+                count: params.showBranch.reconciliation.episodesLeftUnmonitored,
+                unit: 'episodes',
+                items: [],
               },
             },
           ],
@@ -1160,31 +2911,88 @@ export class RottenTomatoesUpcomingMoviesJob {
       ],
       issues: params.reportIssues,
       raw: {
-        sourceStats: params.sourceStats.map((source) => ({
-          url: source.url,
-          discoveredEntries: source.discoveredEntries,
-          parseableEntries: source.parseableEntries,
-          skippedNoYear: source.skippedNoYear,
-          failed: source.failed,
-          error: source.error,
-        })),
-        sampleCandidates: params.dedupedMovies.slice(0, 25).map((movie) => ({
-          title: movie.title,
-          year: movie.year,
-          href: movie.href,
-          sourceUrl: movie.sourceUrl,
-        })),
+        manualCategory: params.manualCategory,
+        effectiveIncludeMovies: params.effectiveIncludeMovies,
+        effectiveIncludeShows: params.effectiveIncludeShows,
+        effectiveShowLimit: params.effectiveShowLimit,
         routeViaSeerr: params.routeViaSeerr,
-        destinationName,
-        destinationStats: params.destinationStats,
-        destinationTitleBuckets: {
-          attempted: normalizeTitleList(
-            params.destinationTitles.attemptedTitles,
-          ),
-          sent: normalizeTitleList(params.destinationTitles.sentTitles),
-          exists: normalizeTitleList(params.destinationTitles.existsTitles),
-          failed: normalizeTitleList(params.destinationTitles.failedTitles),
-          skipped: normalizeTitleList(params.destinationTitles.skippedTitles),
+        movies: {
+          sourceStats: params.movieBranch.sourceStats.map((source) => ({
+            url: source.url,
+            discoveredEntries: source.discoveredEntries,
+            parseableEntries: source.parseableEntries,
+            skippedNoYear: source.skippedNoYear,
+            failed: source.failed,
+            error: source.error,
+          })),
+          sampleCandidates: params.movieBranch.dedupedMovies
+            .slice(0, 25)
+            .map((movie) => ({
+              title: movie.title,
+              year: movie.year,
+              href: movie.href,
+              sourceUrl: movie.sourceUrl,
+            })),
+          destinationStats: params.movieBranch.destinationStats,
+          destinationTitleBuckets: {
+            attempted: normalizeTitleList(
+              params.movieBranch.destinationTitles.attemptedTitles,
+            ),
+            sent: normalizeTitleList(
+              params.movieBranch.destinationTitles.sentTitles,
+            ),
+            exists: normalizeTitleList(
+              params.movieBranch.destinationTitles.existsTitles,
+            ),
+            failed: normalizeTitleList(
+              params.movieBranch.destinationTitles.failedTitles,
+            ),
+            skipped: normalizeTitleList(
+              params.movieBranch.destinationTitles.skippedTitles,
+            ),
+          },
+          safeMatchSkips: params.movieBranch.safeMatchSkipCount,
+        },
+        shows: {
+          sourceStats: params.showBranch.sourceStats.map((source) => ({
+            url: source.url,
+            discoveredEntries: source.discoveredEntries,
+            parseableEntries: source.parseableEntries,
+            scoreFilteredOut: source.scoreFilteredOut,
+            failed: source.failed,
+            error: source.error,
+          })),
+          sampleCandidates: params.showBranch.dedupedShows
+            .slice(0, 25)
+            .map((show) => ({
+              title: show.title,
+              year: show.year,
+              href: show.href,
+              criticsScore: show.criticsScore,
+              audienceScore: show.audienceScore,
+              sourceUrl: show.sourceUrl,
+            })),
+          destinationStats: params.showBranch.destinationStats,
+          destinationTitleBuckets: {
+            attempted: normalizeTitleList(
+              params.showBranch.destinationTitles.attemptedTitles,
+            ),
+            sent: normalizeTitleList(
+              params.showBranch.destinationTitles.sentTitles,
+            ),
+            exists: normalizeTitleList(
+              params.showBranch.destinationTitles.existsTitles,
+            ),
+            failed: normalizeTitleList(
+              params.showBranch.destinationTitles.failedTitles,
+            ),
+            skipped: normalizeTitleList(
+              params.showBranch.destinationTitles.skippedTitles,
+            ),
+          },
+          unresolvedIds: params.showBranch.unresolvedIds,
+          scoreFilteredOut: params.showBranch.scoreFilteredOut,
+          reconciliation: params.showBranch.reconciliation,
         },
       },
     };

--- a/apps/api/src/version.ts
+++ b/apps/api/src/version.ts
@@ -1,6 +1,6 @@
 // Single source of truth for the app version.
 // Bump this constant only.
 
-export const APP_VERSION = '1.7.8-beta-4' as const;
+export const APP_VERSION = '1.7.8-beta-5' as const;
 
 export const APP_VERSION_TAG = `v${APP_VERSION}` as const;

--- a/apps/web/src/lib/version-history.ts
+++ b/apps/web/src/lib/version-history.ts
@@ -37,6 +37,25 @@ export function splitVersionHistoryLabel(
 
 export const VERSION_HISTORY_ENTRIES: VersionHistoryEntry[] = [
   {
+    version: '1.7.8-beta-5',
+    popupHighlights: [
+      'Rotten Tomatoes Upcoming Movies now supports TV shows with a saved Top 10 control you can raise or lower.',
+      'Manual Run now lets you choose the Rotten Tomatoes movie or TV branch for one-off runs without changing saved settings.',
+      'Route via Seerr now applies to both Rotten Tomatoes movies and TV shows, and saved auto-runs always process movies before TV.',
+    ],
+    sections: [
+      {
+        title: 'Rotten Tomatoes Upcoming Movies + TV',
+        bullets: [
+          'The Rotten Tomatoes Task Manager card now saves Movies, TV Shows, and a TV Top count. TV defaults to Top 10, stays visible on the expanded card, and controls how many score-qualified, deduplicated TV candidates are considered across the fixed TV sources.',
+          'Manual Run now opens a Movies or TV Shows chooser for this task. Manual TV runs reuse the saved Top count, while saved scheduled and auto-runs use the card settings and always run movies first, then TV.',
+          'Route via Seerr now applies to both media types: movies still require safe Radarr lookup first, and new TV shows go to Seerr instead of falling back to direct Sonarr adds when Seerr mode is enabled.',
+          'Existing Sonarr shows can still be reconciled against Plex so present episodes stay unmonitored, missing episodes remain monitored, and Rewind now shows separate movie and TV stages plus TV-specific routing and reconciliation stats.',
+        ],
+      },
+    ],
+  },
+  {
     version: '1.7.8-beta-4',
     popupHighlights: [
       'Confirm Monitored now requires Plex-verified playable media and runs Sonarr cascade in episode, season, then series order.',

--- a/apps/web/src/lib/version-history.ts
+++ b/apps/web/src/lib/version-history.ts
@@ -39,28 +39,11 @@ export const VERSION_HISTORY_ENTRIES: VersionHistoryEntry[] = [
   {
     version: '1.7.8-beta-5',
     popupHighlights: [
-      'Rotten Tomatoes Upcoming Movies now supports TV shows with a saved Top 10 control you can raise or lower.',
-      'Manual Run now lets you choose the Rotten Tomatoes movie or TV branch for one-off runs without changing saved settings.',
-      'Route via Seerr now applies to both Rotten Tomatoes movies and TV shows, and saved auto-runs always process movies before TV.',
-    ],
-    sections: [
-      {
-        title: 'Rotten Tomatoes Upcoming Movies + TV',
-        bullets: [
-          'The Rotten Tomatoes Task Manager card now saves Movies, TV Shows, and a TV Top count. TV defaults to Top 10, stays visible on the expanded card, and controls how many score-qualified, deduplicated TV candidates are considered across the fixed TV sources.',
-          'Manual Run now opens a Movies or TV Shows chooser for this task. Manual TV runs reuse the saved Top count, while saved scheduled and auto-runs use the card settings and always run movies first, then TV.',
-          'Route via Seerr now applies to both media types: movies still require safe Radarr lookup first, and new TV shows go to Seerr instead of falling back to direct Sonarr adds when Seerr mode is enabled.',
-          'Existing Sonarr shows can still be reconciled against Plex so present episodes stay unmonitored, missing episodes remain monitored, and Rewind now shows separate movie and TV stages plus TV-specific routing and reconciliation stats.',
-        ],
-      },
-    ],
-  },
-  {
-    version: '1.7.8-beta-4',
-    popupHighlights: [
       'Confirm Monitored now requires Plex-verified playable media and runs Sonarr cascade in episode, season, then series order.',
       'Netflix import no longer fails when legacy databases are missing the releaseDate column.',
-      "Rotten Tomatoes scraper: upcoming-movie discovery works again with Rotten Tomatoes' current movie-card markup.",
+      'Rotten Tomatoes Upcoming Movies + TV Shows now saves separate Movie Top 20 and TV Top 10 counts on the task card.',
+      'Manual Run for Rotten Tomatoes now includes one-run Movies or TV selection, Route via Seerr, and a Top count without changing saved settings.',
+      'Rotten Tomatoes movie discovery now respects the saved or one-run Movie Top count, while saved auto-runs still process movies before TV.',
     ],
     sections: [
       {
@@ -79,11 +62,14 @@ export const VERSION_HISTORY_ENTRIES: VersionHistoryEntry[] = [
         ],
       },
       {
-        title: 'Rotten Tomatoes upcoming movies reliability',
+        title: 'Rotten Tomatoes Upcoming Movies + TV Shows',
         bullets: [
-          "Fixed Rotten Tomatoes upcoming-movie discovery so current browse pages using the newer rt-text movie-card markup are parsed again.",
-          'The scraper now accepts the tagged field wrapper instead of assuming legacy span-only title and start-date markup.',
-          'This restores normal discovery for the Rotten Tomatoes Upcoming Movies job when source pages load successfully.',
+          "Rotten Tomatoes upcoming movie discovery now works with the current browse-page markup using the newer rt-text field wrappers instead of assuming legacy span-only cards.",
+          'The task is now presented as Rotten Tomatoes Upcoming Movies + TV Shows, and the expanded card now saves Movies, TV Shows, Movie Top, and TV Top values. Movies default to Top 20, TV defaults to Top 10, and both ranges can be set from 1 to 100.',
+          'Manual Run now opens a Movies or TV Shows chooser with a one-run Route via Seerr toggle and a one-run Top count. The dialog starts from the saved Seerr setting plus Top 10 every time and does not change the saved card settings.',
+          'Movie discovery now stops once the deduplicated movie pool reaches the effective Movie Top count, matching the existing TV-stop behavior. Saved scheduled and auto-runs still use the card settings and always run movies first, then TV.',
+          'Route via Seerr now applies to both media types: movies still require safe Radarr lookup first, and new TV shows go to Seerr instead of falling back to direct Sonarr adds when Seerr mode is enabled.',
+          'Existing Sonarr shows can still be reconciled against Plex so present episodes stay unmonitored, missing episodes remain monitored, and Rewind now shows separate movie and TV stages plus TV-specific routing and reconciliation stats.',
         ],
       },
     ],

--- a/apps/web/src/lib/version-history.ts
+++ b/apps/web/src/lib/version-history.ts
@@ -41,6 +41,7 @@ export const VERSION_HISTORY_ENTRIES: VersionHistoryEntry[] = [
     popupHighlights: [
       'Confirm Monitored now requires Plex-verified playable media and runs Sonarr cascade in episode, season, then series order.',
       'Netflix import no longer fails when legacy databases are missing the releaseDate column.',
+      "Rotten Tomatoes scraper: upcoming-movie discovery works again with Rotten Tomatoes' current movie-card markup.",
     ],
     sections: [
       {
@@ -56,6 +57,14 @@ export const VERSION_HISTORY_ENTRIES: VersionHistoryEntry[] = [
         bullets: [
           'Preserved releaseDate and firstAirDate when rebuilding ImmaculateTasteMovieLibrary and ImmaculateTasteShowLibrary so imports stop failing with "column does not exist".',
           'Added an idempotent ensure step that backfills releaseDate and firstAirDate on older SQLite databases regardless of migration history state.',
+        ],
+      },
+      {
+        title: 'Rotten Tomatoes upcoming movies reliability',
+        bullets: [
+          "Fixed Rotten Tomatoes upcoming-movie discovery so current browse pages using the newer rt-text movie-card markup are parsed again.",
+          'The scraper now accepts the tagged field wrapper instead of assuming legacy span-only title and start-date markup.',
+          'This restores normal discovery for the Rotten Tomatoes Upcoming Movies job when source pages load successfully.',
         ],
       },
     ],

--- a/apps/web/src/pages/FaqPage.tsx
+++ b/apps/web/src/pages/FaqPage.tsx
@@ -793,19 +793,27 @@ export const FaqPage = () => {
           answer: (
             <>
               <p>
-                This task scrapes fixed Rotten Tomatoes upcoming and newest movie pages, merges the
-                results, and routes safe matches to Radarr or, when enabled, to Seerr.
+                This task can run movie discovery, TV discovery, or both. Saved scheduled and
+                auto-runs use the card toggles, and when both branches are enabled they always run
+                movies first, then TV shows.
               </p>
               <p>Run flow:</p>
               <ol className="list-decimal pl-5 space-y-1">
-                <li>Immaculaterr fetches each built-in Rotten Tomatoes source page.</li>
                 <li>
-                  Movie cards are parsed from the page HTML, then deduplicated by normalized title and
-                  year.
+                  Movie pages still use the existing safe Radarr lookup flow before titles are added
+                  to Radarr or requested in Seerr.
                 </li>
                 <li>
-                  Radarr is checked once up front, then each candidate is matched conservatively before
-                  it is added to Radarr or requested in Seerr.
+                  TV pages are scraped from fixed Rotten Tomatoes browse URLs, filtered to shows with
+                  both critic and audience scores of at least 60, then deduplicated.
+                </li>
+                <li>
+                  TV discovery stops once the saved Top count is reached. The default is Top 10, and
+                  manual TV runs reuse that saved count instead of asking for a one-off value.
+                </li>
+                <li>
+                  Manual Run now lets you choose Movies or TV Shows for that single run without
+                  changing the saved card settings.
                 </li>
               </ol>
             </>
@@ -820,6 +828,14 @@ export const FaqPage = () => {
               <li>
                 Eleven Rotten Tomatoes at-home newest pages for Fandango at Home, Apple TV+, Netflix,
                 Prime Video, Disney+, Max, Peacock, Hulu, Paramount+, AMC+, and Acorn TV.
+              </li>
+              <li>
+                TV discovery uses fixed Rotten Tomatoes TV browse pages for newest releases plus the
+                built-in streaming-provider pages.
+              </li>
+              <li>
+                TV only reads the first HTML page for each source. It does not use Load more or
+                cursor pagination.
               </li>
               <li>
                 These URLs are fixed in code for this task, so there is no custom source editor on the
@@ -837,20 +853,24 @@ export const FaqPage = () => {
           answer: (
             <ul className="list-disc pl-5 space-y-1">
               <li>
-                When the toggle is off, matched movies are added directly to Radarr with the app’s
-                saved Radarr defaults.
+                When the toggle is off, matched movies are added directly to Radarr and new TV shows
+                are added directly to Sonarr with the app’s saved defaults.
               </li>
               <li>
-                When the toggle is on, matched movies are requested in Seerr instead of being added
-                directly to Radarr.
+                When the toggle is on, both movies and TV shows are sent to Seerr instead of being
+                added directly to Radarr or Sonarr.
               </li>
               <li>
-                Rotten Tomatoes titles are still matched conservatively through Radarr lookup first,
-                so Seerr requests only happen for safe title and year matches.
+                Movie requests still depend on conservative Radarr lookup first, so Seerr requests
+                only happen for safe movie title and year matches.
               </li>
               <li>
-                If Seerr routing is enabled but Seerr is not configured, discovery still completes and
-                the destination step is marked skipped.
+                In Seerr mode there is no direct ARR add fallback for new items. If Seerr is missing,
+                discovery still completes and the destination step is skipped.
+              </li>
+              <li>
+                Existing Sonarr shows can still be reconciled against Plex when Sonarr already has the
+                series, even if new TV requests are being routed through Seerr.
               </li>
             </ul>
           ),
@@ -861,21 +881,24 @@ export const FaqPage = () => {
           answer: (
             <ul className="list-disc pl-5 space-y-1">
               <li>
-                Movies already present in Radarr, or already present/requested in Seerr, are counted as
-                existing instead of surfacing as hard failures.
+                The TV Top count defaults to 10 and controls how many score-qualified, deduplicated TV
+                candidates are considered across all fixed TV sources.
               </li>
               <li>
-                If Radarr is not configured, discovery still completes and the destination step is
-                marked skipped. If Seerr routing is enabled but Seerr is not configured, the routing
-                step is skipped too.
+                Movies or shows that already exist in Radarr, Sonarr, or Seerr are counted as existing
+                instead of surfacing as hard failures.
               </li>
               <li>
-                Rewind shows source-page counts plus destination outcomes for attempted, requested or
-                added, existing, failed, and skipped movies.
+                Existing Sonarr shows can have episode, season, and series monitoring updated so Plex
+                copies stay unmonitored while missing episodes stay monitored.
               </li>
               <li>
-                This task does not use TMDB filters. Seerr routing is optional, but safe matching still
-                relies on Radarr lookup.
+                Rewind now shows separate movie and TV steps plus TV-specific stats for source pages,
+                score filtering, unresolved IDs, requests or adds, skips, and reconciliation counts.
+              </li>
+              <li>
+                If both Movies and TV Shows are turned off on the card, scheduled and auto-runs do
+                nothing until at least one branch is enabled again.
               </li>
             </ul>
           ),
@@ -2910,7 +2933,7 @@ export const FaqPage = () => {
     'task-manager-tmdb-upcoming-movies':
       'What this task does, how each run works, and how to edit filters.',
     'task-manager-rotten-tomatoes-upcoming-movies':
-      'Fixed-source Rotten Tomatoes discovery that routes safe matches to Radarr or Seerr.',
+      'Fixed-source Rotten Tomatoes movies + TV discovery with a saved TV Top count and shared Seerr routing.',
     'task-manager-immaculate-taste-collection':
       'Watch-triggered Immaculate Taste updates and missing-item routing.',
     'task-manager-immaculate-taste-refresher':

--- a/apps/web/src/pages/FaqPage.tsx
+++ b/apps/web/src/pages/FaqPage.tsx
@@ -785,11 +785,11 @@ export const FaqPage = () => {
     },
     {
       id: 'task-manager-rotten-tomatoes-upcoming-movies',
-      title: 'Rotten Tomatoes Upcoming Movies',
+      title: 'Rotten Tomatoes Upcoming Movies + TV Shows',
       items: [
         {
           id: 'task-manager-rotten-tomatoes-upcoming-how-it-works',
-          question: 'How does Rotten Tomatoes Upcoming Movies work?',
+          question: 'How does Rotten Tomatoes Upcoming Movies + TV Shows work?',
           answer: (
             <>
               <p>
@@ -801,7 +801,8 @@ export const FaqPage = () => {
               <ol className="list-decimal pl-5 space-y-1">
                 <li>
                   Movie pages still use the existing safe Radarr lookup flow before titles are added
-                  to Radarr or requested in Seerr.
+                  to Radarr or requested in Seerr, and movie discovery stops once the saved Movie Top
+                  count is reached. The default is Top 20.
                 </li>
                 <li>
                   TV pages are scraped from fixed Rotten Tomatoes browse URLs, filtered to shows with
@@ -809,11 +810,12 @@ export const FaqPage = () => {
                 </li>
                 <li>
                   TV discovery stops once the saved Top count is reached. The default is Top 10, and
-                  manual TV runs reuse that saved count instead of asking for a one-off value.
+                  manual runs can choose a one-run Top count without changing the saved card values.
                 </li>
                 <li>
-                  Manual Run now lets you choose Movies or TV Shows for that single run without
-                  changing the saved card settings.
+                  Manual Run now lets you choose Movies or TV Shows, a one-run Route via Seerr
+                  toggle, and a one-run Top count. Those dialog choices do not change the saved
+                  card settings.
                 </li>
               </ol>
             </>
@@ -881,8 +883,13 @@ export const FaqPage = () => {
           answer: (
             <ul className="list-disc pl-5 space-y-1">
               <li>
-                The TV Top count defaults to 10 and controls how many score-qualified, deduplicated TV
-                candidates are considered across all fixed TV sources.
+                The saved Movie Top count defaults to 20 and the saved TV Top count defaults to 10.
+                They control how many deduplicated candidates are considered for each branch across
+                the fixed Rotten Tomatoes sources.
+              </li>
+              <li>
+                Manual runs default to Top 10 in the dialog, but you can change that one-run count
+                anywhere between 1 and 100 without changing the saved card limits.
               </li>
               <li>
                 Movies or shows that already exist in Radarr, Sonarr, or Seerr are counted as existing

--- a/apps/web/src/pages/JobRunDetailPage.tsx
+++ b/apps/web/src/pages/JobRunDetailPage.tsx
@@ -292,18 +292,19 @@ function getProgressPlan(jobId: string): ProgressPlan | null {
 
   if (id === 'rottenTomatoesUpcomingMovies') {
     return {
-      total: 4,
+      total: 5,
       getStage: ({ stepId }) => {
         if (!stepId) return null;
         if (stepId === 'load_settings') return 1;
-        if (stepId === 'scrape_sources') return 2;
-        if (stepId === 'prepare_radarr') return 3;
+        if (stepId === 'scrape_movies') return 2;
+        if (stepId === 'route_movies') return 3;
+        if (stepId === 'scrape_shows') return 4;
         if (
-          stepId === 'route_movies' ||
+          stepId === 'route_shows' ||
           stepId === 'done' ||
           stepId === 'failed'
         ) {
-          return 4;
+          return 5;
         }
         return null;
       },

--- a/apps/web/src/pages/TaskManagerPage.tsx
+++ b/apps/web/src/pages/TaskManagerPage.tsx
@@ -99,6 +99,7 @@ type RottenTomatoesUpcomingSettingsDraft = {
   routeViaSeerr: boolean;
   includeMovies: boolean;
   includeShows: boolean;
+  movieLimit: number;
   showLimit: number;
 };
 
@@ -131,6 +132,7 @@ const TMDB_UPCOMING_DEFAULT_SCORE_MIN = 6;
 const TMDB_UPCOMING_DEFAULT_SCORE_MAX = 10;
 const TMDB_UPCOMING_TOP_LANGUAGE_CODES = ['en', 'zh', 'hi', 'es', 'fr'];
 const TMDB_CALENDAR_WEEKDAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const ROTTEN_TOMATOES_DEFAULT_MOVIE_LIMIT = 20;
 const ROTTEN_TOMATOES_DEFAULT_SHOW_LIMIT = 10;
 const ROTTEN_TOMATOES_MIN_SHOW_LIMIT = 1;
 const ROTTEN_TOMATOES_MAX_SHOW_LIMIT = 100;
@@ -177,7 +179,7 @@ const JOB_CONFIG: Record<
     icon: <Clapperboard className="w-8 h-8" />,
     color: 'text-rose-300',
     description:
-      'Scrapes fixed Rotten Tomatoes movie and TV pages, routes safe movie matches to Radarr or Seerr, and sends TV picks to Sonarr or Seerr using the saved Top count.',
+      'Scrapes fixed Rotten Tomatoes movie and TV pages, respects separate saved movie and TV Top counts, and routes picks to Radarr, Sonarr, or Seerr.',
   },
   mediaAddedCleanup: {
     icon: <CheckCircle2 className="w-8 h-8" />,
@@ -674,6 +676,12 @@ function normalizeRottenTomatoesUpcomingSettings(
     includeShows:
       readBool(settings, 'jobs.rottenTomatoesUpcomingMovies.includeShows') ??
       false,
+    movieLimit: clampNumber(
+      Number(readPath(settings, 'jobs.rottenTomatoesUpcomingMovies.movieLimit')),
+      ROTTEN_TOMATOES_MIN_SHOW_LIMIT,
+      ROTTEN_TOMATOES_MAX_SHOW_LIMIT,
+      ROTTEN_TOMATOES_DEFAULT_MOVIE_LIMIT,
+    ),
     showLimit: clampNumber(
       Number(readPath(settings, 'jobs.rottenTomatoesUpcomingMovies.showLimit')),
       ROTTEN_TOMATOES_MIN_SHOW_LIMIT,
@@ -758,6 +766,11 @@ export function TaskManagerPage() {
     useState(false);
   const [rottenTomatoesRunDialogOpen, setRottenTomatoesRunDialogOpen] =
     useState(false);
+  const [rottenTomatoesRunRouteViaSeerr, setRottenTomatoesRunRouteViaSeerr] =
+    useState(false);
+  const [rottenTomatoesRunTopCount, setRottenTomatoesRunTopCount] = useState(
+    ROTTEN_TOMATOES_DEFAULT_SHOW_LIMIT,
+  );
 
   // Netflix import dialog state
   const [importDialogOpen, setImportDialogOpen] = useState(false);
@@ -837,6 +850,7 @@ export function TaskManagerPage() {
     routeViaSeerr: false,
     includeMovies: true,
     includeShows: false,
+    movieLimit: ROTTEN_TOMATOES_DEFAULT_MOVIE_LIMIT,
     showLimit: ROTTEN_TOMATOES_DEFAULT_SHOW_LIMIT,
   });
   const [tmdbGenreSearchByFilter, setTmdbGenreSearchByFilter] = useState<
@@ -2192,10 +2206,19 @@ export function TaskManagerPage() {
       closeRottenTomatoesRunDialog();
       runJobNow({
         jobId: 'rottenTomatoesUpcomingMovies',
-        input: { category },
+        input: {
+          category,
+          routeViaSeerr: rottenTomatoesRunRouteViaSeerr,
+          topCount: rottenTomatoesRunTopCount,
+        },
       });
     },
-    [closeRottenTomatoesRunDialog, runJobNow],
+    [
+      closeRottenTomatoesRunDialog,
+      rottenTomatoesRunRouteViaSeerr,
+      rottenTomatoesRunTopCount,
+      runJobNow,
+    ],
   );
   const handleToggleImmaculateRefresherDetails = useCallback(() => {
     setImmaculateRefresherDetailsOpen((value) => !value);
@@ -2381,6 +2404,10 @@ export function TaskManagerPage() {
       }
 
       if (jobId === 'rottenTomatoesUpcomingMovies') {
+        setRottenTomatoesRunRouteViaSeerr(
+          rottenTomatoesUpcomingSettingsDraftRef.current.routeViaSeerr,
+        );
+        setRottenTomatoesRunTopCount(ROTTEN_TOMATOES_DEFAULT_SHOW_LIMIT);
         setRottenTomatoesRunDialogOpen(true);
         return;
       }
@@ -2863,12 +2890,44 @@ export function TaskManagerPage() {
       updateRottenTomatoesUpcomingSettings,
     ],
   );
+  const handleToggleRottenTomatoesRunRouteViaSeerr = useCallback(
+    (event: ReactMouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+      const next = !rottenTomatoesRunRouteViaSeerr;
+      if (next && !canEnableSeerrTaskToggles) {
+        openIntegrationSetupDialog('seerr');
+        return;
+      }
+      setRottenTomatoesRunRouteViaSeerr(next);
+    },
+    [
+      canEnableSeerrTaskToggles,
+      openIntegrationSetupDialog,
+      rottenTomatoesRunRouteViaSeerr,
+    ],
+  );
   const handleToggleRottenTomatoesUpcomingIncludeMovies = useCallback(
     (event: ReactMouseEvent<HTMLButtonElement>) => {
       event.stopPropagation();
       updateRottenTomatoesUpcomingSettings((prev) => ({
         ...prev,
         includeMovies: !prev.includeMovies,
+      }));
+    },
+    [updateRottenTomatoesUpcomingSettings],
+  );
+  const handleRottenTomatoesUpcomingMovieLimitChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      event.stopPropagation();
+      const value = clampNumber(
+        Number(event.currentTarget.value),
+        ROTTEN_TOMATOES_MIN_SHOW_LIMIT,
+        ROTTEN_TOMATOES_MAX_SHOW_LIMIT,
+        ROTTEN_TOMATOES_DEFAULT_MOVIE_LIMIT,
+      );
+      updateRottenTomatoesUpcomingSettings((prev) => ({
+        ...prev,
+        movieLimit: value,
       }));
     },
     [updateRottenTomatoesUpcomingSettings],
@@ -2882,6 +2941,19 @@ export function TaskManagerPage() {
       }));
     },
     [updateRottenTomatoesUpcomingSettings],
+  );
+  const handleRottenTomatoesRunTopCountChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      event.stopPropagation();
+      const value = clampNumber(
+        Number(event.currentTarget.value),
+        ROTTEN_TOMATOES_MIN_SHOW_LIMIT,
+        ROTTEN_TOMATOES_MAX_SHOW_LIMIT,
+        ROTTEN_TOMATOES_DEFAULT_SHOW_LIMIT,
+      );
+      setRottenTomatoesRunTopCount(value);
+    },
+    [],
   );
   const handleRottenTomatoesUpcomingShowLimitChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
@@ -5808,51 +5880,80 @@ export function TaskManagerPage() {
                                         Includes
                                       </div>
                                       <div className="mt-3 flex flex-col gap-3">
-                                        <div className="flex items-center justify-between gap-4 rounded-xl border border-white/10 bg-[#0F0B15]/35 px-4 py-3">
-                                          <div className="min-w-0">
+                                        <div className="flex flex-col gap-3 rounded-xl border border-white/10 bg-[#0F0B15]/35 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+                                          <div className="min-w-0 flex-1">
                                             <div className="text-sm font-semibold text-white">
                                               Movies
                                             </div>
                                             <div className="mt-1 text-xs leading-relaxed text-white/55">
-                                              Keep the existing Rotten Tomatoes movie flow and route
-                                              safe matches to Radarr or Seerr.
+                                              Scrape fixed Rotten Tomatoes movie pages, keep safe
+                                              matches only, and stop once the saved Top count is
+                                              reached.
                                             </div>
                                           </div>
-                                          <button
-                                            type="button"
-                                            role="switch"
-                                            aria-checked={
-                                              rottenTomatoesUpcomingSettingsDraft.includeMovies
-                                            }
-                                            onClick={
-                                              handleToggleRottenTomatoesUpcomingIncludeMovies
-                                            }
-                                            onPointerDown={handleStopPropagationPointer}
-                                            disabled={
-                                              settingsQuery.isLoading ||
-                                              rottenTomatoesUpcomingSettingsMutation.isPending
-                                            }
-                                            className={cn(
-                                              'relative inline-flex h-7 w-12 shrink-0 items-center overflow-hidden rounded-full transition-colors active:scale-95',
-                                              rottenTomatoesUpcomingSettingsDraft.includeMovies
-                                                ? 'bg-rose-400'
-                                                : 'bg-[#2a2438] border-2 border-white/10',
-                                            )}
-                                            aria-label="Toggle Rotten Tomatoes upcoming movies"
-                                          >
-                                            <span
-                                              className={cn(
-                                                'inline-flex h-5 w-5 transform items-center justify-center rounded-full bg-white transition-transform',
+                                          <div className="flex items-center justify-between gap-3 sm:justify-end">
+                                            <label className="flex items-center gap-2 rounded-lg border border-white/10 bg-black/20 px-3 py-2 text-xs text-white/65">
+                                              <span className="font-semibold uppercase tracking-wider text-white/50">
+                                                Top
+                                              </span>
+                                              <input
+                                                type="number"
+                                                min={ROTTEN_TOMATOES_MIN_SHOW_LIMIT}
+                                                max={ROTTEN_TOMATOES_MAX_SHOW_LIMIT}
+                                                inputMode="numeric"
+                                                value={
+                                                  rottenTomatoesUpcomingSettingsDraft.movieLimit
+                                                }
+                                                onChange={
+                                                  handleRottenTomatoesUpcomingMovieLimitChange
+                                                }
+                                                onClick={handleStopPropagation}
+                                                onPointerDown={handleStopPropagationPointer}
+                                                disabled={
+                                                  settingsQuery.isLoading ||
+                                                  rottenTomatoesUpcomingSettingsMutation.isPending ||
+                                                  !rottenTomatoesUpcomingSettingsDraft.includeMovies
+                                                }
+                                                className="h-8 w-16 rounded-md border border-white/10 bg-[#0F0B15]/60 px-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-rose-300/40 disabled:cursor-not-allowed disabled:opacity-50"
+                                                aria-label="Rotten Tomatoes movie count"
+                                              />
+                                            </label>
+                                            <button
+                                              type="button"
+                                              role="switch"
+                                              aria-checked={
                                                 rottenTomatoesUpcomingSettingsDraft.includeMovies
-                                                  ? 'translate-x-6'
-                                                  : 'translate-x-1',
+                                              }
+                                              onClick={
+                                                handleToggleRottenTomatoesUpcomingIncludeMovies
+                                              }
+                                              onPointerDown={handleStopPropagationPointer}
+                                              disabled={
+                                                settingsQuery.isLoading ||
+                                                rottenTomatoesUpcomingSettingsMutation.isPending
+                                              }
+                                              className={cn(
+                                                'relative inline-flex h-7 w-12 shrink-0 items-center overflow-hidden rounded-full transition-colors active:scale-95',
+                                                rottenTomatoesUpcomingSettingsDraft.includeMovies
+                                                  ? 'bg-rose-400'
+                                                  : 'bg-[#2a2438] border-2 border-white/10',
                                               )}
+                                              aria-label="Toggle Rotten Tomatoes upcoming movies"
                                             >
-                                              {rottenTomatoesUpcomingSettingsMutation.isPending && (
-                                                <Loader2 className="h-3 w-3 animate-spin text-black/70" />
-                                              )}
-                                            </span>
-                                          </button>
+                                              <span
+                                                className={cn(
+                                                  'inline-flex h-5 w-5 transform items-center justify-center rounded-full bg-white transition-transform',
+                                                  rottenTomatoesUpcomingSettingsDraft.includeMovies
+                                                    ? 'translate-x-6'
+                                                    : 'translate-x-1',
+                                                )}
+                                              >
+                                                {rottenTomatoesUpcomingSettingsMutation.isPending && (
+                                                  <Loader2 className="h-3 w-3 animate-spin text-black/70" />
+                                                )}
+                                              </span>
+                                            </button>
+                                          </div>
                                         </div>
 
                                         <div className="flex flex-col gap-3 rounded-xl border border-white/10 bg-[#0F0B15]/35 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
@@ -6727,12 +6828,11 @@ export function TaskManagerPage() {
                     Run now
                   </div>
                   <h2 className="mt-2 text-2xl font-black tracking-tight text-white">
-                    Rotten Tomatoes Upcoming Movies
+                    Rotten Tomatoes Upcoming Movies + TV Shows
                   </h2>
                   <p className="mt-2 text-sm leading-relaxed text-white/70">
-                    Choose which branch to run right now. TV Shows will use the saved Top{' '}
-                    {rottenTomatoesUpcomingSettingsDraft.showLimit} setting from the expanded
-                    card.
+                    Choose the branch, one-run routing, and one-run Top count for this manual
+                    run. These dialog choices do not change the saved card settings.
                   </p>
                 </div>
                 <button
@@ -6745,7 +6845,65 @@ export function TaskManagerPage() {
                 </button>
               </div>
 
-              <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <div className="mt-6 space-y-4">
+                <div className="rounded-2xl border border-white/10 bg-white/[0.04] p-4">
+                  <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="min-w-0">
+                      <div className="text-sm font-semibold text-white">
+                        Route via Seerr
+                      </div>
+                      <div className="mt-1 text-xs leading-relaxed text-white/60">
+                        Turn this on for this run only to send matched movies and TV shows
+                        through Seerr instead of direct ARR adds.
+                      </div>
+                    </div>
+                    <button
+                      type="button"
+                      role="switch"
+                      aria-checked={rottenTomatoesRunRouteViaSeerr}
+                      onClick={handleToggleRottenTomatoesRunRouteViaSeerr}
+                      className={cn(
+                        'relative inline-flex h-7 w-12 shrink-0 items-center overflow-hidden rounded-full transition-colors active:scale-95',
+                        rottenTomatoesRunRouteViaSeerr
+                          ? 'bg-rose-400'
+                          : 'bg-[#2a2438] border-2 border-white/10',
+                      )}
+                      aria-label="Toggle one-run Seerr routing"
+                    >
+                      <span
+                        className={cn(
+                          'inline-flex h-5 w-5 transform items-center justify-center rounded-full bg-white transition-transform',
+                          rottenTomatoesRunRouteViaSeerr
+                            ? 'translate-x-6'
+                            : 'translate-x-1',
+                        )}
+                      />
+                    </button>
+                  </div>
+
+                  <div className="mt-4 flex items-center justify-between gap-3 rounded-xl border border-white/10 bg-black/20 px-3 py-2">
+                    <div>
+                      <div className="text-xs font-semibold uppercase tracking-wider text-white/50">
+                        Top count
+                      </div>
+                      <div className="mt-1 text-xs text-white/60">
+                        Default is Top 10 for manual runs.
+                      </div>
+                    </div>
+                    <input
+                      type="number"
+                      min={ROTTEN_TOMATOES_MIN_SHOW_LIMIT}
+                      max={ROTTEN_TOMATOES_MAX_SHOW_LIMIT}
+                      inputMode="numeric"
+                      value={rottenTomatoesRunTopCount}
+                      onChange={handleRottenTomatoesRunTopCountChange}
+                      className="h-10 w-20 rounded-md border border-white/10 bg-[#0F0B15]/60 px-3 text-sm text-white focus:outline-none focus:ring-2 focus:ring-rose-300/40"
+                      aria-label="Rotten Tomatoes manual top count"
+                    />
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                 <button
                   type="button"
                   onClick={() => handleRunRottenTomatoesCategory('movies')}
@@ -6762,13 +6920,13 @@ export function TaskManagerPage() {
                     <div>
                       <div className="text-base font-bold text-white">Movies</div>
                       <div className="text-xs uppercase tracking-[0.18em] text-rose-200/70">
-                        Radarr or Seerr
+                        Top {rottenTomatoesRunTopCount}
                       </div>
                     </div>
                   </div>
                   <p className="mt-4 text-sm leading-relaxed text-white/65">
                     Scrape the fixed Rotten Tomatoes movie pages and use the existing safe Radarr
-                    lookup flow before routing matches.
+                    lookup flow before routing matches with the one-run settings above.
                   </p>
                 </button>
 
@@ -6788,15 +6946,16 @@ export function TaskManagerPage() {
                     <div>
                       <div className="text-base font-bold text-white">TV Shows</div>
                       <div className="text-xs uppercase tracking-[0.18em] text-cyan-200/70">
-                        Top {rottenTomatoesUpcomingSettingsDraft.showLimit}
+                        Top {rottenTomatoesRunTopCount}
                       </div>
                     </div>
                   </div>
                   <p className="mt-4 text-sm leading-relaxed text-white/65">
-                    Scrape score-qualified Rotten Tomatoes TV pages, stop at the saved Top limit,
-                    then send new shows to Sonarr or Seerr.
+                    Scrape score-qualified Rotten Tomatoes TV pages, stop at the one-run Top
+                    limit, then route new shows with the one-run settings above.
                   </p>
                 </button>
+                </div>
               </div>
 
               <div className="mt-6 flex justify-end">

--- a/apps/web/src/pages/TaskManagerPage.tsx
+++ b/apps/web/src/pages/TaskManagerPage.tsx
@@ -93,8 +93,13 @@ type TmdbUpcomingSettingsDraft = {
   filters: TmdbUpcomingFilterDraft[];
 };
 
+type RottenTomatoesManualCategory = 'movies' | 'shows';
+
 type RottenTomatoesUpcomingSettingsDraft = {
   routeViaSeerr: boolean;
+  includeMovies: boolean;
+  includeShows: boolean;
+  showLimit: number;
 };
 
 type TmdbFilterChipOption = {
@@ -126,6 +131,9 @@ const TMDB_UPCOMING_DEFAULT_SCORE_MIN = 6;
 const TMDB_UPCOMING_DEFAULT_SCORE_MAX = 10;
 const TMDB_UPCOMING_TOP_LANGUAGE_CODES = ['en', 'zh', 'hi', 'es', 'fr'];
 const TMDB_CALENDAR_WEEKDAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const ROTTEN_TOMATOES_DEFAULT_SHOW_LIMIT = 10;
+const ROTTEN_TOMATOES_MIN_SHOW_LIMIT = 1;
+const ROTTEN_TOMATOES_MAX_SHOW_LIMIT = 100;
 
 const DAYS_OF_WEEK: Array<{ value: string; label: string; short: string }> = [
   { value: '0', label: 'Sunday', short: 'Sun' },
@@ -169,7 +177,7 @@ const JOB_CONFIG: Record<
     icon: <Clapperboard className="w-8 h-8" />,
     color: 'text-rose-300',
     description:
-      'Scrapes fixed Rotten Tomatoes upcoming and newest movie pages, deduplicates safe matches, and routes them to Radarr or Seerr.',
+      'Scrapes fixed Rotten Tomatoes movie and TV pages, routes safe movie matches to Radarr or Seerr, and sends TV picks to Sonarr or Seerr using the saved Top count.',
   },
   mediaAddedCleanup: {
     icon: <CheckCircle2 className="w-8 h-8" />,
@@ -660,6 +668,18 @@ function normalizeRottenTomatoesUpcomingSettings(
     routeViaSeerr:
       readBool(settings, 'jobs.rottenTomatoesUpcomingMovies.routeViaSeerr') ??
       false,
+    includeMovies:
+      readBool(settings, 'jobs.rottenTomatoesUpcomingMovies.includeMovies') ??
+      true,
+    includeShows:
+      readBool(settings, 'jobs.rottenTomatoesUpcomingMovies.includeShows') ??
+      false,
+    showLimit: clampNumber(
+      Number(readPath(settings, 'jobs.rottenTomatoesUpcomingMovies.showLimit')),
+      ROTTEN_TOMATOES_MIN_SHOW_LIMIT,
+      ROTTEN_TOMATOES_MAX_SHOW_LIMIT,
+      ROTTEN_TOMATOES_DEFAULT_SHOW_LIMIT,
+    ),
   };
 }
 
@@ -735,6 +755,8 @@ export function TaskManagerPage() {
   const movieSeedTitleRef = useRef<HTMLInputElement | null>(null);
   const resetMovieSeedDialogOnCloseRef = useRef(false);
   const [unmonitorConfirmDialogOpen, setUnmonitorConfirmDialogOpen] =
+    useState(false);
+  const [rottenTomatoesRunDialogOpen, setRottenTomatoesRunDialogOpen] =
     useState(false);
 
   // Netflix import dialog state
@@ -813,6 +835,9 @@ export function TaskManagerPage() {
     setRottenTomatoesUpcomingSettingsDraft,
   ] = useState<RottenTomatoesUpcomingSettingsDraft>({
     routeViaSeerr: false,
+    includeMovies: true,
+    includeShows: false,
+    showLimit: ROTTEN_TOMATOES_DEFAULT_SHOW_LIMIT,
   });
   const [tmdbGenreSearchByFilter, setTmdbGenreSearchByFilter] = useState<
     Record<string, string>
@@ -2016,6 +2041,9 @@ export function TaskManagerPage() {
   const closeUnmonitorConfirmDialog = useCallback(() => {
     setUnmonitorConfirmDialogOpen(false);
   }, []);
+  const closeRottenTomatoesRunDialog = useCallback(() => {
+    setRottenTomatoesRunDialogOpen(false);
+  }, []);
   const resetMovieSeedDialogState = useCallback(() => {
     setMovieSeedMediaType('movie');
     setMovieSeedTitle('');
@@ -2158,6 +2186,16 @@ export function TaskManagerPage() {
       openIntegrationSetupDialog,
       runJobNow,
     ],
+  );
+  const handleRunRottenTomatoesCategory = useCallback(
+    (category: RottenTomatoesManualCategory) => {
+      closeRottenTomatoesRunDialog();
+      runJobNow({
+        jobId: 'rottenTomatoesUpcomingMovies',
+        input: { category },
+      });
+    },
+    [closeRottenTomatoesRunDialog, runJobNow],
   );
   const handleToggleImmaculateRefresherDetails = useCallback(() => {
     setImmaculateRefresherDetailsOpen((value) => !value);
@@ -2339,6 +2377,11 @@ export function TaskManagerPage() {
 
       if (jobId === 'unmonitorConfirm') {
         setUnmonitorConfirmDialogOpen(true);
+        return;
+      }
+
+      if (jobId === 'rottenTomatoesUpcomingMovies') {
+        setRottenTomatoesRunDialogOpen(true);
         return;
       }
 
@@ -2819,6 +2862,42 @@ export function TaskManagerPage() {
       rottenTomatoesUpcomingSettingsDraft.routeViaSeerr,
       updateRottenTomatoesUpcomingSettings,
     ],
+  );
+  const handleToggleRottenTomatoesUpcomingIncludeMovies = useCallback(
+    (event: ReactMouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+      updateRottenTomatoesUpcomingSettings((prev) => ({
+        ...prev,
+        includeMovies: !prev.includeMovies,
+      }));
+    },
+    [updateRottenTomatoesUpcomingSettings],
+  );
+  const handleToggleRottenTomatoesUpcomingIncludeShows = useCallback(
+    (event: ReactMouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+      updateRottenTomatoesUpcomingSettings((prev) => ({
+        ...prev,
+        includeShows: !prev.includeShows,
+      }));
+    },
+    [updateRottenTomatoesUpcomingSettings],
+  );
+  const handleRottenTomatoesUpcomingShowLimitChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      event.stopPropagation();
+      const value = clampNumber(
+        Number(event.currentTarget.value),
+        ROTTEN_TOMATOES_MIN_SHOW_LIMIT,
+        ROTTEN_TOMATOES_MAX_SHOW_LIMIT,
+        ROTTEN_TOMATOES_DEFAULT_SHOW_LIMIT,
+      );
+      updateRottenTomatoesUpcomingSettings((prev) => ({
+        ...prev,
+        showLimit: value,
+      }));
+    },
+    [updateRottenTomatoesUpcomingSettings],
   );
   const handleTmdbUpcomingGlobalLimitChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
@@ -5724,14 +5803,142 @@ export function TaskManagerPage() {
                                   </div>
 
                                   <div className="grid grid-cols-1 gap-4">
+                                    <div className="rounded-xl border border-white/10 bg-[#1a1625]/60 p-4">
+                                      <div className="text-xs font-bold uppercase tracking-wider text-gray-500">
+                                        Includes
+                                      </div>
+                                      <div className="mt-3 flex flex-col gap-3">
+                                        <div className="flex items-center justify-between gap-4 rounded-xl border border-white/10 bg-[#0F0B15]/35 px-4 py-3">
+                                          <div className="min-w-0">
+                                            <div className="text-sm font-semibold text-white">
+                                              Movies
+                                            </div>
+                                            <div className="mt-1 text-xs leading-relaxed text-white/55">
+                                              Keep the existing Rotten Tomatoes movie flow and route
+                                              safe matches to Radarr or Seerr.
+                                            </div>
+                                          </div>
+                                          <button
+                                            type="button"
+                                            role="switch"
+                                            aria-checked={
+                                              rottenTomatoesUpcomingSettingsDraft.includeMovies
+                                            }
+                                            onClick={
+                                              handleToggleRottenTomatoesUpcomingIncludeMovies
+                                            }
+                                            onPointerDown={handleStopPropagationPointer}
+                                            disabled={
+                                              settingsQuery.isLoading ||
+                                              rottenTomatoesUpcomingSettingsMutation.isPending
+                                            }
+                                            className={cn(
+                                              'relative inline-flex h-7 w-12 shrink-0 items-center overflow-hidden rounded-full transition-colors active:scale-95',
+                                              rottenTomatoesUpcomingSettingsDraft.includeMovies
+                                                ? 'bg-rose-400'
+                                                : 'bg-[#2a2438] border-2 border-white/10',
+                                            )}
+                                            aria-label="Toggle Rotten Tomatoes upcoming movies"
+                                          >
+                                            <span
+                                              className={cn(
+                                                'inline-flex h-5 w-5 transform items-center justify-center rounded-full bg-white transition-transform',
+                                                rottenTomatoesUpcomingSettingsDraft.includeMovies
+                                                  ? 'translate-x-6'
+                                                  : 'translate-x-1',
+                                              )}
+                                            >
+                                              {rottenTomatoesUpcomingSettingsMutation.isPending && (
+                                                <Loader2 className="h-3 w-3 animate-spin text-black/70" />
+                                              )}
+                                            </span>
+                                          </button>
+                                        </div>
+
+                                        <div className="flex flex-col gap-3 rounded-xl border border-white/10 bg-[#0F0B15]/35 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+                                          <div className="min-w-0 flex-1">
+                                            <div className="text-sm font-semibold text-white">
+                                              TV Shows
+                                            </div>
+                                            <div className="mt-1 text-xs leading-relaxed text-white/55">
+                                              Scrape fixed Rotten Tomatoes TV pages, keep
+                                              score-qualified shows, and stop once the saved Top
+                                              count is reached.
+                                            </div>
+                                          </div>
+                                          <div className="flex items-center justify-between gap-3 sm:justify-end">
+                                            <label className="flex items-center gap-2 rounded-lg border border-white/10 bg-black/20 px-3 py-2 text-xs text-white/65">
+                                              <span className="font-semibold uppercase tracking-wider text-white/50">
+                                                Top
+                                              </span>
+                                              <input
+                                                type="number"
+                                                min={ROTTEN_TOMATOES_MIN_SHOW_LIMIT}
+                                                max={ROTTEN_TOMATOES_MAX_SHOW_LIMIT}
+                                                inputMode="numeric"
+                                                value={rottenTomatoesUpcomingSettingsDraft.showLimit}
+                                                onChange={
+                                                  handleRottenTomatoesUpcomingShowLimitChange
+                                                }
+                                                onClick={handleStopPropagation}
+                                                onPointerDown={handleStopPropagationPointer}
+                                                disabled={
+                                                  settingsQuery.isLoading ||
+                                                  rottenTomatoesUpcomingSettingsMutation.isPending ||
+                                                  !rottenTomatoesUpcomingSettingsDraft.includeShows
+                                                }
+                                                className="h-8 w-16 rounded-md border border-white/10 bg-[#0F0B15]/60 px-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-rose-300/40 disabled:cursor-not-allowed disabled:opacity-50"
+                                                aria-label="Rotten Tomatoes TV show count"
+                                              />
+                                            </label>
+                                            <button
+                                              type="button"
+                                              role="switch"
+                                              aria-checked={
+                                                rottenTomatoesUpcomingSettingsDraft.includeShows
+                                              }
+                                              onClick={
+                                                handleToggleRottenTomatoesUpcomingIncludeShows
+                                              }
+                                              onPointerDown={handleStopPropagationPointer}
+                                              disabled={
+                                                settingsQuery.isLoading ||
+                                                rottenTomatoesUpcomingSettingsMutation.isPending
+                                              }
+                                              className={cn(
+                                                'relative inline-flex h-7 w-12 shrink-0 items-center overflow-hidden rounded-full transition-colors active:scale-95',
+                                                rottenTomatoesUpcomingSettingsDraft.includeShows
+                                                  ? 'bg-rose-400'
+                                                  : 'bg-[#2a2438] border-2 border-white/10',
+                                              )}
+                                              aria-label="Toggle Rotten Tomatoes upcoming TV shows"
+                                            >
+                                              <span
+                                                className={cn(
+                                                  'inline-flex h-5 w-5 transform items-center justify-center rounded-full bg-white transition-transform',
+                                                  rottenTomatoesUpcomingSettingsDraft.includeShows
+                                                    ? 'translate-x-6'
+                                                    : 'translate-x-1',
+                                                )}
+                                              >
+                                                {rottenTomatoesUpcomingSettingsMutation.isPending && (
+                                                  <Loader2 className="h-3 w-3 animate-spin text-black/70" />
+                                                )}
+                                              </span>
+                                            </button>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+
                                     <div className="flex min-h-[98px] items-center justify-between gap-4 rounded-xl border border-white/10 bg-[#1a1625]/60 px-4 py-3">
                                       <div className="min-w-0">
                                         <div className="text-sm font-semibold text-white">
                                           Route via Seerr
                                         </div>
                                         <div className="mt-1 text-xs text-white/55 leading-relaxed">
-                                          Enable to request matched movies in Seerr instead of
-                                          adding them directly to Radarr.
+                                          Enable to request both matched movies and new TV shows in
+                                          Seerr instead of adding them directly to Radarr or Sonarr.
                                         </div>
                                       </div>
                                       <button
@@ -5754,7 +5961,7 @@ export function TaskManagerPage() {
                                             ? 'bg-cyan-400'
                                             : 'bg-[#2a2438] border-2 border-white/10',
                                         )}
-                                        aria-label="Toggle route via Seerr for Rotten Tomatoes Upcoming Movies"
+                                        aria-label="Toggle route via Seerr for Rotten Tomatoes upcoming movies and TV shows"
                                       >
                                         <span
                                           className={cn(
@@ -5770,6 +5977,18 @@ export function TaskManagerPage() {
                                         </span>
                                       </button>
                                     </div>
+
+                                    {!rottenTomatoesUpcomingSettingsDraft.includeMovies &&
+                                      !rottenTomatoesUpcomingSettingsDraft.includeShows && (
+                                        <div className="flex items-start gap-2 rounded-xl border border-amber-500/25 bg-amber-500/10 px-3 py-2 text-xs leading-relaxed text-amber-200">
+                                          <CircleAlert className="mt-0.5 h-4 w-4 shrink-0" />
+                                          <span>
+                                            Movies and TV Shows are both off, so scheduled and auto
+                                            runs will not send anything until at least one branch is
+                                            enabled again.
+                                          </span>
+                                        </div>
+                                      )}
                                   </div>
 
                                   {rottenTomatoesUpcomingSettingsMutation.isError && (
@@ -6478,6 +6697,117 @@ export function TaskManagerPage() {
                     )}
                   </button>
                 </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      <AnimatePresence>
+        {rottenTomatoesRunDialogOpen && (
+          <motion.div
+            className="fixed inset-0 z-[100000] flex items-center justify-center p-4 sm:p-6"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={closeRottenTomatoesRunDialog}
+          >
+            <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
+
+            <motion.div
+              initial={{ opacity: 0, y: 24, scale: 0.98 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: 24, scale: 0.98 }}
+              transition={{ type: 'spring', stiffness: 260, damping: 26 }}
+              onClick={handleStopPropagation}
+              className="relative w-full sm:max-w-lg rounded-[32px] border border-white/10 bg-[#1a1625]/80 p-6 shadow-2xl shadow-rose-500/10 backdrop-blur-2xl sm:p-7"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div className="min-w-0">
+                  <div className="text-xs font-bold uppercase tracking-wider text-white/50">
+                    Run now
+                  </div>
+                  <h2 className="mt-2 text-2xl font-black tracking-tight text-white">
+                    Rotten Tomatoes Upcoming Movies
+                  </h2>
+                  <p className="mt-2 text-sm leading-relaxed text-white/70">
+                    Choose which branch to run right now. TV Shows will use the saved Top{' '}
+                    {rottenTomatoesUpcomingSettingsDraft.showLimit} setting from the expanded
+                    card.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={closeRottenTomatoesRunDialog}
+                  className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/5 text-white/80 transition hover:bg-white/10 active:scale-[0.98]"
+                  aria-label="Close"
+                >
+                  <X className="h-5 w-5" />
+                </button>
+              </div>
+
+              <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <button
+                  type="button"
+                  onClick={() => handleRunRottenTomatoesCategory('movies')}
+                  className="group rounded-[28px] border border-white/10 bg-white/[0.04] p-5 text-left transition hover:border-white/20 hover:bg-white/[0.08] active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-60"
+                  disabled={
+                    runMutation.isPending ||
+                    terminalState.rottenTomatoesUpcomingMovies?.status === 'running'
+                  }
+                >
+                  <div className="flex items-center gap-3">
+                    <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-rose-400/20 bg-rose-400/10">
+                      <Clapperboard className="h-6 w-6 text-rose-200" />
+                    </div>
+                    <div>
+                      <div className="text-base font-bold text-white">Movies</div>
+                      <div className="text-xs uppercase tracking-[0.18em] text-rose-200/70">
+                        Radarr or Seerr
+                      </div>
+                    </div>
+                  </div>
+                  <p className="mt-4 text-sm leading-relaxed text-white/65">
+                    Scrape the fixed Rotten Tomatoes movie pages and use the existing safe Radarr
+                    lookup flow before routing matches.
+                  </p>
+                </button>
+
+                <button
+                  type="button"
+                  onClick={() => handleRunRottenTomatoesCategory('shows')}
+                  className="group rounded-[28px] border border-white/10 bg-white/[0.04] p-5 text-left transition hover:border-white/20 hover:bg-white/[0.08] active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-60"
+                  disabled={
+                    runMutation.isPending ||
+                    terminalState.rottenTomatoesUpcomingMovies?.status === 'running'
+                  }
+                >
+                  <div className="flex items-center gap-3">
+                    <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-cyan-400/20 bg-cyan-400/10">
+                      <Clapperboard className="h-6 w-6 text-cyan-200" />
+                    </div>
+                    <div>
+                      <div className="text-base font-bold text-white">TV Shows</div>
+                      <div className="text-xs uppercase tracking-[0.18em] text-cyan-200/70">
+                        Top {rottenTomatoesUpcomingSettingsDraft.showLimit}
+                      </div>
+                    </div>
+                  </div>
+                  <p className="mt-4 text-sm leading-relaxed text-white/65">
+                    Scrape score-qualified Rotten Tomatoes TV pages, stop at the saved Top limit,
+                    then send new shows to Sonarr or Seerr.
+                  </p>
+                </button>
+              </div>
+
+              <div className="mt-6 flex justify-end">
+                <button
+                  type="button"
+                  onClick={closeRottenTomatoesRunDialog}
+                  className="h-12 rounded-full border border-white/15 bg-white/5 px-6 text-white/80 transition hover:bg-white/10 active:scale-[0.98]"
+                >
+                  Cancel
+                </button>
+              </div>
             </motion.div>
           </motion.div>
         )}

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -51,7 +51,7 @@ Pick a feature area first, then jump into the full section below.
 
 > ### [Rotten Tomatoes Upcoming Movies](#rotten-tomatoes-upcoming-movies)
 >
-> Fixed-source Rotten Tomatoes discovery that routes safe matches to Radarr or Seerr.
+> Fixed-source Rotten Tomatoes movies + TV discovery with a saved TV Top count and shared Seerr routing.
 > [How does Rotten Tomatoes Upcoming Movies work?](#how-does-rotten-tomatoes-upcoming-movies-work) · [What sources does it check?](#what-sources-does-it-check) · [What does the Route via Seerr toggle do?](#what-does-the-route-via-seerr-toggle-do) · [What results should I expect after a run?](#what-results-should-i-expect-after-a-run)
 
 > ### [Immaculate Taste Collection](#immaculate-taste-collection)
@@ -421,34 +421,39 @@ Open in app: [Task Manager -> Rotten Tomatoes Upcoming Movies](/task-manager#job
 
 ### How does Rotten Tomatoes Upcoming Movies work?
 
-This task scrapes fixed Rotten Tomatoes upcoming and newest movie pages, merges the results, and routes safe matches to Radarr or, when enabled, to Seerr.
+This task can run movie discovery, TV discovery, or both. Saved scheduled and auto-runs use the card toggles, and when both branches are enabled they always run movies first, then TV shows.
 
 Run flow:
 
-1. Immaculaterr fetches each built-in Rotten Tomatoes source page.
-2. Movie cards are parsed from the page HTML, then deduplicated by normalized title and year.
-3. Radarr is checked once up front, then each candidate is matched conservatively before it is added to Radarr or requested in Seerr.
+1. Movie pages still use the existing safe Radarr lookup flow before titles are added to Radarr or requested in Seerr.
+2. TV pages are scraped from fixed Rotten Tomatoes browse URLs, filtered to shows with both critic and audience scores of at least 60, then deduplicated.
+3. TV discovery stops once the saved Top count is reached. The default is Top 10, and manual TV runs reuse that saved count instead of asking for a one-off value.
+4. Manual Run now lets you choose Movies or TV Shows for that single run without changing the saved card settings.
 
 ### What sources does it check?
 
 - One Rotten Tomatoes in-theaters newest page.
 - Eleven Rotten Tomatoes at-home newest pages for Fandango at Home, Apple TV+, Netflix, Prime Video, Disney+, Max, Peacock, Hulu, Paramount+, AMC+, and Acorn TV.
+- TV discovery uses fixed Rotten Tomatoes TV browse pages for newest releases plus the built-in streaming-provider pages.
+- TV only reads the first HTML page for each source. It does not use Load more or cursor pagination.
 - These URLs are fixed in code for this task, so there is no custom source editor on the card.
 - If one source page fails, the run keeps going and reports that source as skipped.
 
 ### What does the Route via Seerr toggle do?
 
-- When the toggle is off, matched movies are added directly to Radarr with the app's saved Radarr defaults.
-- When the toggle is on, matched movies are requested in Seerr instead of being added directly to Radarr.
-- Rotten Tomatoes titles are still matched conservatively through Radarr lookup first, so Seerr requests only happen for safe title and year matches.
-- If Seerr routing is enabled but Seerr is not configured, discovery still completes and the destination step is marked skipped.
+- When the toggle is off, matched movies are added directly to Radarr and new TV shows are added directly to Sonarr with the app's saved defaults.
+- When the toggle is on, both movies and TV shows are sent to Seerr instead of being added directly to Radarr or Sonarr.
+- Movie requests still depend on conservative Radarr lookup first, so Seerr requests only happen for safe movie title and year matches.
+- In Seerr mode there is no direct ARR add fallback for new items. If Seerr is missing, discovery still completes and the destination step is skipped.
+- Existing Sonarr shows can still be reconciled against Plex when Sonarr already has the series, even if new TV requests are being routed through Seerr.
 
 ### What results should I expect after a run?
 
-- Movies already present in Radarr, or already present/requested in Seerr, are counted as existing instead of surfacing as hard failures.
-- If Radarr is not configured, discovery still completes and the destination step is marked skipped. If Seerr routing is enabled but Seerr is not configured, the routing step is skipped too.
-- Rewind shows source-page counts plus destination outcomes for attempted, requested or added, existing, failed, and skipped movies.
-- This task does not use TMDB filters. Seerr routing is optional, but safe matching still relies on Radarr lookup.
+- The TV Top count defaults to 10 and controls how many score-qualified, deduplicated TV candidates are considered across all fixed TV sources.
+- Movies or shows that already exist in Radarr, Sonarr, or Seerr are counted as existing instead of surfacing as hard failures.
+- Existing Sonarr shows can have episode, season, and series monitoring updated so Plex copies stay unmonitored while missing episodes stay monitored.
+- Rewind now shows separate movie and TV steps plus TV-specific stats for source pages, score filtering, unresolved IDs, requests or adds, skips, and reconciliation counts.
+- If both Movies and TV Shows are turned off on the card, scheduled and auto-runs do nothing until at least one branch is enabled again.
 
 ## Immaculate Taste Collection
 

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -425,10 +425,10 @@ This task can run movie discovery, TV discovery, or both. Saved scheduled and au
 
 Run flow:
 
-1. Movie pages still use the existing safe Radarr lookup flow before titles are added to Radarr or requested in Seerr.
+1. Movie pages still use the existing safe Radarr lookup flow before titles are added to Radarr or requested in Seerr, and movie discovery stops once the saved Movie Top count is reached. The default is Top 20.
 2. TV pages are scraped from fixed Rotten Tomatoes browse URLs, filtered to shows with both critic and audience scores of at least 60, then deduplicated.
-3. TV discovery stops once the saved Top count is reached. The default is Top 10, and manual TV runs reuse that saved count instead of asking for a one-off value.
-4. Manual Run now lets you choose Movies or TV Shows for that single run without changing the saved card settings.
+3. TV discovery stops once the saved Top count is reached. The default is Top 10, and manual runs can choose a one-run Top count without changing the saved card values.
+4. Manual Run now lets you choose Movies or TV Shows, a one-run Route via Seerr toggle, and a one-run Top count. Those dialog choices do not change the saved card settings.
 
 ### What sources does it check?
 
@@ -449,7 +449,8 @@ Run flow:
 
 ### What results should I expect after a run?
 
-- The TV Top count defaults to 10 and controls how many score-qualified, deduplicated TV candidates are considered across all fixed TV sources.
+- The saved Movie Top count defaults to 20 and the saved TV Top count defaults to 10. They control how many deduplicated candidates are considered for each branch across the fixed Rotten Tomatoes sources.
+- Manual runs default to Top 10 in the dialog, but you can change that one-run count anywhere between 1 and 100 without changing the saved card limits.
 - Movies or shows that already exist in Radarr, Sonarr, or Seerr are counted as existing instead of surfacing as hard failures.
 - Existing Sonarr shows can have episode, season, and series monitoring updated so Plex copies stay unmonitored while missing episodes stay monitored.
 - Rewind now shows separate movie and TV steps plus TV-specific stats for source pages, score filtering, unresolved IDs, requests or adds, skips, and reconciliation counts.

--- a/doc/README.md
+++ b/doc/README.md
@@ -47,7 +47,7 @@ Major Features Include
 - **Discovery and maintenance jobs**:
   - `Fresh Out Of The Oven` builds recent-release movie and TV rows for titles a user has not watched yet.
   - `TMDB Upcoming Movies` finds upcoming movies with filter sets and routes matches to Radarr or Seerr.
-  - `Rotten Tomatoes Upcoming Movies` scrapes fixed Rotten Tomatoes pages and routes safe matches to Radarr or Seerr.
+  - `Rotten Tomatoes Upcoming Movies` scrapes fixed Rotten Tomatoes movie and TV pages, uses a saved TV Top count, and routes through Radarr or Sonarr directly or through Seerr for both media types.
   - Cleanup and ARR sync jobs help keep Plex, Radarr, and Sonarr tidy after imports and downloads, including season-aware Sonarr monitoring cleanup.
 - **History imports**:
   - Netflix CSV import creates dedicated Netflix import collections and feeds the main recommendation system.

--- a/doc/README.md
+++ b/doc/README.md
@@ -47,7 +47,7 @@ Major Features Include
 - **Discovery and maintenance jobs**:
   - `Fresh Out Of The Oven` builds recent-release movie and TV rows for titles a user has not watched yet.
   - `TMDB Upcoming Movies` finds upcoming movies with filter sets and routes matches to Radarr or Seerr.
-  - `Rotten Tomatoes Upcoming Movies` scrapes fixed Rotten Tomatoes movie and TV pages, uses a saved TV Top count, and routes through Radarr or Sonarr directly or through Seerr for both media types.
+  - `Rotten Tomatoes Upcoming Movies + TV Shows` scrapes fixed Rotten Tomatoes movie and TV pages, uses separate saved Movie Top 20 and TV Top 10 counts, and routes through Radarr or Sonarr directly or through Seerr for both media types.
   - Cleanup and ARR sync jobs help keep Plex, Radarr, and Sonarr tidy after imports and downloads, including season-aware Sonarr monitoring cleanup.
 - **History imports**:
   - Netflix CSV import creates dedicated Netflix import collections and feeds the main recommendation system.

--- a/doc/Version_History.md
+++ b/doc/Version_History.md
@@ -5,27 +5,22 @@ This file tracks notable changes by version.
 ## 1.7.8-beta-5
 
 - What's new in 1.7.8 beta 5:
-- Rotten Tomatoes Upcoming Movies + TV:
-  - The Rotten Tomatoes Task Manager card now saves Movies, TV Shows, and a TV Top count. TV defaults to Top 10, stays visible on the expanded card, and controls how many score-qualified, deduplicated TV candidates are considered across the fixed TV sources.
-  - Manual Run now opens a Movies or TV Shows chooser for this task. Manual TV runs reuse the saved Top count, while saved scheduled and auto-runs use the card settings and always run movies first, then TV.
-  - Route via Seerr now applies to both media types: movies still require safe Radarr lookup first, and new TV shows go to Seerr instead of falling back to direct Sonarr adds when Seerr mode is enabled.
-  - Existing Sonarr shows can still be reconciled against Plex so present episodes stay unmonitored, missing episodes remain monitored, and Rewind now shows separate movie and TV stages plus TV-specific routing and reconciliation stats.
-
-## 1.7.8-beta-4
-
-- What's new in 1.7.8 beta 4:
 - Confirm Monitored Sonarr cascade:
   - Confirm Monitored now requires Plex-verified playable media before Radarr movies or Sonarr episodes are treated as present.
   - Sonarr cascade still happens, but in ordered passes: all episodes first, then seasons, then series.
   - If every tracked positive-numbered season ends unmonitored, the series itself is unmonitored too.
 - Netflix import reliability (issue #199):
-  - Fixed `/api/import/netflix` failing with "column `releaseDate` does not exist" on older SQLite databases whose schema had drifted from the Prisma schema.
-  - `ImmaculateTasteMovieLibrary` and `ImmaculateTasteShowLibrary` rebuild paths now preserve `releaseDate` and `firstAirDate` instead of silently dropping them.
-  - Added an idempotent startup step that restores `releaseDate` and `firstAirDate` plus their indexes regardless of migration history state.
+  - Preserved `releaseDate` and `firstAirDate` when rebuilding `ImmaculateTasteMovieLibrary` and `ImmaculateTasteShowLibrary` so imports stop failing with "column does not exist".
+  - Added an idempotent ensure step that backfills `releaseDate` and `firstAirDate` on older SQLite databases regardless of migration history state.
+- Rotten Tomatoes Upcoming Movies + TV Shows:
+  - Rotten Tomatoes upcoming movie discovery now works with the current browse-page markup using the newer `rt-text` field wrappers instead of assuming legacy span-only cards.
+  - The task is now presented as `Rotten Tomatoes Upcoming Movies + TV Shows`, and the expanded card now saves Movies, TV Shows, Movie Top, and TV Top values. Movies default to Top 20, TV defaults to Top 10, and both ranges can be set from 1 to 100.
+  - Manual Run now opens a Movies or TV Shows chooser with a one-run `Route via Seerr` toggle and a one-run Top count. The dialog starts from the saved Seerr setting plus Top 10 every time and does not change the saved card settings.
+  - Movie discovery now stops once the deduplicated movie pool reaches the effective Movie Top count, matching the existing TV-stop behavior. Saved scheduled and auto-runs still use the card settings and always run movies first, then TV.
+  - Route via Seerr now applies to both media types: movies still require safe Radarr lookup first, and new TV shows go to Seerr instead of falling back to direct Sonarr adds when Seerr mode is enabled.
+  - Existing Sonarr shows can still be reconciled against Plex so present episodes stay unmonitored, missing episodes remain monitored, and Rewind now shows separate movie and TV stages plus TV-specific routing and reconciliation stats.
 
-  1.7.7
-
----
+## 1.7.7
 
 - What's new in 1.7.7:
 - Smarter recommendations:

--- a/doc/Version_History.md
+++ b/doc/Version_History.md
@@ -6,10 +6,10 @@ This file tracks notable changes by version.
 
 - What's new in 1.7.8 beta 5:
 - Rotten Tomatoes Upcoming Movies + TV:
-  - The Rotten Tomatoes Task Manager card now saves Movies, TV Shows, and a TV Top count, with TV defaulting to Top 10 and fetching only enough fixed TV pages to reach that deduplicated, score-qualified pool.
-  - Manual Run now opens a Movies or TV Shows chooser for this task, while saved scheduled and auto-runs use the card settings and always run movies first, then TV.
-  - Route via Seerr now applies to both media types: movies still require safe Radarr lookup first, and TV shows go to Seerr instead of falling back to direct Sonarr adds for new requests.
-  - Existing Sonarr shows can still be reconciled against Plex so present episodes stay unmonitored and missing episodes remain monitored.
+  - The Rotten Tomatoes Task Manager card now saves Movies, TV Shows, and a TV Top count. TV defaults to Top 10, stays visible on the expanded card, and controls how many score-qualified, deduplicated TV candidates are considered across the fixed TV sources.
+  - Manual Run now opens a Movies or TV Shows chooser for this task. Manual TV runs reuse the saved Top count, while saved scheduled and auto-runs use the card settings and always run movies first, then TV.
+  - Route via Seerr now applies to both media types: movies still require safe Radarr lookup first, and new TV shows go to Seerr instead of falling back to direct Sonarr adds when Seerr mode is enabled.
+  - Existing Sonarr shows can still be reconciled against Plex so present episodes stay unmonitored, missing episodes remain monitored, and Rewind now shows separate movie and TV stages plus TV-specific routing and reconciliation stats.
 
 ## 1.7.8-beta-4
 

--- a/doc/Version_History.md
+++ b/doc/Version_History.md
@@ -2,6 +2,15 @@
 
 This file tracks notable changes by version.
 
+## 1.7.8-beta-5
+
+- What's new in 1.7.8 beta 5:
+- Rotten Tomatoes Upcoming Movies + TV:
+  - The Rotten Tomatoes Task Manager card now saves Movies, TV Shows, and a TV Top count, with TV defaulting to Top 10 and fetching only enough fixed TV pages to reach that deduplicated, score-qualified pool.
+  - Manual Run now opens a Movies or TV Shows chooser for this task, while saved scheduled and auto-runs use the card settings and always run movies first, then TV.
+  - Route via Seerr now applies to both media types: movies still require safe Radarr lookup first, and TV shows go to Seerr instead of falling back to direct Sonarr adds for new requests.
+  - Existing Sonarr shows can still be reconciled against Plex so present episodes stay unmonitored and missing episodes remain monitored.
+
 ## 1.7.8-beta-4
 
 - What's new in 1.7.8 beta 4:

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "3481",
+  "message": "3483",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "3479",
+  "message": "3480",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "3483",
+  "message": "3484",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "3484",
+  "message": "3485",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "3480",
+  "message": "3481",
   "color": "blue"
 }


### PR DESCRIPTION
## Summary
- harden Confirm Monitored so Plex-verified playability gates completion and Sonarr cascade runs in episode, season, then series order
- improve Netflix import resilience on older databases that are missing legacy date columns
- expand Rotten Tomatoes discovery into `Rotten Tomatoes Upcoming Movies + TV Shows` with separate saved Movie/TV Top counts, one-run manual overrides, and shared Seerr routing
- refresh task help text, README/docs, and in-app What's New / version history for the new behavior

## Why
`develop` includes the queued 1.7.8-beta-5 release work that has not been promoted to `master` yet. This PR packages the latest job reliability fixes, the Rotten Tomatoes Movies + TV expansion, and the corresponding release-note updates into one release promotion.

## Impact
- Confirm Monitored is stricter about only treating actually playable Plex media as present before unmonitoring downstream items.
- Rotten Tomatoes task runs now support movies and TV together, saved per-branch Top counts, and one-run manual overrides without mutating saved settings.
- Seerr routing now applies consistently across both media types in the Rotten Tomatoes flow.
- Users see updated docs and What's New content that match the shipped task behavior.

## Validation
- `npm -w apps/web exec -- eslint -- src/pages/TaskManagerPage.tsx src/pages/FaqPage.tsx src/lib/version-history.ts`
- `npm -w apps/api exec -- eslint -- src/jobs/rotten-tomatoes-upcoming-movies.job.ts src/jobs/rotten-tomatoes-upcoming-movies.job.spec.ts src/jobs/job-registry.ts`
- `npm -w apps/api run test -- --runInBand src/jobs/rotten-tomatoes-upcoming-movies.job.spec.ts`
- `npm -w apps/web run build`
- `npm run test`
- `npm run security:ci`
- `docker compose -f docker/immaculaterr/docker-compose.source.yml up -d --build --force-recreate immaculaterr`
- `curl -I http://127.0.0.1:5454/` returned `HTTP/1.1 200 OK`

## Notes
- The Docker rebuild completed successfully from the local workspace source.
- The web build still reports the existing non-blocking Vite chunk-size warnings.
- Docker also repeated the existing warning that `immaculaterr-data` already exists outside Compose ownership.
