### PR TITLE
Release 1.7.8-beta-6 from develop to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,42 @@ The examples above set the app container timezone to `America/New_York`. Change 
 For local HTTPS, run [`docker/immaculaterr/install-local-ca.sh`](docker/immaculaterr/install-local-ca.sh) on the Docker host (recommended), or accept your browser's risk warning when prompted (you may need to re-accept in later browser sessions).
 ##
 
+## Optional: host under `/recommendations`
+
+Set `APP_BASE_PATH=/recommendations` on the app container and keep `TRUST_PROXY=1` when a reverse proxy sits in front of Immaculaterr.
+
+Example `.env` or compose overrides:
+
+```env
+APP_BASE_PATH=/recommendations
+TRUST_PROXY=1
+```
+
+After that, open:
+
+- `http://<server-ip>:5454/recommendations/`
+- `https://<server-ip>:5464/recommendations/`
+
+In the app, open `Profile` to confirm the active `Public path` value.
+
+Example nginx reverse proxy:
+
+```nginx
+location = /recommendations {
+  return 301 /recommendations/;
+}
+
+location /recommendations/ {
+  proxy_pass http://127.0.0.1:5454;
+  proxy_http_version 1.1;
+  proxy_set_header Host $host;
+  proxy_set_header X-Forwarded-Host $host;
+  proxy_set_header X-Forwarded-Proto $scheme;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Port $server_port;
+}
+```
+
 ## Documentation
 - Setup guide: [`doc/setupguide.md`](doc/setupguide.md)
 - FAQ: [`doc/FAQ.md`](doc/FAQ.md)

--- a/apps/api/src/app.dto.ts
+++ b/apps/api/src/app.dto.ts
@@ -21,4 +21,7 @@ export class AppMetaResponseDto {
 
   @ApiProperty({ example: '2026-01-09T15:54:13.000Z', nullable: true })
   buildTime!: string | null;
+
+  @ApiProperty({ example: '/recommendations' })
+  publicBasePath!: string;
 }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -29,8 +29,17 @@ import { API_STATIC_EXCLUDE_PATH } from './app.constants';
 import { ArrInstanceModule } from './arr-instances/arr-instance.module';
 import { ImmaculateTasteProfileModule } from './immaculate-taste-profiles/immaculate-taste-profile.module';
 import { ImportModule } from './import/import.module';
+import {
+  buildAppRenderPath,
+  buildPrefixedStaticExcludePath,
+  readAppBasePath,
+} from './public-base-path';
 
 const webDistPath = join(__dirname, '..', '..', 'web', 'dist');
+const appBasePath = readAppBasePath();
+const staticExcludePaths = appBasePath
+  ? [API_STATIC_EXCLUDE_PATH, buildPrefixedStaticExcludePath(appBasePath)]
+  : [API_STATIC_EXCLUDE_PATH];
 const staticImports = existsSync(webDistPath)
   ? [
       ServeStaticModule.forRoot({
@@ -38,7 +47,13 @@ const staticImports = existsSync(webDistPath)
         // Keep API routes on the Nest side.
         // NOTE: path-to-regexp v8 no longer supports legacy regexp syntax like "/api/(.*)".
         // Use an optional wildcard group instead: matches "/api" and anything under it.
-        exclude: [API_STATIC_EXCLUDE_PATH],
+        exclude: staticExcludePaths,
+        ...(appBasePath
+          ? {
+              serveRoot: appBasePath,
+              renderPath: buildAppRenderPath(appBasePath),
+            }
+          : {}),
       }),
     ]
   : [];

--- a/apps/api/src/app.service.ts
+++ b/apps/api/src/app.service.ts
@@ -4,6 +4,7 @@ import { access, stat } from 'node:fs/promises';
 import type { HealthResponseDto } from './app.dto';
 import { PrismaService } from './db/prisma.service';
 import { readAppMeta } from './app.meta';
+import { readAppBasePath } from './public-base-path';
 
 export type ReadinessCheck =
   | { ok: true }
@@ -33,7 +34,10 @@ export class AppService {
   }
 
   getMeta() {
-    return readAppMeta();
+    return {
+      ...readAppMeta(),
+      publicBasePath: readAppBasePath(),
+    };
   }
 
   async getReadiness(): Promise<ReadinessResponse> {

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -35,6 +35,11 @@ import {
   WEBHOOKS_PLEX_CANONICAL_PREFIX,
 } from './app.constants';
 import { sanitizePathForLog, truncateForLog } from './log.utils';
+import {
+  createAppBasePathApiRewriteMiddleware,
+  createAppBasePathRootRedirectMiddleware,
+  readAppBasePath,
+} from './public-base-path';
 
 function ensureLegacyGlobals() {
   const g = globalThis as Record<string, unknown>;
@@ -138,6 +143,13 @@ async function bootstrap() {
   app.use(securityHeadersMiddleware);
   app.use(privateCacheMiddleware);
   app.use(cookieParser());
+
+  const appBasePath = readAppBasePath();
+
+  if (appBasePath) {
+    app.use(createAppBasePathApiRewriteMiddleware(appBasePath));
+    app.use(createAppBasePathRootRedirectMiddleware(appBasePath));
+  }
 
   // Compatibility: people (and some guides) often paste Plex webhook URLs without the `/api` prefix.
   // Accept `/webhooks/plex` as an alias for `/api/webhooks/plex`.
@@ -367,7 +379,7 @@ async function bootstrap() {
 
   const url = await app.getUrl().catch(() => `http://${host}:${port}`);
   bootstrapLogger.log(
-    `API listening: ${url}${API_PREFIX_PATH} (dataDir=${process.env.APP_DATA_DIR ?? 'n/a'})`,
+    `API listening: ${url}${API_PREFIX_PATH} (dataDir=${process.env.APP_DATA_DIR ?? 'n/a'}, publicBasePath=${appBasePath || '/'})`,
   );
 }
 void bootstrap().catch((err) => {

--- a/apps/api/src/public-base-path.spec.ts
+++ b/apps/api/src/public-base-path.spec.ts
@@ -1,0 +1,39 @@
+import { buildAppRenderPath, normalizeAppBasePath } from './public-base-path';
+
+describe('public base path helpers', () => {
+  it('normalizes empty and root values to no prefix', () => {
+    expect(normalizeAppBasePath(undefined)).toBe('');
+    expect(normalizeAppBasePath('')).toBe('');
+    expect(normalizeAppBasePath('/')).toBe('');
+    expect(normalizeAppBasePath('  /  ')).toBe('');
+  });
+
+  it('strips trailing slashes from slash-prefixed paths', () => {
+    expect(normalizeAppBasePath('/recommendations')).toBe('/recommendations');
+    expect(normalizeAppBasePath('/recommendations/')).toBe('/recommendations');
+    expect(normalizeAppBasePath('/recommendations///')).toBe(
+      '/recommendations',
+    );
+    expect(normalizeAppBasePath(' /nested/path/ ')).toBe('/nested/path');
+  });
+
+  it('rejects invalid APP_BASE_PATH values', () => {
+    expect(() => normalizeAppBasePath('recommendations')).toThrow(
+      /APP_BASE_PATH/,
+    );
+    expect(() => normalizeAppBasePath('http://example.com/path')).toThrow(
+      /APP_BASE_PATH/,
+    );
+    expect(() => normalizeAppBasePath('/recommendations?x=1')).toThrow(
+      /APP_BASE_PATH/,
+    );
+    expect(() => normalizeAppBasePath('/recommendations#hash')).toThrow(
+      /APP_BASE_PATH/,
+    );
+  });
+
+  it('uses the render path shape Nest can append to a prefixed static mount', () => {
+    expect(buildAppRenderPath('')).toBe('');
+    expect(buildAppRenderPath('/recommendations')).toBe('{*path}');
+  });
+});

--- a/apps/api/src/public-base-path.ts
+++ b/apps/api/src/public-base-path.ts
@@ -1,0 +1,83 @@
+import type { NextFunction, Request, Response } from 'express';
+import { API_PREFIX_PATH, API_STATIC_EXCLUDE_PATH } from './app.constants';
+
+const APP_BASE_PATH_INVALID_MESSAGE =
+  'APP_BASE_PATH must be empty or start with "/" and must not include query or hash fragments.';
+
+const TRAILING_SLASHES_REGEX = /\/+$/;
+const INVALID_BASE_PATH_CHARS_REGEX = /[?#]/;
+
+export function normalizeAppBasePath(raw: string | null | undefined): string {
+  const value = `${raw ?? ''}`.trim();
+  if (!value || value === '/') return '';
+  if (!value.startsWith('/') || INVALID_BASE_PATH_CHARS_REGEX.test(value)) {
+    throw new Error(APP_BASE_PATH_INVALID_MESSAGE);
+  }
+
+  const normalized = value.replace(TRAILING_SLASHES_REGEX, '');
+  return normalized || '';
+}
+
+export function readAppBasePath(raw = process.env.APP_BASE_PATH): string {
+  return normalizeAppBasePath(raw);
+}
+
+export function joinWithAppBasePath(
+  basePath: string,
+  path: `/${string}` | '/',
+): string {
+  if (path === '/') return basePath ? `${basePath}/` : '/';
+  return basePath ? `${basePath}${path}` : path;
+}
+
+export function buildPrefixedApiPath(basePath: string): string {
+  return joinWithAppBasePath(basePath, API_PREFIX_PATH);
+}
+
+export function buildPrefixedStaticExcludePath(basePath: string): string {
+  if (!basePath) return API_STATIC_EXCLUDE_PATH;
+  return `${buildPrefixedApiPath(basePath)}{/*path}`;
+}
+
+export function buildAppRenderPath(basePath: string): string {
+  return basePath ? '{*path}' : '';
+}
+
+export function createAppBasePathApiRewriteMiddleware(basePath: string) {
+  if (!basePath) {
+    return (_req: Request, _res: Response, next: NextFunction) => next();
+  }
+
+  const publicApiPath = buildPrefixedApiPath(basePath);
+  const publicApiPathWithSlash = `${publicApiPath}/`;
+  const publicApiPathWithQuery = `${publicApiPath}?`;
+
+  return (req: Request, _res: Response, next: NextFunction) => {
+    const url = req.url || '';
+    if (
+      url === publicApiPath ||
+      url.startsWith(publicApiPathWithSlash) ||
+      url.startsWith(publicApiPathWithQuery)
+    ) {
+      req.url = `${API_PREFIX_PATH}${url.slice(publicApiPath.length)}`;
+    }
+    next();
+  };
+}
+
+export function createAppBasePathRootRedirectMiddleware(basePath: string) {
+  const redirectTarget = joinWithAppBasePath(basePath, '/');
+
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (
+      !basePath ||
+      (req.method !== 'GET' && req.method !== 'HEAD') ||
+      req.url !== '/'
+    ) {
+      next();
+      return;
+    }
+
+    res.redirect(302, redirectTarget);
+  };
+}

--- a/apps/api/src/version.ts
+++ b/apps/api/src/version.ts
@@ -1,6 +1,6 @@
 // Single source of truth for the app version.
 // Bump this constant only.
 
-export const APP_VERSION = '1.7.8-beta-5' as const;
+export const APP_VERSION = '1.7.8-beta-6' as const;
 
 export const APP_VERSION_TAG = `v${APP_VERSION}` as const;

--- a/apps/api/test/app.e2e-spec.ts
+++ b/apps/api/test/app.e2e-spec.ts
@@ -2,24 +2,55 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 import { App } from 'supertest/types';
-import { AppModule } from '../src/app.module';
+import { AppController } from '../src/app.controller';
+import { AppService } from '../src/app.service';
+import { PrismaService } from '../src/db/prisma.service';
+import { createAppBasePathApiRewriteMiddleware } from '../src/public-base-path';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication<App>;
 
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule],
+      controllers: [AppController],
+      providers: [
+        AppService,
+        {
+          provide: PrismaService,
+          useValue: {
+            $queryRaw: jest.fn(),
+          } satisfies Partial<PrismaService>,
+        },
+      ],
     }).compile();
 
     app = moduleFixture.createNestApplication();
+    app.use(createAppBasePathApiRewriteMiddleware('/recommendations'));
     app.setGlobalPrefix('api');
     await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
   });
 
   it('/api/health (GET)', () => {
     return request(app.getHttpServer())
       .get('/api/health')
+      .expect(200)
+      .expect((res) => {
+        const body = res.body as unknown;
+        const status =
+          body && typeof body === 'object'
+            ? (body as Record<string, unknown>)['status']
+            : null;
+        if (status !== 'ok') throw new Error('Expected { status: "ok" }');
+      });
+  });
+
+  it('/recommendations/api/health (GET)', () => {
+    return request(app.getHttpServer())
+      .get('/recommendations/api/health')
       .expect(200)
       .expect((res) => {
         const body = res.body as unknown;

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -2,10 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="icon" type="image/png" sizes="192x192" href="/icon-192.png" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-    <link rel="manifest" href="/manifest.json" />
+    <base href="/" />
+    <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
+    <link rel="icon" type="image/png" sizes="192x192" href="./icon-192.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="./apple-touch-icon.png" />
+    <link rel="manifest" href="./manifest.json" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
@@ -19,6 +20,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>

--- a/apps/web/public/manifest.json
+++ b/apps/web/public/manifest.json
@@ -2,25 +2,25 @@
   "name": "Immaculaterr",
   "short_name": "Immaculaterr",
   "description": "Automate your media collection curation with Immaculaterr",
-  "start_url": "/",
+  "start_url": "./",
   "display": "standalone",
   "background_color": "#1a1a1a",
   "theme_color": "#facc15",
   "icons": [
     {
-      "src": "/icon-192.png",
+      "src": "./icon-192.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "/icon-512.png",
+      "src": "./icon-512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "/icon-512.png",
+      "src": "./icon-512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable"

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -19,6 +19,7 @@ import { SetupUnraidPage } from '@/pages/SetupUnraidPage';
 import { VersionHistoryPage } from '@/pages/VersionHistoryPage';
 import { DebuggerPage } from '@/pages/DebuggerPage';
 import { ProfilePage } from '@/pages/ProfilePage';
+import { getPublicBasePath } from '@/lib/public-path';
 
 // skipcq: SCT-A000 - Legacy localStorage cleanup key, not a credential.
 const LEGACY_ONBOARDING_STORAGE_KEY = 'tcp_onboarding_v1';
@@ -43,6 +44,8 @@ const LegacyJobsRedirect = () => {
 };
 
 const App = () => {
+  const publicBasePath = getPublicBasePath();
+
   useEffect(() => {
     // One-time cleanup: stop using legacy localStorage onboarding/secrets.
     // Note: we only remove the legacy key; we never store secrets in browser storage.
@@ -54,7 +57,7 @@ const App = () => {
   }, []);
 
   return (
-    <BrowserRouter>
+    <BrowserRouter basename={publicBasePath || undefined}>
       <Routes>
         <Route path="/" element={<Outlet />}>
           {/* All pages require authentication and wizard completion */}

--- a/apps/web/src/api/app.ts
+++ b/apps/web/src/api/app.ts
@@ -6,6 +6,7 @@ export type AppMetaResponse = {
   version: string;
   buildSha: string | null;
   buildTime: string | null;
+  publicBasePath: string;
 };
 
 export function getAppMeta() {

--- a/apps/web/src/api/constants.ts
+++ b/apps/web/src/api/constants.ts
@@ -1,3 +1,5 @@
+import { withPublicBasePath } from '@/lib/public-path';
+
 export const API_PREFIX = '/api';
 export const JSON_HEADERS = { 'Content-Type': 'application/json' } as const;
 export const PLEX_OAUTH_POLL_HEADERS = {
@@ -5,7 +7,7 @@ export const PLEX_OAUTH_POLL_HEADERS = {
 } as const;
 
 export function apiPath(path: `/${string}`): string {
-  return `${API_PREFIX}${path}`;
+  return `${withPublicBasePath(API_PREFIX)}${path}`;
 }
 
 export function toQuerySuffix(searchParams: URLSearchParams): string {

--- a/apps/web/src/app/AppShell.tsx
+++ b/apps/web/src/app/AppShell.tsx
@@ -35,6 +35,7 @@ import {
   normalizeVersion,
 } from '@/lib/version-history';
 import { clearClientUserData } from '@/lib/security/clearClientUserData';
+import { withPublicBasePath } from '@/lib/public-path';
 
 const readOnboardingCompleted = (settings: unknown): boolean => {
   if (!settings || typeof settings !== 'object' || Array.isArray(settings)) return false;
@@ -279,7 +280,7 @@ export const AppShell = () => {
     onSuccess: async () => {
       queryClient.clear();
       await clearClientUserData();
-      window.location.href = '/';
+      window.location.href = withPublicBasePath('/');
     },
   });
 

--- a/apps/web/src/app/WhatsNewModal.tsx
+++ b/apps/web/src/app/WhatsNewModal.tsx
@@ -1,4 +1,5 @@
 import { motion, AnimatePresence } from 'motion/react';
+import { Link } from 'react-router-dom';
 
 import {
   splitVersionHistoryLabel,
@@ -86,12 +87,12 @@ export function WhatsNewModal(props: {
 
             <div className="border-t border-white/10 bg-[#090a0d]/75 px-5 py-4 pb-[calc(env(safe-area-inset-bottom)+1rem)] sm:px-6">
               <div className="flex items-center justify-between gap-4">
-                <a
-                  href="/version-history"
+                <Link
+                  to="/version-history"
                   className="text-xs text-white/55 transition-colors hover:text-white/85 sm:text-sm"
                 >
                   View Full Version History
-                </a>
+                </Link>
 
                 <button
                   type="button"

--- a/apps/web/src/components/MobileNavigation.tsx
+++ b/apps/web/src/components/MobileNavigation.tsx
@@ -18,6 +18,10 @@ import { useSafeNavigate } from '@/lib/navigation';
 import { createDebuggerUrl } from '@/lib/debugger';
 import { formatDisplayVersion } from '@/lib/version-history';
 import { clearClientUserData } from '@/lib/security/clearClientUserData';
+import {
+  toPublicHref,
+  withPublicBasePath,
+} from '@/lib/public-path';
 
 interface MobileNavigationProps {
   onLogout: () => void;
@@ -84,7 +88,7 @@ export function MobileNavigation({ onLogout }: MobileNavigationProps) {
       window.matchMedia?.('(display-mode: standalone)')?.matches ||
       Boolean((navigator as unknown as { standalone?: boolean } | undefined)?.standalone);
     if (isStandalone) {
-      window.location.assign(dest);
+      window.location.assign(toPublicHref(dest));
       return;
     }
 
@@ -106,7 +110,6 @@ export function MobileNavigation({ onLogout }: MobileNavigationProps) {
     Boolean(updatesQuery.data?.updateAvailable) && Boolean(updatesQuery.data?.latestVersion);
   const updateLabel = formatDisplayVersion(updatesQuery.data?.latestVersion ?? null);
   const currentLabel = formatDisplayVersion(updatesQuery.data?.currentVersion ?? null);
-
   useEffect(() => {
     const updatePositions = () => {
       const positions = buttonRefs.current.map((ref) => {
@@ -145,7 +148,7 @@ export function MobileNavigation({ onLogout }: MobileNavigationProps) {
     try {
       await resetDev();
       await clearClientUserData();
-      window.location.href = '/';
+      window.location.href = withPublicBasePath('/');
     } catch {
       setResetError('Network error while resetting account.');
     } finally {

--- a/apps/web/src/components/Navigation.tsx
+++ b/apps/web/src/components/Navigation.tsx
@@ -18,6 +18,7 @@ import { useSafeNavigate } from '@/lib/navigation';
 import { createDebuggerUrl } from '@/lib/debugger';
 import { formatDisplayVersion } from '@/lib/version-history';
 import { clearClientUserData } from '@/lib/security/clearClientUserData';
+import { withPublicBasePath } from '@/lib/public-path';
 
 interface NavItem {
   label: string;
@@ -85,7 +86,6 @@ export function Navigation() {
     Boolean(updatesQuery.data?.updateAvailable) && Boolean(updatesQuery.data?.latestVersion);
   const updateLabel = formatDisplayVersion(updatesQuery.data?.latestVersion ?? null);
   const currentLabel = formatDisplayVersion(updatesQuery.data?.currentVersion ?? null);
-
   useEffect(() => {
     if (!updateAvailable || !updateLabel) return;
 
@@ -251,7 +251,7 @@ export function Navigation() {
       // Clear everything like logout
       queryClient.clear();
       await clearClientUserData();
-      window.location.href = '/';
+      window.location.href = withPublicBasePath('/');
     },
     onError: (err) => {
       setResetError(err instanceof Error ? err.message : String(err));

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { useNavigate, type NavigateOptions, type To } from 'react-router-dom';
+import { toPublicHref } from '@/lib/public-path';
 
 const ROUTER_PATH_DATA_KEY = 'routerPath';
 
@@ -47,7 +48,7 @@ export function useSafeNavigate() {
         try {
           const routerPath = getRouterPath();
           if (routerPath && routerPath !== destPath) {
-            window.location.assign(href || destPath);
+            window.location.assign(toPublicHref(href || destPath));
           }
         } catch {
           // ignore

--- a/apps/web/src/lib/public-path.ts
+++ b/apps/web/src/lib/public-path.ts
@@ -1,0 +1,53 @@
+const ABSOLUTE_URL_REGEX = /^[a-zA-Z][a-zA-Z\d+.-]*:/;
+const TRAILING_SLASHES_REGEX = /\/+$/;
+
+function normalizeBasePath(pathname: string): string {
+  const trimmed = (pathname ?? '').trim();
+  if (!trimmed || trimmed === '/') return '';
+
+  const normalized = trimmed.replace(TRAILING_SLASHES_REGEX, '');
+  return normalized === '/' ? '' : normalized;
+}
+
+function isAlreadyPrefixed(basePath: string, path: string): boolean {
+  if (!basePath) return false;
+  return path === basePath || path.startsWith(`${basePath}/`);
+}
+
+export function getPublicBasePath(): string {
+  if (typeof document === 'undefined' || !document.baseURI) return '';
+
+  try {
+    return normalizeBasePath(new URL(document.baseURI).pathname);
+  } catch {
+    return '';
+  }
+}
+
+export function withPublicBasePath(path: `/${string}` | '/'): string {
+  const basePath = getPublicBasePath();
+  if (!basePath) return path;
+  if (isAlreadyPrefixed(basePath, path)) return path;
+  if (path === '/') return `${basePath}/`;
+  return `${basePath}${path}`;
+}
+
+export function toPublicHref(href: string): string {
+  const trimmed = (href ?? '').trim();
+  if (!trimmed) return trimmed;
+  if (ABSOLUTE_URL_REGEX.test(trimmed) || trimmed.startsWith('//')) {
+    return trimmed;
+  }
+  if (!trimmed.startsWith('/')) return trimmed;
+
+  try {
+    const url = new URL(trimmed, window.location.origin);
+    const basePath = getPublicBasePath();
+    if (isAlreadyPrefixed(basePath, url.pathname)) {
+      return `${url.pathname}${url.search}${url.hash}`;
+    }
+    return `${withPublicBasePath(url.pathname as `/${string}` | '/')}${url.search}${url.hash}`;
+  } catch {
+    return withPublicBasePath(trimmed as `/${string}` | '/');
+  }
+}

--- a/apps/web/src/lib/version-history.ts
+++ b/apps/web/src/lib/version-history.ts
@@ -39,72 +39,34 @@ export const VERSION_HISTORY_ENTRIES: VersionHistoryEntry[] = [
   {
     version: '1.7.8-beta-6',
     popupHighlights: [
-      'Prefix-hosted deployments now work under /recommendations without a separate web build.',
-      'The app derives its public path from the rendered document base, so router links, API calls, and fallback navigations stay inside the configured prefix.',
-      'Docker and setup docs now include APP_BASE_PATH=/recommendations guidance plus an nginx reverse-proxy example.',
-      'There are no Prisma schema, migration, or data changes in this beta.',
+      'Prefix hosting under /recommendations now works across the app, API, and Docker setup.',
+      'Confirm Monitored is stricter and now checks Plex-playable media before Radarr or Sonarr items are treated as present.',
+      'Rotten Tomatoes Upcoming now handles separate Movies and TV settings with cleaner one-run options.',
+      'Netflix import is safer on older SQLite databases, with no Prisma or stored-data changes in this beta.',
     ],
     sections: [
       {
-        title: 'Prefix-hosted app + API support',
+        title: 'Hosting and routing',
         bullets: [
-          'Added APP_BASE_PATH support so the SPA, static assets, and public API can be served under /recommendations while the internal Nest API routes stay on /api.',
-          'Requests to /recommendations/api/... are now rewritten onto the existing /api/... handlers, so prefixed reverse-proxy traffic no longer falls through to the SPA shell.',
-          'When a public prefix is configured, the app redirects bare / to /recommendations/ and exposes the active public path in Profile plus GET /api/meta.',
+          'Added APP_BASE_PATH support so Immaculaterr can run under /recommendations without a separate web build.',
+          'Prefixed API requests now rewrite cleanly to /api/..., and Profile shows the active Public path alongside GET /api/meta.',
+          'Web assets, router links, API helpers, and logout/reset flows now stay inside the configured public path.',
         ],
       },
       {
-        title: 'Frontend path handling',
+        title: 'Confirm Monitored and imports',
         bullets: [
-          'Production assets now use a runtime-friendly relative base, and the React app derives its effective basename from the rendered document base instead of hardcoding root.',
-          'API helpers, standalone/PWA navigations, safe-navigate fallbacks, version-history links, and logout/reset redirects now stay inside the configured public prefix.',
-          'Profile now shows a read-only Public path field so deployments are easier to verify at a glance.',
-        ],
-      },
-      {
-        title: 'Docker and deployment guidance',
-        bullets: [
-          'Container startup now patches the built web shell base href from APP_BASE_PATH, so one image can serve either root or /recommendations deployments.',
-          'Compose templates and setup docs now pass APP_BASE_PATH through directly and keep TRUST_PROXY=1 called out for reverse-proxy deployments.',
-          'No Prisma schema, migration, generated-client, or stored-data changes are included in this beta.',
-        ],
-      },
-    ],
-  },
-  {
-    version: '1.7.8-beta-5',
-    popupHighlights: [
-      'Confirm Monitored now requires Plex-verified playable media and runs Sonarr cascade in episode, season, then series order.',
-      'Netflix import no longer fails when legacy databases are missing the releaseDate column.',
-      'Rotten Tomatoes Upcoming Movies + TV Shows now saves separate Movie Top 20 and TV Top 10 counts on the task card.',
-      'Manual Run for Rotten Tomatoes now includes one-run Movies or TV selection, Route via Seerr, and a Top count without changing saved settings.',
-      'Rotten Tomatoes movie discovery now respects the saved or one-run Movie Top count, while saved auto-runs still process movies before TV.',
-    ],
-    sections: [
-      {
-        title: 'Confirm Monitored Sonarr cascade',
-        bullets: [
-          'Confirm Monitored now requires Plex-verified playable media before Radarr movies or Sonarr episodes are treated as present.',
-          'Sonarr cascade still happens, but in ordered passes: all episodes first, then seasons, then series.',
-          'If every tracked positive-numbered season ends unmonitored, the series itself is unmonitored too.',
-        ],
-      },
-      {
-        title: 'Netflix import reliability (issue #199)',
-        bullets: [
-          'Preserved releaseDate and firstAirDate when rebuilding ImmaculateTasteMovieLibrary and ImmaculateTasteShowLibrary so imports stop failing with "column does not exist".',
-          'Added an idempotent ensure step that backfills releaseDate and firstAirDate on older SQLite databases regardless of migration history state.',
+          'Confirm Monitored now requires Plex-verified playable media before Radarr movies or Sonarr episodes count as present.',
+          'Sonarr confirmation now runs in order: episodes first, then seasons, then series.',
+          'Netflix import now handles older SQLite databases that are missing releaseDate or firstAirDate columns.',
         ],
       },
       {
         title: 'Rotten Tomatoes Upcoming Movies + TV Shows',
         bullets: [
-          "Rotten Tomatoes upcoming movie discovery now works with the current browse-page markup using the newer rt-text field wrappers instead of assuming legacy span-only cards.",
-          'The task is now presented as Rotten Tomatoes Upcoming Movies + TV Shows, and the expanded card now saves Movies, TV Shows, Movie Top, and TV Top values. Movies default to Top 20, TV defaults to Top 10, and both ranges can be set from 1 to 100.',
-          'Manual Run now opens a Movies or TV Shows chooser with a one-run Route via Seerr toggle and a one-run Top count. The dialog starts from the saved Seerr setting plus Top 10 every time and does not change the saved card settings.',
-          'Movie discovery now stops once the deduplicated movie pool reaches the effective Movie Top count, matching the existing TV-stop behavior. Saved scheduled and auto-runs still use the card settings and always run movies first, then TV.',
-          'Route via Seerr now applies to both media types: movies still require safe Radarr lookup first, and new TV shows go to Seerr instead of falling back to direct Sonarr adds when Seerr mode is enabled.',
-          'Existing Sonarr shows can still be reconciled against Plex so present episodes stay unmonitored, missing episodes remain monitored, and Rewind now shows separate movie and TV stages plus TV-specific routing and reconciliation stats.',
+          'The task now supports separate Movies and TV Shows settings, including independent Top counts.',
+          'Manual Run now lets you choose media type, Top count, and Route via Seerr without changing saved settings.',
+          'Discovery, routing, and reconciliation are now clearer for both movies and TV, with better Rewind reporting.',
         ],
       },
     ],

--- a/apps/web/src/lib/version-history.ts
+++ b/apps/web/src/lib/version-history.ts
@@ -37,6 +37,41 @@ export function splitVersionHistoryLabel(
 
 export const VERSION_HISTORY_ENTRIES: VersionHistoryEntry[] = [
   {
+    version: '1.7.8-beta-6',
+    popupHighlights: [
+      'Prefix-hosted deployments now work under /recommendations without a separate web build.',
+      'The app derives its public path from the rendered document base, so router links, API calls, and fallback navigations stay inside the configured prefix.',
+      'Docker and setup docs now include APP_BASE_PATH=/recommendations guidance plus an nginx reverse-proxy example.',
+      'There are no Prisma schema, migration, or data changes in this beta.',
+    ],
+    sections: [
+      {
+        title: 'Prefix-hosted app + API support',
+        bullets: [
+          'Added APP_BASE_PATH support so the SPA, static assets, and public API can be served under /recommendations while the internal Nest API routes stay on /api.',
+          'Requests to /recommendations/api/... are now rewritten onto the existing /api/... handlers, so prefixed reverse-proxy traffic no longer falls through to the SPA shell.',
+          'When a public prefix is configured, the app redirects bare / to /recommendations/ and exposes the active public path in Profile plus GET /api/meta.',
+        ],
+      },
+      {
+        title: 'Frontend path handling',
+        bullets: [
+          'Production assets now use a runtime-friendly relative base, and the React app derives its effective basename from the rendered document base instead of hardcoding root.',
+          'API helpers, standalone/PWA navigations, safe-navigate fallbacks, version-history links, and logout/reset redirects now stay inside the configured public prefix.',
+          'Profile now shows a read-only Public path field so deployments are easier to verify at a glance.',
+        ],
+      },
+      {
+        title: 'Docker and deployment guidance',
+        bullets: [
+          'Container startup now patches the built web shell base href from APP_BASE_PATH, so one image can serve either root or /recommendations deployments.',
+          'Compose templates and setup docs now pass APP_BASE_PATH through directly and keep TRUST_PROXY=1 called out for reverse-proxy deployments.',
+          'No Prisma schema, migration, generated-client, or stored-data changes are included in this beta.',
+        ],
+      },
+    ],
+  },
+  {
     version: '1.7.8-beta-5',
     popupHighlights: [
       'Confirm Monitored now requires Plex-verified playable media and runs Sonarr cascade in episode, season, then series order.',

--- a/apps/web/src/pages/FaqPage.tsx
+++ b/apps/web/src/pages/FaqPage.tsx
@@ -224,6 +224,50 @@ export const FaqPage = () => {
             </>
           ),
         },
+        {
+          id: 'getting-started-public-path',
+          question: 'How do I change the Public path?',
+          answer: (
+            <>
+              <p>
+                You cannot change the Public path from inside Immaculaterr. That value is read-only
+                and reflects how the app is currently being served by Docker and your reverse proxy.
+              </p>
+              <ol className="list-decimal pl-5 space-y-1">
+                <li>
+                  Set <code className="font-mono">APP_BASE_PATH=/recommendations</code> in your
+                  Docker environment.
+                </li>
+                <li>
+                  Keep <code className="font-mono">TRUST_PROXY=1</code> enabled.
+                </li>
+                <li>
+                  Make sure your proxy forwards <code className="font-mono">/recommendations/</code>{' '}
+                  to Immaculaterr.
+                </li>
+                <li>Recreate or restart the Immaculaterr container.</li>
+                <li>
+                  Open the app on <code className="font-mono">/recommendations/</code> and confirm
+                  the result in{' '}
+                  <Link to="/profile#profile-public-path-panel" className={faqLinkClass}>
+                    Profile - Public path
+                  </Link>
+                  .
+                </li>
+              </ol>
+              <p>
+                Use{' '}
+                <Link
+                  to="/setup#update-paths-public-path-hosting"
+                  className={faqLinkClass}
+                >
+                  Setup - Public path hosting
+                </Link>{' '}
+                for the deployment steps.
+              </p>
+            </>
+          ),
+        },
       ],
     },
     {

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useState, type ChangeEvent, type FormEvent } from 'react';
+import { Link } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { motion, useAnimation } from 'motion/react';
 import { ShieldCheck, UserRoundCog } from 'lucide-react';
@@ -23,6 +24,7 @@ import {
   APP_BG_HIGHLIGHT_CLASS,
   APP_BG_IMAGE_URL,
 } from '@/lib/ui-classes';
+import { getPublicBasePath, withPublicBasePath } from '@/lib/public-path';
 
 const MIN_PASSWORD_LENGTH = 10;
 
@@ -81,7 +83,7 @@ export function ProfilePage() {
       queryClient.clear();
       await clearClientUserData();
       toast.success('Password updated. Please sign in again.');
-      window.location.href = '/';
+      window.location.href = withPublicBasePath('/');
     },
     onError: (error) => {
       setPasswordError(
@@ -253,6 +255,10 @@ export function ProfilePage() {
     'min-w-0 rounded-3xl border border-white/10 bg-[#0b0c0f]/60 p-6 shadow-2xl backdrop-blur-2xl lg:p-8';
   const inputClass =
     'min-w-0 w-full rounded-xl border border-white/15 bg-white/10 px-4 py-3 text-white placeholder-white/40 outline-none transition focus:border-transparent focus:ring-2 focus:ring-white/20';
+  const publicBasePath = getPublicBasePath();
+  const publicPathLabel = publicBasePath || '/';
+  const profileShortcutClass =
+    'inline-flex min-h-[44px] items-center justify-center rounded-xl border border-white/10 bg-white/5 px-4 py-2.5 text-sm font-semibold text-white/85 transition hover:bg-white/10 hover:text-white';
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-gray-50 dark:bg-gray-900 text-white font-sans selection:bg-[#facc15] selection:text-black select-none [-webkit-touch-callout:none] [&_input]:select-text [&_textarea]:select-text [&_select]:select-text">
@@ -451,6 +457,49 @@ export function ProfilePage() {
                     : 'Save recovery questions'}
                 </button>
               </form>
+            </div>
+          </div>
+
+          <div className="mt-6">
+            <div id="profile-public-path-panel" className={cardClass}>
+              <div className="mb-4 flex items-center gap-2 text-white">
+                <ShieldCheck className="h-5 w-5 text-[#facc15]" />
+                <h2 className="text-xl font-semibold">Public path</h2>
+              </div>
+              <p className="mb-4 text-sm text-white/70">
+                This is the active browser path prefix for this Immaculaterr instance.
+                Use it when you are verifying reverse-proxy or subpath hosting. Root
+                deployments show <span className="font-mono text-white/80">/</span>.
+              </p>
+              <div className="space-y-1">
+                <label
+                  htmlFor="profile-public-path"
+                  className="block text-xs font-bold uppercase tracking-wider text-white/60"
+                >
+                  Public path
+                </label>
+                <input
+                  id="profile-public-path"
+                  type="text"
+                  readOnly
+                  value={publicPathLabel}
+                  className={`${inputClass} font-mono text-sm text-white/80`}
+                />
+              </div>
+              <div className="mt-4 grid gap-3 md:grid-cols-2">
+                <Link
+                  to="/faq#getting-started-public-path"
+                  className={profileShortcutClass}
+                >
+                  How to change this path
+                </Link>
+                <Link
+                  to="/setup#update-paths-public-path-hosting"
+                  className={profileShortcutClass}
+                >
+                  Open setup steps
+                </Link>
+              </div>
             </div>
           </div>
         </div>

--- a/apps/web/src/pages/SetupPage.tsx
+++ b/apps/web/src/pages/SetupPage.tsx
@@ -61,6 +61,11 @@ const OPTIONAL_HTTPS_SIDECAR_COMMAND = [
   './install-local-ca.sh',
 ].join('\n');
 
+const PUBLIC_PATH_HOSTING_ENV_SNIPPET = [
+  'APP_BASE_PATH=/recommendations',
+  'TRUST_PROXY=1',
+].join('\n');
+
 async function copyToClipboard(text: string) {
   if (navigator?.clipboard?.writeText) {
     await navigator.clipboard.writeText(text);
@@ -343,6 +348,48 @@ export const SetupPage = () => {
                   that need it.
                 </li>
               </ul>
+            </>
+          ),
+        },
+        {
+          id: 'update-paths-public-path-hosting',
+          question: 'Public path hosting under /recommendations',
+          answer: (
+            <>
+              <p>
+                Use this when you want Immaculaterr to live under a reverse-proxy subpath like{' '}
+                <code className="font-mono">/recommendations</code>.
+              </p>
+              <ol className="list-decimal pl-5 space-y-1">
+                <li>
+                  Add these values to the Docker env file or compose environment for the app
+                  container.
+                </li>
+                <li>Recreate the Immaculaterr container.</li>
+                <li>
+                  Open the app on{' '}
+                  <code className="font-mono">http://&lt;server-ip&gt;:5454/recommendations/</code>{' '}
+                  or <code className="font-mono">https://&lt;server-ip&gt;:5464/recommendations/</code>.
+                </li>
+                <li>
+                  Confirm the result in{' '}
+                  <Link to="/profile#profile-public-path-panel" className="font-semibold text-white/85 underline underline-offset-2 hover:text-white">
+                    Profile - Public path
+                  </Link>
+                  .
+                </li>
+              </ol>
+              {renderCommandBlock(
+                'update-paths-public-path-hosting',
+                PUBLIC_PATH_HOSTING_ENV_SNIPPET,
+              )}
+              <p>
+                Need the full explanation? Open{' '}
+                <Link to="/faq#getting-started-public-path" className="font-semibold text-white/85 underline underline-offset-2 hover:text-white">
+                  FAQ - How do I change the Public path?
+                </Link>
+                .
+              </p>
             </>
           ),
         },

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -11,7 +11,8 @@ const appVersionMatch = appVersionSource.match(/APP_VERSION = '([^']+)'/);
 const appAssetVersion = appVersionMatch?.[1] ?? 'dev';
 
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({ command }) => ({
+  base: command === 'build' ? './' : '/',
   define: {
     __APP_ASSET_VERSION__: JSON.stringify(appAssetVersion),
   },
@@ -49,4 +50,4 @@ export default defineConfig({
       ...(process.env.WEB_ALLOWED_HOSTS?.split(',').map((h) => h.trim()).filter(Boolean) ?? []),
     ],
   },
-});
+}));

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -9,7 +9,7 @@ Pick a feature area first, then jump into the full section below.
 > ### [Getting started](#getting-started)
 >
 > Basics, first-run setup, and how to reach the app.
-> [What is Immaculaterr?](#what-is-immaculaterr) · [What are the three main pages I need to understand?](#what-are-the-three-main-pages-i-need-to-understand) · [How do I do first-time setup?](#how-do-i-do-first-time-setup)
+> [What is Immaculaterr?](#what-is-immaculaterr) · [What are the three main pages I need to understand?](#what-are-the-three-main-pages-i-need-to-understand) · [How do I do first-time setup?](#how-do-i-do-first-time-setup) · [Can I host Immaculaterr under /recommendations behind nginx?](#can-i-host-immaculaterr-under-recommendations-behind-nginx)
 >
 > - 1 more answer in the section below.
 
@@ -218,6 +218,39 @@ For TrueNAS SCALE GUI installs, use [Setup: TrueNAS](/setup/truenas), which incl
 
 - Option 1 (recommended): HTTPS sidecar + encrypted secret transport.
 - Option 2 (compatibility): HTTP-only with `SECRETS_TRANSPORT_ALLOW_PLAINTEXT=true` (plaintext credential transport).
+
+### Can I host Immaculaterr under /recommendations behind nginx?
+
+Yes. Set `APP_BASE_PATH=/recommendations` on the app container and keep `TRUST_PROXY=1` so secure-cookie and reverse-proxy detection continue to work correctly.
+
+You cannot change this from inside the app itself. The `Public path` field in Profile is read-only and only shows the active result after Docker + proxy changes are applied.
+
+Use a trailing slash for the public entrypoint:
+
+- `http://<server-ip>:5454/recommendations/`
+- `https://<server-ip>:5464/recommendations/`
+
+In the app, open `Profile` to confirm the active `Public path` value.
+
+Example nginx configuration:
+
+```nginx
+location = /recommendations {
+  return 301 /recommendations/;
+}
+
+location /recommendations/ {
+  proxy_pass http://127.0.0.1:5454;
+  proxy_http_version 1.1;
+  proxy_set_header Host $host;
+  proxy_set_header X-Forwarded-Host $host;
+  proxy_set_header X-Forwarded-Proto $scheme;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Port $server_port;
+}
+```
+
+This keeps both the SPA and `/recommendations/api/...` working without a separate image build.
 
 ## Task Manager
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -126,6 +126,43 @@ Then open either:
 
 The `.env` file above sets the app container timezone to `America/New_York`. Change it if you prefer a different IANA timezone.
 
+Optional: host under `/recommendations`
+---
+
+Set `APP_BASE_PATH=/recommendations` on the app container and keep `TRUST_PROXY=1` when a reverse proxy sits in front of Immaculaterr.
+
+Example `.env` or compose overrides:
+
+```env
+APP_BASE_PATH=/recommendations
+TRUST_PROXY=1
+```
+
+After that, browse to:
+
+- `http://<server-ip>:5454/recommendations/`
+- `https://<server-ip>:5464/recommendations/`
+
+In the app, open `Profile` to confirm the active `Public path` value.
+
+Example nginx reverse proxy:
+
+```nginx
+location = /recommendations {
+  return 301 /recommendations/;
+}
+
+location /recommendations/ {
+  proxy_pass http://127.0.0.1:5454;
+  proxy_http_version 1.1;
+  proxy_set_header Host $host;
+  proxy_set_header X-Forwarded-Host $host;
+  proxy_set_header X-Forwarded-Proto $scheme;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Port $server_port;
+}
+```
+
 Optional (recommended for HTTPS without browser warnings):
 
 ```bash

--- a/doc/Version_History.md
+++ b/doc/Version_History.md
@@ -2,6 +2,22 @@
 
 This file tracks notable changes by version.
 
+## 1.7.8-beta-6
+
+- What's new in 1.7.8 beta 6:
+- Prefix-hosted app + API support:
+  - Added `APP_BASE_PATH` support so the SPA, static assets, and public API can be served under `/recommendations` while the internal Nest API routes stay on `/api`.
+  - Requests to `/recommendations/api/...` now rewrite onto the existing `/api/...` handlers, so prefixed reverse-proxy traffic no longer falls through to the SPA shell.
+  - When a public prefix is configured, the app redirects bare `/` to `/recommendations/` and exposes the active public path in Profile plus `GET /api/meta`.
+- Frontend path handling:
+  - Production assets now use a runtime-friendly relative base, and the React app derives its effective basename from the rendered document base instead of hardcoding root.
+  - API helpers, standalone/PWA navigations, safe-navigate fallbacks, version-history links, and logout/reset redirects now stay inside the configured public prefix.
+  - Profile now shows a read-only `Public path` field so deployments are easier to verify at a glance.
+- Docker and deployment guidance:
+  - Container startup now patches the built web shell base href from `APP_BASE_PATH`, so one image can serve either root or `/recommendations` deployments.
+  - Compose templates and setup docs now pass `APP_BASE_PATH` through directly and keep `TRUST_PROXY=1` called out for reverse-proxy deployments.
+  - There are no Prisma schema, migration, generated-client, or stored-data changes in this beta.
+
 ## 1.7.8-beta-5
 
 - What's new in 1.7.8 beta 5:

--- a/doc/Version_History.md
+++ b/doc/Version_History.md
@@ -4,37 +4,19 @@ This file tracks notable changes by version.
 
 ## 1.7.8-beta-6
 
-- What's new in 1.7.8 beta 6:
-- Prefix-hosted app + API support:
-  - Added `APP_BASE_PATH` support so the SPA, static assets, and public API can be served under `/recommendations` while the internal Nest API routes stay on `/api`.
-  - Requests to `/recommendations/api/...` now rewrite onto the existing `/api/...` handlers, so prefixed reverse-proxy traffic no longer falls through to the SPA shell.
-  - When a public prefix is configured, the app redirects bare `/` to `/recommendations/` and exposes the active public path in Profile plus `GET /api/meta`.
-- Frontend path handling:
-  - Production assets now use a runtime-friendly relative base, and the React app derives its effective basename from the rendered document base instead of hardcoding root.
-  - API helpers, standalone/PWA navigations, safe-navigate fallbacks, version-history links, and logout/reset redirects now stay inside the configured public prefix.
-  - Profile now shows a read-only `Public path` field so deployments are easier to verify at a glance.
-- Docker and deployment guidance:
-  - Container startup now patches the built web shell base href from `APP_BASE_PATH`, so one image can serve either root or `/recommendations` deployments.
-  - Compose templates and setup docs now pass `APP_BASE_PATH` through directly and keep `TRUST_PROXY=1` called out for reverse-proxy deployments.
-  - There are no Prisma schema, migration, generated-client, or stored-data changes in this beta.
-
-## 1.7.8-beta-5
-
-- What's new in 1.7.8 beta 5:
-- Confirm Monitored Sonarr cascade:
-  - Confirm Monitored now requires Plex-verified playable media before Radarr movies or Sonarr episodes are treated as present.
-  - Sonarr cascade still happens, but in ordered passes: all episodes first, then seasons, then series.
-  - If every tracked positive-numbered season ends unmonitored, the series itself is unmonitored too.
-- Netflix import reliability (issue #199):
-  - Preserved `releaseDate` and `firstAirDate` when rebuilding `ImmaculateTasteMovieLibrary` and `ImmaculateTasteShowLibrary` so imports stop failing with "column does not exist".
-  - Added an idempotent ensure step that backfills `releaseDate` and `firstAirDate` on older SQLite databases regardless of migration history state.
+- This entry combines the beta 5 and beta 6 changes.
+- Hosting and routing:
+  - Added `APP_BASE_PATH` support so Immaculaterr can run under `/recommendations` without a separate web build.
+  - Prefixed API requests now rewrite cleanly to `/api/...`, and Profile shows the active `Public path` alongside `GET /api/meta`.
+  - Web assets, router links, API helpers, and logout/reset flows now stay inside the configured public path.
+- Confirm Monitored and imports:
+  - Confirm Monitored now requires Plex-verified playable media before Radarr movies or Sonarr episodes count as present.
+  - Sonarr confirmation now runs in order: episodes first, then seasons, then series.
+  - Netflix import now handles older SQLite databases that are missing `releaseDate` or `firstAirDate` columns.
 - Rotten Tomatoes Upcoming Movies + TV Shows:
-  - Rotten Tomatoes upcoming movie discovery now works with the current browse-page markup using the newer `rt-text` field wrappers instead of assuming legacy span-only cards.
-  - The task is now presented as `Rotten Tomatoes Upcoming Movies + TV Shows`, and the expanded card now saves Movies, TV Shows, Movie Top, and TV Top values. Movies default to Top 20, TV defaults to Top 10, and both ranges can be set from 1 to 100.
-  - Manual Run now opens a Movies or TV Shows chooser with a one-run `Route via Seerr` toggle and a one-run Top count. The dialog starts from the saved Seerr setting plus Top 10 every time and does not change the saved card settings.
-  - Movie discovery now stops once the deduplicated movie pool reaches the effective Movie Top count, matching the existing TV-stop behavior. Saved scheduled and auto-runs still use the card settings and always run movies first, then TV.
-  - Route via Seerr now applies to both media types: movies still require safe Radarr lookup first, and new TV shows go to Seerr instead of falling back to direct Sonarr adds when Seerr mode is enabled.
-  - Existing Sonarr shows can still be reconciled against Plex so present episodes stay unmonitored, missing episodes remain monitored, and Rewind now shows separate movie and TV stages plus TV-specific routing and reconciliation stats.
+  - The task now supports separate Movies and TV Shows settings, including independent Top counts.
+  - Manual Run now lets you choose media type, Top count, and `Route via Seerr` without changing saved settings.
+  - Discovery, routing, and reconciliation are now clearer for both movies and TV, with better Rewind reporting.
 
 ## 1.7.7
 

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "3485",
+  "message": "3486",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "3486",
+  "message": "3487",
   "color": "blue"
 }

--- a/doc/setupguide.md
+++ b/doc/setupguide.md
@@ -42,6 +42,43 @@ Then open:
 
 The `.env` file above sets the app container timezone to `America/New_York`. Change it if you prefer a different IANA timezone.
 
+Optional: host under `/recommendations`
+---
+
+Set `APP_BASE_PATH=/recommendations` and keep `TRUST_PROXY=1` in the app container when you want the app to live under a reverse-proxy subpath.
+
+Example `.env` additions:
+
+```env
+APP_BASE_PATH=/recommendations
+TRUST_PROXY=1
+```
+
+Then browse to:
+
+- `http://<server-ip>:5454/recommendations/`
+- `https://<server-ip>:5464/recommendations/`
+
+In the app, open `Profile` to confirm the active `Public path` value.
+
+Example nginx reverse proxy:
+
+```nginx
+location = /recommendations {
+  return 301 /recommendations/;
+}
+
+location /recommendations/ {
+  proxy_pass http://127.0.0.1:5454;
+  proxy_http_version 1.1;
+  proxy_set_header Host $host;
+  proxy_set_header X-Forwarded-Host $host;
+  proxy_set_header X-Forwarded-Proto $scheme;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Port $server_port;
+}
+```
+
 Compose stacks at a glance
 ---
 
@@ -54,6 +91,7 @@ Supported compose templates live in `docker/immaculaterr/`:
 
 These compose files use `network_mode: host` by default. On Linux, this keeps local integrations simple (`http://localhost:<port>` from inside the app).
 If you want New York time in the app container, add `TZ=America/New_York` to the `.env` file next to the compose file.
+If you want prefix hosting, also add `APP_BASE_PATH=/recommendations`.
 
 Optional: Docker secret for APP_MASTER_KEY
 ---

--- a/docker/immaculaterr/.env.example
+++ b/docker/immaculaterr/.env.example
@@ -33,6 +33,7 @@
 
 # --- Reverse Proxy ---
 # TRUST_PROXY=1
+# APP_BASE_PATH=/recommendations
 
 # --- CORS ---
 # CORS_ORIGINS=

--- a/docker/immaculaterr/docker-compose.dockerhub.yml
+++ b/docker/immaculaterr/docker-compose.dockerhub.yml
@@ -13,6 +13,7 @@ services:
       - PORT=${APP_INTERNAL_PORT:-5455}
       - TZ=${TZ:-America/New_York}
       - APP_DATA_DIR=/data
+      - APP_BASE_PATH=${APP_BASE_PATH:-}
       - DATABASE_URL=file:/data/tcp.sqlite
       - UPDATE_CHECK_ENABLED=${UPDATE_CHECK_ENABLED:-true}
       - UPDATE_CHECK_REPO=${UPDATE_CHECK_REPO:-}

--- a/docker/immaculaterr/docker-compose.https.yml
+++ b/docker/immaculaterr/docker-compose.https.yml
@@ -13,6 +13,7 @@ services:
       - PORT=${APP_INTERNAL_PORT:-5455}
       - TZ=${TZ:-America/New_York}
       - APP_DATA_DIR=/data
+      - APP_BASE_PATH=${APP_BASE_PATH:-}
       - DATABASE_URL=file:/data/tcp.sqlite
       - UPDATE_CHECK_ENABLED=${UPDATE_CHECK_ENABLED:-true}
       - UPDATE_CHECK_REPO=${UPDATE_CHECK_REPO:-}

--- a/docker/immaculaterr/docker-compose.source.yml
+++ b/docker/immaculaterr/docker-compose.source.yml
@@ -15,7 +15,9 @@ services:
       - HOST=0.0.0.0
       - PORT=${APP_PORT:-5454}
       - TZ=${TZ:-America/New_York}
+      - TRUST_PROXY=${TRUST_PROXY:-1}
       - APP_DATA_DIR=/data
+      - APP_BASE_PATH=${APP_BASE_PATH:-}
       - DATABASE_URL=file:/data/tcp.sqlite
       - UPDATE_CHECK_ENABLED=${UPDATE_CHECK_ENABLED:-true}
       - UPDATE_CHECK_REPO=${UPDATE_CHECK_REPO:-}

--- a/docker/immaculaterr/docker-compose.yml
+++ b/docker/immaculaterr/docker-compose.yml
@@ -12,7 +12,9 @@ services:
       - HOST=0.0.0.0
       - PORT=${APP_PORT:-5454}
       - TZ=${TZ:-America/New_York}
+      - TRUST_PROXY=${TRUST_PROXY:-1}
       - APP_DATA_DIR=/data
+      - APP_BASE_PATH=${APP_BASE_PATH:-}
       - DATABASE_URL=file:/data/tcp.sqlite
       - UPDATE_CHECK_ENABLED=${UPDATE_CHECK_ENABLED:-true}
       - UPDATE_CHECK_REPO=${UPDATE_CHECK_REPO:-}

--- a/docker/immaculaterr/entrypoint.sh
+++ b/docker/immaculaterr/entrypoint.sh
@@ -2,10 +2,73 @@
 set -eu
 
 APP_DATA_DIR="${APP_DATA_DIR:-/data}"
+APP_BASE_PATH="${APP_BASE_PATH:-}"
 DB_PRE_MIGRATE_BACKUP="${DB_PRE_MIGRATE_BACKUP:-true}"
 DB_PRE_MIGRATE_BACKUP_STRICT="${DB_PRE_MIGRATE_BACKUP_STRICT:-false}"
 DB_PRE_MIGRATE_BACKUP_KEEP="${DB_PRE_MIGRATE_BACKUP_KEEP:-10}"
 DB_PRE_MIGRATE_BACKUP_DIR="${DB_PRE_MIGRATE_BACKUP_DIR:-$APP_DATA_DIR/backups/pre-migrate}"
+
+trim() {
+  # shellcheck disable=SC2001
+  printf '%s' "$1" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
+}
+
+normalize_app_base_path() {
+  raw="$(trim "$1")"
+  if [ -z "$raw" ] || [ "$raw" = "/" ]; then
+    printf ''
+    return 0
+  fi
+
+  case "$raw" in
+    /*) ;;
+    *)
+      echo "ERROR: APP_BASE_PATH must be empty or start with '/'." >&2
+      return 1
+      ;;
+  esac
+
+  case "$raw" in
+    *\?*|*#*)
+      echo "ERROR: APP_BASE_PATH must not include query or hash fragments." >&2
+      return 1
+      ;;
+  esac
+
+  normalized="$raw"
+  while [ "${normalized%/}" != "$normalized" ]; do
+    normalized="${normalized%/}"
+  done
+
+  if [ -z "$normalized" ] || [ "$normalized" = "/" ]; then
+    printf ''
+    return 0
+  fi
+
+  printf '%s' "$normalized"
+}
+
+escape_sed_replacement() {
+  printf '%s' "$1" | sed 's/[&|]/\\&/g'
+}
+
+patch_web_base_href() {
+  web_index_file="/app/apps/web/dist/index.html"
+  if [ ! -f "$web_index_file" ]; then
+    return 0
+  fi
+
+  base_href='/'
+  if [ -n "$APP_BASE_PATH" ]; then
+    base_href="${APP_BASE_PATH}/"
+  fi
+  escaped_base_href="$(escape_sed_replacement "$base_href")"
+  tmp_file="${web_index_file}.tmp"
+
+  sed "s|<base href=\"[^\"]*\" />|<base href=\"${escaped_base_href}\" />|" "$web_index_file" > "$tmp_file"
+  mv "$tmp_file" "$web_index_file"
+  echo "Configured web base href: $base_href"
+}
 
 resolve_db_file() {
   db_file="$APP_DATA_DIR/tcp.sqlite"
@@ -72,6 +135,10 @@ create_pre_migrate_backup() {
     rm -f "$f" "${f}-wal" "${f}-shm" 2>/dev/null || true
   done
 }
+
+APP_BASE_PATH="$(normalize_app_base_path "$APP_BASE_PATH")"
+export APP_BASE_PATH
+patch_web_base_href
 
 # Best-effort hardening for the mounted data directory.
 mkdir -p "$APP_DATA_DIR" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- release the `1.7.8-beta-6` changes from `develop` into `master`
- add support for hosting Immaculaterr under a configurable public base path via `APP_BASE_PATH`
- update the app and docs so Public path guidance is easier to find from Profile, FAQ, and Setup
- simplify and combine the beta 5 + beta 6 version-history notes into the final beta 6 entry

## Why
- subpath hosting needed first-class support for reverse-proxy deployments such as `/recommendations`
- users needed clearer in-app guidance on where the active Public path is shown and how to configure it
- the beta release notes had overlapping entries that were easier to understand as one concise update

## Impact
- Immaculaterr can now run from either `/` or a configured subpath without Prisma or stored-data changes
- Profile exposes the active Public path and links users directly to the supporting FAQ and Setup instructions
- Docker compose templates and docs now describe how to configure `APP_BASE_PATH`

## Validation
- `npm -w apps/web exec eslint -- src/lib/version-history.ts`
- `npm -w apps/web run build`
- `npm run security:ci`
- Docker smoke checks for both root hosting and `/recommendations` hosting were completed during local deployment verification
