### PR TITLE
docs: rename Public path to App base path and generalize hosting example

### DIFF
--- a/apps/api/src/app.dto.ts
+++ b/apps/api/src/app.dto.ts
@@ -22,6 +22,6 @@ export class AppMetaResponseDto {
   @ApiProperty({ example: '2026-01-09T15:54:13.000Z', nullable: true })
   buildTime!: string | null;
 
-  @ApiProperty({ example: '/recommendations' })
+  @ApiProperty({ example: '/immaculaterr' })
   publicBasePath!: string;
 }

--- a/apps/api/src/public-base-path.spec.ts
+++ b/apps/api/src/public-base-path.spec.ts
@@ -9,11 +9,9 @@ describe('public base path helpers', () => {
   });
 
   it('strips trailing slashes from slash-prefixed paths', () => {
-    expect(normalizeAppBasePath('/recommendations')).toBe('/recommendations');
-    expect(normalizeAppBasePath('/recommendations/')).toBe('/recommendations');
-    expect(normalizeAppBasePath('/recommendations///')).toBe(
-      '/recommendations',
-    );
+    expect(normalizeAppBasePath('/immaculaterr')).toBe('/immaculaterr');
+    expect(normalizeAppBasePath('/immaculaterr/')).toBe('/immaculaterr');
+    expect(normalizeAppBasePath('/immaculaterr///')).toBe('/immaculaterr');
     expect(normalizeAppBasePath(' /nested/path/ ')).toBe('/nested/path');
   });
 
@@ -24,16 +22,16 @@ describe('public base path helpers', () => {
     expect(() => normalizeAppBasePath('http://example.com/path')).toThrow(
       /APP_BASE_PATH/,
     );
-    expect(() => normalizeAppBasePath('/recommendations?x=1')).toThrow(
+    expect(() => normalizeAppBasePath('/immaculaterr?x=1')).toThrow(
       /APP_BASE_PATH/,
     );
-    expect(() => normalizeAppBasePath('/recommendations#hash')).toThrow(
+    expect(() => normalizeAppBasePath('/immaculaterr#hash')).toThrow(
       /APP_BASE_PATH/,
     );
   });
 
   it('uses the render path shape Nest can append to a prefixed static mount', () => {
     expect(buildAppRenderPath('')).toBe('');
-    expect(buildAppRenderPath('/recommendations')).toBe('{*path}');
+    expect(buildAppRenderPath('/immaculaterr')).toBe('{*path}');
   });
 });

--- a/apps/api/test/app.e2e-spec.ts
+++ b/apps/api/test/app.e2e-spec.ts
@@ -9,6 +9,7 @@ import { createAppBasePathApiRewriteMiddleware } from '../src/public-base-path';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication<App>;
+  const appBasePath = '/nested/app-base';
 
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -25,7 +26,7 @@ describe('AppController (e2e)', () => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
-    app.use(createAppBasePathApiRewriteMiddleware('/recommendations'));
+    app.use(createAppBasePathApiRewriteMiddleware(appBasePath));
     app.setGlobalPrefix('api');
     await app.init();
   });
@@ -48,9 +49,9 @@ describe('AppController (e2e)', () => {
       });
   });
 
-  it('/recommendations/api/health (GET)', () => {
+  it('rewrites health checks under an arbitrary app base path (GET)', () => {
     return request(app.getHttpServer())
-      .get('/recommendations/api/health')
+      .get(`${appBasePath}/api/health`)
       .expect(200)
       .expect((res) => {
         const body = res.body as unknown;

--- a/apps/web/src/lib/version-history.ts
+++ b/apps/web/src/lib/version-history.ts
@@ -39,7 +39,7 @@ export const VERSION_HISTORY_ENTRIES: VersionHistoryEntry[] = [
   {
     version: '1.7.8-beta-6',
     popupHighlights: [
-      'Prefix hosting under /recommendations now works across the app, API, and Docker setup.',
+      'App base path hosting now works across the app, API, and Docker setup.',
       'Confirm Monitored is stricter and now checks Plex-playable media before Radarr or Sonarr items are treated as present.',
       'Rotten Tomatoes Upcoming now handles separate Movies and TV settings with cleaner one-run options.',
       'Netflix import is safer on older SQLite databases, with no Prisma or stored-data changes in this beta.',
@@ -48,9 +48,9 @@ export const VERSION_HISTORY_ENTRIES: VersionHistoryEntry[] = [
       {
         title: 'Hosting and routing',
         bullets: [
-          'Added APP_BASE_PATH support so Immaculaterr can run under /recommendations without a separate web build.',
-          'Prefixed API requests now rewrite cleanly to /api/..., and Profile shows the active Public path alongside GET /api/meta.',
-          'Web assets, router links, API helpers, and logout/reset flows now stay inside the configured public path.',
+          'Added APP_BASE_PATH support so Immaculaterr can run under any reverse-proxy subpath without a separate web build.',
+          'Prefixed API requests now rewrite cleanly to /api/..., and Profile shows the active app base path alongside API metadata.',
+          'Web assets, router links, API helpers, and logout/reset flows now stay inside the configured app base path.',
         ],
       },
       {

--- a/apps/web/src/pages/FaqPage.tsx
+++ b/apps/web/src/pages/FaqPage.tsx
@@ -226,42 +226,54 @@ export const FaqPage = () => {
         },
         {
           id: 'getting-started-public-path',
-          question: 'How do I change the Public path?',
+          question: 'How do I host Immaculaterr under an app base path behind a reverse proxy?',
           answer: (
             <>
               <p>
-                You cannot change the Public path from inside Immaculaterr. That value is read-only
-                and reflects how the app is currently being served by Docker and your reverse proxy.
+                Set <code className="font-mono">APP_BASE_PATH</code> to the exact public prefix you
+                want, then make your proxy or tunnel forward that same prefix to Immaculaterr. This
+                works with Nginx, Caddy, Traefik, Cloudflare Tunnel, Tailscale Funnel, and similar
+                setups.
+              </p>
+              <p>
+                Replace <code className="font-mono">/immaculaterr</code> below with any subpath you
+                want, such as <code className="font-mono">/recommendations</code> or{' '}
+                <code className="font-mono">/media-helper</code>.
               </p>
               <ol className="list-decimal pl-5 space-y-1">
                 <li>
-                  Set <code className="font-mono">APP_BASE_PATH=/recommendations</code> in your
-                  Docker environment.
+                  Set <code className="font-mono">APP_BASE_PATH=/immaculaterr</code> in your Docker
+                  environment.
                 </li>
                 <li>
                   Keep <code className="font-mono">TRUST_PROXY=1</code> enabled.
                 </li>
                 <li>
-                  Make sure your proxy forwards <code className="font-mono">/recommendations/</code>{' '}
-                  to Immaculaterr.
+                  Make sure your proxy preserves and forwards{' '}
+                  <code className="font-mono">/immaculaterr/</code> to Immaculaterr instead of
+                  stripping that prefix.
                 </li>
                 <li>Recreate or restart the Immaculaterr container.</li>
                 <li>
-                  Open the app on <code className="font-mono">/recommendations/</code> and confirm
-                  the result in{' '}
+                  Open the app on <code className="font-mono">/immaculaterr/</code> and confirm the
+                  result in{' '}
                   <Link to="/profile#profile-public-path-panel" className={faqLinkClass}>
-                    Profile - Public path
+                    Profile - App base path
                   </Link>
                   .
                 </li>
               </ol>
+              <p>
+                Once set, the same app base path is used across the SPA, API requests, asset URLs,
+                redirects, and logout flows.
+              </p>
               <p>
                 Use{' '}
                 <Link
                   to="/setup#update-paths-public-path-hosting"
                   className={faqLinkClass}
                 >
-                  Setup - Public path hosting
+                  Setup - App base path hosting
                 </Link>{' '}
                 for the deployment steps.
               </p>

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -464,19 +464,19 @@ export function ProfilePage() {
             <div id="profile-public-path-panel" className={cardClass}>
               <div className="mb-4 flex items-center gap-2 text-white">
                 <ShieldCheck className="h-5 w-5 text-[#facc15]" />
-                <h2 className="text-xl font-semibold">Public path</h2>
+                <h2 className="text-xl font-semibold">App base path</h2>
               </div>
               <p className="mb-4 text-sm text-white/70">
                 This is the active browser path prefix for this Immaculaterr instance.
-                Use it when you are verifying reverse-proxy or subpath hosting. Root
-                deployments show <span className="font-mono text-white/80">/</span>.
+                Use it when you are verifying reverse-proxy or tunnel subpath hosting.
+                Root deployments show <span className="font-mono text-white/80">/</span>.
               </p>
               <div className="space-y-1">
                 <label
                   htmlFor="profile-public-path"
                   className="block text-xs font-bold uppercase tracking-wider text-white/60"
                 >
-                  Public path
+                  App base path
                 </label>
                 <input
                   id="profile-public-path"
@@ -491,13 +491,13 @@ export function ProfilePage() {
                   to="/faq#getting-started-public-path"
                   className={profileShortcutClass}
                 >
-                  How to change this path
+                  How to configure this path
                 </Link>
                 <Link
                   to="/setup#update-paths-public-path-hosting"
                   className={profileShortcutClass}
                 >
-                  Open setup steps
+                  Open proxy setup steps
                 </Link>
               </div>
             </div>

--- a/apps/web/src/pages/SetupPage.tsx
+++ b/apps/web/src/pages/SetupPage.tsx
@@ -62,7 +62,7 @@ const OPTIONAL_HTTPS_SIDECAR_COMMAND = [
 ].join('\n');
 
 const PUBLIC_PATH_HOSTING_ENV_SNIPPET = [
-  'APP_BASE_PATH=/recommendations',
+  'APP_BASE_PATH=/immaculaterr',
   'TRUST_PROXY=1',
 ].join('\n');
 
@@ -353,32 +353,42 @@ export const SetupPage = () => {
         },
         {
           id: 'update-paths-public-path-hosting',
-          question: 'Public path hosting under /recommendations',
+          question: 'App base path hosting behind a reverse proxy',
           answer: (
             <>
               <p>
-                Use this when you want Immaculaterr to live under a reverse-proxy subpath like{' '}
-                <code className="font-mono">/recommendations</code>.
+                Use this when you want Immaculaterr to live under a subpath such as{' '}
+                <code className="font-mono">/immaculaterr</code>. Replace that example with any app
+                base path you want.
               </p>
               <ol className="list-decimal pl-5 space-y-1">
                 <li>
                   Add these values to the Docker env file or compose environment for the app
                   container.
                 </li>
+                <li>
+                  Make sure your proxy or tunnel preserves the same prefix instead of stripping it.
+                  This applies to Nginx, Caddy, Traefik, Cloudflare Tunnel, Tailscale Funnel, and
+                  similar setups.
+                </li>
                 <li>Recreate the Immaculaterr container.</li>
                 <li>
                   Open the app on{' '}
-                  <code className="font-mono">http://&lt;server-ip&gt;:5454/recommendations/</code>{' '}
-                  or <code className="font-mono">https://&lt;server-ip&gt;:5464/recommendations/</code>.
+                  <code className="font-mono">http://&lt;server-ip&gt;:5454/immaculaterr/</code> or{' '}
+                  <code className="font-mono">https://&lt;server-ip&gt;:5464/immaculaterr/</code>.
                 </li>
                 <li>
                   Confirm the result in{' '}
                   <Link to="/profile#profile-public-path-panel" className="font-semibold text-white/85 underline underline-offset-2 hover:text-white">
-                    Profile - Public path
+                    Profile - App base path
                   </Link>
                   .
                 </li>
               </ol>
+              <p>
+                The configured app base path is then used throughout the web app, API calls, and
+                Docker-served asset URLs.
+              </p>
               {renderCommandBlock(
                 'update-paths-public-path-hosting',
                 PUBLIC_PATH_HOSTING_ENV_SNIPPET,
@@ -386,7 +396,7 @@ export const SetupPage = () => {
               <p>
                 Need the full explanation? Open{' '}
                 <Link to="/faq#getting-started-public-path" className="font-semibold text-white/85 underline underline-offset-2 hover:text-white">
-                  FAQ - How do I change the Public path?
+                  FAQ - How do I host Immaculaterr under an app base path?
                 </Link>
                 .
               </p>

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -9,7 +9,7 @@ Pick a feature area first, then jump into the full section below.
 > ### [Getting started](#getting-started)
 >
 > Basics, first-run setup, and how to reach the app.
-> [What is Immaculaterr?](#what-is-immaculaterr) · [What are the three main pages I need to understand?](#what-are-the-three-main-pages-i-need-to-understand) · [How do I do first-time setup?](#how-do-i-do-first-time-setup) · [Can I host Immaculaterr under /recommendations behind nginx?](#can-i-host-immaculaterr-under-recommendations-behind-nginx)
+> [What is Immaculaterr?](#what-is-immaculaterr) · [What are the three main pages I need to understand?](#what-are-the-three-main-pages-i-need-to-understand) · [How do I do first-time setup?](#how-do-i-do-first-time-setup) · [How do I host Immaculaterr under an app base path behind a reverse proxy?](#how-do-i-host-immaculaterr-under-an-app-base-path-behind-a-reverse-proxy)
 >
 > - 1 more answer in the section below.
 
@@ -219,27 +219,36 @@ For TrueNAS SCALE GUI installs, use [Setup: TrueNAS](/setup/truenas), which incl
 - Option 1 (recommended): HTTPS sidecar + encrypted secret transport.
 - Option 2 (compatibility): HTTP-only with `SECRETS_TRANSPORT_ALLOW_PLAINTEXT=true` (plaintext credential transport).
 
-### Can I host Immaculaterr under /recommendations behind nginx?
+### How do I host Immaculaterr under an app base path behind a reverse proxy?
 
-Yes. Set `APP_BASE_PATH=/recommendations` on the app container and keep `TRUST_PROXY=1` so secure-cookie and reverse-proxy detection continue to work correctly.
+Set `APP_BASE_PATH` to the exact public prefix you want and keep `TRUST_PROXY=1` so secure-cookie and reverse-proxy detection continue to work correctly.
 
-You cannot change this from inside the app itself. The `Public path` field in Profile is read-only and only shows the active result after Docker + proxy changes are applied.
+This works with any proxy or tunnel that preserves the prefix when forwarding to Immaculaterr, including nginx, Caddy, Traefik, Cloudflare Tunnel, and Tailscale Funnel.
+
+You cannot change this from inside the app itself. The `App base path` field in Profile is read-only and only shows the active result after Docker + proxy changes are applied.
+
+Replace `/immaculaterr` below with any subpath you want, such as `/recommendations` or `/media-helper`.
+
+```env
+APP_BASE_PATH=/immaculaterr
+TRUST_PROXY=1
+```
 
 Use a trailing slash for the public entrypoint:
 
-- `http://<server-ip>:5454/recommendations/`
-- `https://<server-ip>:5464/recommendations/`
+- `http://<server-ip>:5454/immaculaterr/`
+- `https://<server-ip>:5464/immaculaterr/`
 
-In the app, open `Profile` to confirm the active `Public path` value.
+In the app, open `Profile` to confirm the active `App base path` value.
 
 Example nginx configuration:
 
 ```nginx
-location = /recommendations {
-  return 301 /recommendations/;
+location = /immaculaterr {
+  return 301 /immaculaterr/;
 }
 
-location /recommendations/ {
+location /immaculaterr/ {
   proxy_pass http://127.0.0.1:5454;
   proxy_http_version 1.1;
   proxy_set_header Host $host;
@@ -250,7 +259,7 @@ location /recommendations/ {
 }
 ```
 
-This keeps both the SPA and `/recommendations/api/...` working without a separate image build.
+This keeps both the SPA and `/immaculaterr/api/...` working without a separate image build.
 
 ## Task Manager
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -126,33 +126,37 @@ Then open either:
 
 The `.env` file above sets the app container timezone to `America/New_York`. Change it if you prefer a different IANA timezone.
 
-Optional: host under `/recommendations`
+Optional: host under an app base path
 ---
 
-Set `APP_BASE_PATH=/recommendations` on the app container and keep `TRUST_PROXY=1` when a reverse proxy sits in front of Immaculaterr.
+Set `APP_BASE_PATH` on the app container and keep `TRUST_PROXY=1` when a reverse proxy or tunnel sits in front of Immaculaterr.
+
+Replace `/immaculaterr` below with any subpath you want, such as `/recommendations` or `/media-helper`.
 
 Example `.env` or compose overrides:
 
 ```env
-APP_BASE_PATH=/recommendations
+APP_BASE_PATH=/immaculaterr
 TRUST_PROXY=1
 ```
 
 After that, browse to:
 
-- `http://<server-ip>:5454/recommendations/`
-- `https://<server-ip>:5464/recommendations/`
+- `http://<server-ip>:5454/immaculaterr/`
+- `https://<server-ip>:5464/immaculaterr/`
 
-In the app, open `Profile` to confirm the active `Public path` value.
+Make sure your proxy preserves and forwards that same prefix to Immaculaterr. This works with nginx, Caddy, Traefik, Cloudflare Tunnel, Tailscale Funnel, and similar setups.
+
+In the app, open `Profile` to confirm the active `App base path` value.
 
 Example nginx reverse proxy:
 
 ```nginx
-location = /recommendations {
-  return 301 /recommendations/;
+location = /immaculaterr {
+  return 301 /immaculaterr/;
 }
 
-location /recommendations/ {
+location /immaculaterr/ {
   proxy_pass http://127.0.0.1:5454;
   proxy_http_version 1.1;
   proxy_set_header Host $host;

--- a/doc/Version_History.md
+++ b/doc/Version_History.md
@@ -6,9 +6,9 @@ This file tracks notable changes by version.
 
 - This entry combines the beta 5 and beta 6 changes.
 - Hosting and routing:
-  - Added `APP_BASE_PATH` support so Immaculaterr can run under `/recommendations` without a separate web build.
-  - Prefixed API requests now rewrite cleanly to `/api/...`, and Profile shows the active `Public path` alongside `GET /api/meta`.
-  - Web assets, router links, API helpers, and logout/reset flows now stay inside the configured public path.
+  - Added `APP_BASE_PATH` support so Immaculaterr can run under any reverse-proxy subpath without a separate web build.
+  - Prefixed API requests now rewrite cleanly to `/api/...`, and Profile shows the active app base path alongside API metadata.
+  - Web assets, router links, API helpers, and logout/reset flows now stay inside the configured app base path.
 - Confirm Monitored and imports:
   - Confirm Monitored now requires Plex-verified playable media before Radarr movies or Sonarr episodes count as present.
   - Sonarr confirmation now runs in order: episodes first, then seasons, then series.

--- a/doc/setupguide.md
+++ b/doc/setupguide.md
@@ -42,33 +42,37 @@ Then open:
 
 The `.env` file above sets the app container timezone to `America/New_York`. Change it if you prefer a different IANA timezone.
 
-Optional: host under `/recommendations`
+Optional: host under an app base path
 ---
 
-Set `APP_BASE_PATH=/recommendations` and keep `TRUST_PROXY=1` in the app container when you want the app to live under a reverse-proxy subpath.
+Set `APP_BASE_PATH` and keep `TRUST_PROXY=1` in the app container when you want the app to live under a reverse-proxy or tunnel subpath.
+
+Replace `/immaculaterr` below with any subpath you want, such as `/recommendations` or `/media-helper`.
 
 Example `.env` additions:
 
 ```env
-APP_BASE_PATH=/recommendations
+APP_BASE_PATH=/immaculaterr
 TRUST_PROXY=1
 ```
 
 Then browse to:
 
-- `http://<server-ip>:5454/recommendations/`
-- `https://<server-ip>:5464/recommendations/`
+- `http://<server-ip>:5454/immaculaterr/`
+- `https://<server-ip>:5464/immaculaterr/`
 
-In the app, open `Profile` to confirm the active `Public path` value.
+Make sure your proxy preserves and forwards that same prefix to Immaculaterr. This works with nginx, Caddy, Traefik, Cloudflare Tunnel, Tailscale Funnel, and similar setups.
+
+In the app, open `Profile` to confirm the active `App base path` value.
 
 Example nginx reverse proxy:
 
 ```nginx
-location = /recommendations {
-  return 301 /recommendations/;
+location = /immaculaterr {
+  return 301 /immaculaterr/;
 }
 
-location /recommendations/ {
+location /immaculaterr/ {
   proxy_pass http://127.0.0.1:5454;
   proxy_http_version 1.1;
   proxy_set_header Host $host;
@@ -91,7 +95,7 @@ Supported compose templates live in `docker/immaculaterr/`:
 
 These compose files use `network_mode: host` by default. On Linux, this keeps local integrations simple (`http://localhost:<port>` from inside the app).
 If you want New York time in the app container, add `TZ=America/New_York` to the `.env` file next to the compose file.
-If you want prefix hosting, also add `APP_BASE_PATH=/recommendations`.
+If you want app-base-path hosting, also add `APP_BASE_PATH=/immaculaterr` (or your own chosen subpath).
 
 Optional: Docker secret for APP_MASTER_KEY
 ---

--- a/docker/immaculaterr/.env.example
+++ b/docker/immaculaterr/.env.example
@@ -33,7 +33,8 @@
 
 # --- Reverse Proxy ---
 # TRUST_PROXY=1
-# APP_BASE_PATH=/recommendations
+# Set to a leading-slash subpath if your proxy keeps Immaculaterr under a prefix.
+# APP_BASE_PATH=/immaculaterr
 
 # --- CORS ---
 # CORS_ORIGINS=


### PR DESCRIPTION
- Rename "Public path" UI labels and documentation references to "App base path" for clarity.
- Update `APP_BASE_PATH` examples and documentation to use `/immaculaterr` as the default subpath instead of `/recommendations`.
- Generalize reverse-proxy instructions to include Nginx, Caddy, Traefik, Cloudflare Tunnel, and Tailscale Funnel.
- Update unit and E2E tests to reflect the terminology change and use arbitrary base paths.
- Improve FAQ and Setup UI descriptions regarding reverse-proxy prefix preservation.

## Summary

What does this change do, and why?

## Changes

- 

## How to test

- 

## UI screenshots (if applicable)

- 

## Checklist

- [x] I tested this change locally (or in Docker).
- [x] I added/updated docs where needed.
- [x] I kept this PR focused (no unrelated changes).

