### PR TITLE
feat(web): suggest adding Immaculaterr to the home screen on mobile

### DIFF
--- a/apps/api/src/version.ts
+++ b/apps/api/src/version.ts
@@ -1,6 +1,6 @@
 // Single source of truth for the app version.
 // Bump this constant only.
 
-export const APP_VERSION = '1.7.10-beta-4' as const;
+export const APP_VERSION = '1.7.10-beta-5' as const;
 
 export const APP_VERSION_TAG = `v${APP_VERSION}` as const;

--- a/apps/web/src/app/AppShell.tsx
+++ b/apps/web/src/app/AppShell.tsx
@@ -19,6 +19,7 @@ import { tintClassForPath } from '@/app/route-tints';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
+import { InstallAppBanner } from '@/components/InstallAppBanner';
 import { MobileNavigation } from '@/components/MobileNavigation';
 import { Navigation } from '@/components/Navigation';
 import {
@@ -445,6 +446,10 @@ export const AppShell = () => {
       <div className="lg:hidden">
         <MobileNavigation onLogout={handleLogout} />
       </div>
+
+      {/* Home-screen install suggestion (mobile only, self-gates on platform
+          and dismissal state) */}
+      <InstallAppBanner />
 
       {/* What's New Modal */}
       <WhatsNewModal

--- a/apps/web/src/components/InstallAppBanner.tsx
+++ b/apps/web/src/components/InstallAppBanner.tsx
@@ -1,0 +1,143 @@
+import { useCallback, useEffect, useState } from 'react';
+import { AnimatePresence, motion } from 'motion/react';
+import { Download, Share, SquarePlus, X } from 'lucide-react';
+
+import {
+  clearDeferredInstallPrompt,
+  getDeferredInstallPrompt,
+  isAndroid,
+  isInstallPromptEligible,
+  isIosSafari,
+  markInstallPromptDismissed,
+  markInstallPromptInstalled,
+  onDeferredInstallPromptChange,
+} from '@/lib/install-prompt';
+
+type Variant = 'android' | 'ios';
+
+// Give the page a moment to settle before suggesting anything — the very
+// first thing a mobile visitor sees should be the app, not a pitch for it.
+const SHOW_DELAY_MS = 4000;
+
+function computeVariant(): Variant | null {
+  if (!isInstallPromptEligible()) return null;
+  if (isAndroid() && getDeferredInstallPrompt()) return 'android';
+  if (isIosSafari()) return 'ios';
+  return null;
+}
+
+export function InstallAppBanner() {
+  const [variant, setVariant] = useState<Variant | null>(computeVariant);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    // Chrome can fire beforeinstallprompt after mount (it waits on its own
+    // engagement heuristics), so keep listening rather than checking once.
+    return onDeferredInstallPromptChange(() => {
+      setVariant(computeVariant());
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!variant) return;
+    const timer = window.setTimeout(() => setVisible(true), SHOW_DELAY_MS);
+    return () => window.clearTimeout(timer);
+  }, [variant]);
+
+  const handleDismiss = useCallback(() => {
+    markInstallPromptDismissed();
+    setVisible(false);
+    setVariant(null);
+  }, []);
+
+  const handleInstall = useCallback(() => {
+    const prompt = getDeferredInstallPrompt();
+    if (!prompt) return;
+    setVisible(false);
+    void prompt
+      .prompt()
+      .then(() => prompt.userChoice)
+      .then((choice) => {
+        if (choice.outcome === 'accepted') {
+          markInstallPromptInstalled();
+        } else {
+          markInstallPromptDismissed();
+        }
+      })
+      .finally(() => {
+        clearDeferredInstallPrompt();
+        setVariant(null);
+      });
+  }, []);
+
+  return (
+    <AnimatePresence>
+      {visible && variant ? (
+        <motion.div
+          initial={{ opacity: 0, y: 24 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 24 }}
+          transition={{ duration: 0.3, ease: 'easeOut' }}
+          role="status"
+          className="fixed bottom-28 left-4 right-4 z-[900] lg:hidden"
+        >
+          <div className="mx-auto flex max-w-md items-start gap-3 rounded-2xl border border-white/10 bg-[#0b0c0f]/90 p-4 shadow-2xl backdrop-blur-2xl">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-[#facc15]/15">
+              {variant === 'android' ? (
+                <Download className="h-4 w-4 text-[#facc15]" aria-hidden="true" />
+              ) : (
+                <Share className="h-4 w-4 text-[#facc15]" aria-hidden="true" />
+              )}
+            </div>
+
+            <div className="min-w-0 flex-1">
+              {variant === 'android' ? (
+                <>
+                  <p className="text-sm font-semibold text-white">Install Immaculaterr</p>
+                  <p className="mt-0.5 text-xs leading-relaxed text-white/60">
+                    Add it to your home screen for quicker, full-screen access.
+                  </p>
+                  <div className="mt-2.5 flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={handleInstall}
+                      className="min-h-[32px] rounded-lg bg-[#facc15] px-3 py-1.5 text-xs font-bold text-black transition hover:bg-[#fde68a] active:scale-[0.98]"
+                    >
+                      Install
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleDismiss}
+                      className="min-h-[32px] rounded-lg px-3 py-1.5 text-xs font-semibold text-white/55 transition hover:text-white/85"
+                    >
+                      Not now
+                    </button>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <p className="text-sm font-semibold text-white">Add to Home Screen</p>
+                  <p className="mt-0.5 text-xs leading-relaxed text-white/60">
+                    Tap <Share className="inline h-3 w-3 -translate-y-px" aria-hidden="true" />{' '}
+                    Share, then{' '}
+                    <SquarePlus className="inline h-3 w-3 -translate-y-px" aria-hidden="true" />{' '}
+                    &quot;Add to Home Screen&quot;.
+                  </p>
+                </>
+              )}
+            </div>
+
+            <button
+              type="button"
+              onClick={handleDismiss}
+              aria-label="Dismiss install suggestion"
+              className="shrink-0 rounded-lg p-1 text-white/40 transition hover:bg-white/10 hover:text-white/80"
+            >
+              <X className="h-4 w-4" aria-hidden="true" />
+            </button>
+          </div>
+        </motion.div>
+      ) : null}
+    </AnimatePresence>
+  );
+}

--- a/apps/web/src/lib/install-prompt.ts
+++ b/apps/web/src/lib/install-prompt.ts
@@ -1,0 +1,123 @@
+/**
+ * Home-screen install suggestion, shared state between main.tsx (which must
+ * attach the beforeinstallprompt listener before React mounts — a listener
+ * added later never sees an event that already fired) and InstallAppBanner
+ * (which reads the captured event lazily).
+ */
+
+type BeforeInstallPromptEvent = Event & {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
+};
+
+let deferredPrompt: BeforeInstallPromptEvent | null = null;
+const listeners = new Set<() => void>();
+
+function notifyListeners(): void {
+  listeners.forEach((listener) => listener());
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('beforeinstallprompt', (event) => {
+    event.preventDefault();
+    deferredPrompt = event as BeforeInstallPromptEvent;
+    notifyListeners();
+  });
+
+  window.addEventListener('appinstalled', () => {
+    deferredPrompt = null;
+    markInstallPromptInstalled();
+    notifyListeners();
+  });
+}
+
+export function getDeferredInstallPrompt(): BeforeInstallPromptEvent | null {
+  return deferredPrompt;
+}
+
+export function clearDeferredInstallPrompt(): void {
+  deferredPrompt = null;
+}
+
+/** Returns an unsubscribe function. Fires when the captured prompt changes. */
+export function onDeferredInstallPromptChange(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function isStandaloneDisplayMode(): boolean {
+  if (typeof window === 'undefined') return false;
+  if (window.matchMedia?.('(display-mode: standalone)').matches) return true;
+  // iOS Safari has no display-mode media query for this; it exposes a
+  // nonstandard flag on navigator instead once launched from the home screen.
+  return (window.navigator as { standalone?: boolean }).standalone === true;
+}
+
+export function isAndroid(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  return /android/i.test(navigator.userAgent);
+}
+
+export function isIosSafari(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  const ua = navigator.userAgent;
+  // iPadOS 13+ reports as "MacIntel" with touch support, not "iPad".
+  const isIos =
+    /iphone|ipad|ipod/i.test(ua) ||
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+  if (!isIos) return false;
+  // Other iOS browsers (Chrome/Firefox/Edge) all run on WebKit but tag their
+  // own UA token. Their "Add to Home Screen" only creates a bookmark that
+  // reopens in that browser — only Safari's produces a true standalone PWA
+  // honoring the manifest, so only Safari gets the suggestion.
+  return !/crios|fxios|edgios|opios/i.test(ua);
+}
+
+const STORAGE_KEY = 'tcp.installPrompt.v1';
+const DISMISS_COOLDOWN_MS = 21 * 24 * 60 * 60 * 1000; // ~3 weeks
+
+type InstallPromptState = {
+  dismissedAt: number | null;
+  installed: boolean;
+};
+
+function readInstallPromptState(): InstallPromptState {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { dismissedAt: null, installed: false };
+    const parsed = JSON.parse(raw) as Partial<InstallPromptState>;
+    return {
+      dismissedAt: typeof parsed.dismissedAt === 'number' ? parsed.dismissedAt : null,
+      installed: parsed.installed === true,
+    };
+  } catch {
+    return { dismissedAt: null, installed: false };
+  }
+}
+
+function writeInstallPromptState(state: InstallPromptState): void {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // Best-effort: private browsing / a full storage quota shouldn't crash the app.
+  }
+}
+
+export function markInstallPromptDismissed(): void {
+  writeInstallPromptState({ ...readInstallPromptState(), dismissedAt: Date.now() });
+}
+
+export function markInstallPromptInstalled(): void {
+  writeInstallPromptState({ dismissedAt: null, installed: true });
+}
+
+/** Gates on "has this user opted out recently / already installed" — callers
+ * still need to check platform (isAndroid + a captured prompt, or isIosSafari). */
+export function isInstallPromptEligible(): boolean {
+  if (isStandaloneDisplayMode()) return false;
+  const state = readInstallPromptState();
+  if (state.installed) return false;
+  return (
+    state.dismissedAt === null || Date.now() - state.dismissedAt >= DISMISS_COOLDOWN_MS
+  );
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -6,6 +6,10 @@ import './index.css';
 import App from './App.tsx';
 import { applyTheme } from '@/app/theme';
 import { Toaster } from '@/components/ui/sonner';
+// Side-effect import: attaches the beforeinstallprompt listener immediately,
+// before React mounts. A listener added later can miss an event that fires
+// during initial load. See InstallAppBanner for the consumer.
+import '@/lib/install-prompt';
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/doc/Version_History.md
+++ b/doc/Version_History.md
@@ -2,6 +2,12 @@
 
 This file tracks notable changes by version.
 
+## 1.7.10-beta-5
+
+- What's new since 1.7.10-beta-4:
+- On mobile, Immaculaterr now suggests adding it to your home screen: a small dismissible banner on Android offers a one-tap install, and on iOS Safari it shows the Share -> Add to Home Screen steps (only Safari can create a true standalone app from the manifest; other iOS browsers can't). It never interrupts — it waits a few seconds before appearing, never shows if you're already using the installed app, and stays away for about three weeks after you dismiss it once.
+- Retinted the dashboard chart's loading skeleton from a white shimmer to a warm amber one so it doesn't clash with the yellow-green backdrop.
+
 ## 1.7.10-beta-4
 
 - What's new since 1.7.10-beta-3:


### PR DESCRIPTION
## Summary

Rolls `develop` into `master`: a small, dismissible banner on mobile suggests installing Immaculaterr to the home screen, without ever blocking the page.

## Changes

- **Android:** captures the browser's native `beforeinstallprompt` event and offers a one-tap Install button that triggers the real install flow.
- **iOS Safari:** there's no equivalent API, so it shows the Share -> Add to Home Screen steps instead. Restricted to actual Safari — other iOS browsers' "add to home screen" only makes a bookmark that reopens in that browser, not a standalone PWA honoring the manifest.
- **Not annoying, by design:** never shows once already running standalone (checked via `display-mode: standalone` and iOS's `navigator.standalone`), waits 4s after mount before appearing, and once dismissed stays quiet for about three weeks (localStorage-tracked) instead of nagging on every visit. Desktop is untouched (`lg:hidden`, plus the platform checks themselves exclude it).
- The existing manifest/icons were already installable — this only adds the UI nudge, no manifest changes.

## How to test

- Rendered the real `InstallAppBanner` component standalone (isolated preview harness, deleted before commit) with mobile UA spoofing:
  - Android UA + a synthetic `beforeinstallprompt` event -> banner renders with Install/Not now, tapping Install calls `.prompt()`.
  - Android UA with no event fired -> renders nothing (safe no-op when Chrome hasn't offered installability).
  - iOS Safari UA -> renders the Share/Add-to-Home-Screen instructions, dismiss-only.
- Confirmed the cooldown: dismissed the banner, reloaded, re-fired the install-prompt event — banner correctly stayed hidden.
- `npm run lint`, `npm run build`, `npm run test` (503 tests) all pass.
- Rebuilt and redeployed the local source container; clean startup, no errors, `/api/updates` reports the new version.

## UI screenshots (if applicable)

Rendered and reviewed for both platforms during development; not attached here.

## Checklist

- [x] I tested this change locally (or in Docker).
- [x] I added/updated docs where needed.
- [x] I kept this PR focused (no unrelated changes).