### PR TITLE
fix(web): tint the dashboard chart skeleton's shimmer amber, not white

### DIFF
--- a/apps/web/src/components/HeroSection.tsx
+++ b/apps/web/src/components/HeroSection.tsx
@@ -857,12 +857,15 @@ export function HeroSection() {
                       </div>
                       {/* A narrow band that travels across, not a full-width wash:
                           at half the track's width the highlight clears the surface
-                          instead of parking a sheet of white over it. Hidden under
-                          reduced motion — the status text below is the real signal,
-                          so nothing is lost by dropping the decoration. */}
+                          instead of parking a sheet of white over it. Tinted amber
+                          rather than plain white so the glint reads as warm light
+                          catching the card, not a cold streak cutting across the
+                          yellow-green backdrop it sits on. Hidden under reduced
+                          motion — the status text below is the real signal, so
+                          nothing is lost by dropping the decoration. */}
                       <div
                         aria-hidden="true"
-                        className="absolute inset-y-0 left-0 w-1/2 animate-shimmer bg-gradient-to-r from-transparent via-white/40 to-transparent motion-reduce:hidden"
+                        className="absolute inset-y-0 left-0 w-1/2 animate-shimmer bg-gradient-to-r from-transparent via-amber-100/70 to-transparent motion-reduce:hidden"
                       />
                       {/* Same shape as the empty state below — icon over a single
                           line, sitting directly on the surface. A white chip here


### PR DESCRIPTION
## Summary

Rolls `develop` into `master`: retints the Media Analytics loading skeleton's shimmer sweep from a cold white streak to a warm amber gleam.

## Changes

- **web:** the dashboard chart's loading skeleton (`HeroSection.tsx`) sweeps a highlight band across the card while data loads. It was `via-white/40`, a stark white streak that clashed against the dashboard's yellow-green backdrop and the card's own black-tinted glass — the card's own code comment even called it out as the one white element in an otherwise black-tint design. Retinted to `via-amber-100/70`: a warm gold glint that reads as light catching the frosted card instead of a sheet of white parked over it.
- Animation mechanics (GPU-composited transform, half-width band, linear timing, motion-reduce handling) are unchanged — this is a color-only change.

## How to test

- Side-by-side render of the real component's exact Tailwind classes (card, backdrop gradient, skeleton bars, shimmer band) against a synthetic copy of the dashboard's yellow-green backdrop, comparing `via-white/40` against several warm-tinted candidates (`amber-100/55`, `amber-100/70`, `amber-200/45`, `yellow-100/60`, `orange-50/65`, `white/20`). `amber-100/55` nearly disappeared against the card; `amber-100/70` kept clear visibility as a shimmer while reading as warm gold instead of a cold streak.
- `npm run lint`, `npm run build`, `npm run test` (503 tests) all pass.

## UI screenshots (if applicable)

Before/after comparison shared with the repo owner directly during review; not attached here.

## Checklist

- [x] I tested this change locally (or in Docker).
- [x] I added/updated docs where needed.
- [x] I kept this PR focused (no unrelated changes).
