### PR TITLE
chore: bump version to 1.7.10

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -3038,7 +3038,7 @@
           },
           "version": {
             "type": "string",
-            "example": "1.7.10-beta-3"
+            "example": "1.7.10"
           },
           "buildSha": {
             "type": "object",
@@ -3164,11 +3164,11 @@
         "properties": {
           "currentVersion": {
             "type": "string",
-            "example": "1.7.10-beta-3"
+            "example": "1.7.10"
           },
           "latestVersion": {
             "type": "object",
-            "example": "1.7.10-beta-3",
+            "example": "1.7.10",
             "nullable": true
           },
           "updateAvailable": {
@@ -3186,7 +3186,7 @@
           },
           "latestUrl": {
             "type": "object",
-            "example": "https://github.com/ohmz/Immaculaterr/releases/tag/v1.7.10-beta-3",
+            "example": "https://github.com/ohmz/Immaculaterr/releases/tag/v1.7.10",
             "nullable": true
           },
           "checkedAt": {

--- a/apps/api/src/version.ts
+++ b/apps/api/src/version.ts
@@ -1,6 +1,6 @@
 // Single source of truth for the app version.
 // Bump this constant only.
 
-export const APP_VERSION = '1.7.10-beta-5' as const;
+export const APP_VERSION = '1.7.10' as const;
 
 export const APP_VERSION_TAG = `v${APP_VERSION}` as const;

--- a/apps/web/src/api/generated.ts
+++ b/apps/web/src/api/generated.ts
@@ -1793,7 +1793,7 @@ export interface components {
         AppMetaResponseDto: {
             /** @example immaculaterr */
             name: string;
-            /** @example 1.7.10-beta-3 */
+            /** @example 1.7.10 */
             version: string;
             /** @example 41fb2cb */
             buildSha: Record<string, never> | null;
@@ -1827,9 +1827,9 @@ export interface components {
         UpdateProfileDto: Record<string, never>;
         ReorderProfilesDto: Record<string, never>;
         UpdatesResponseDto: {
-            /** @example 1.7.10-beta-3 */
+            /** @example 1.7.10 */
             currentVersion: string;
-            /** @example 1.7.10-beta-3 */
+            /** @example 1.7.10 */
             latestVersion: Record<string, never> | null;
             /** @example true */
             updateAvailable: boolean;
@@ -1837,7 +1837,7 @@ export interface components {
             source: string;
             /** @example ohmz/Immaculaterr */
             repo: Record<string, never> | null;
-            /** @example https://github.com/ohmz/Immaculaterr/releases/tag/v1.7.10-beta-3 */
+            /** @example https://github.com/ohmz/Immaculaterr/releases/tag/v1.7.10 */
             latestUrl: Record<string, never> | null;
             /** @example 2026-01-09T16:05:00.000Z */
             checkedAt: string;

--- a/apps/web/src/lib/version-history.ts
+++ b/apps/web/src/lib/version-history.ts
@@ -37,12 +37,14 @@ export function splitVersionHistoryLabel(
 
 export const VERSION_HISTORY_ENTRIES: VersionHistoryEntry[] = [
   {
-    version: '1.7.10-beta-3',
+    version: '1.7.10',
     popupHighlights: [
       'Cutting Room: a new page that finds and prunes the media nobody will ever watch, with dry runs and one-click restore.',
       'Large Files: swap oversized movies and episodes for smaller copies automatically.',
       'Tautulli: an optional integration with its own setup step and Vault card.',
       'Safer automation: Confirm Monitored waits for a verified file, and repeat Plex watches stop rebuilding the same collections.',
+      'Fixed repeated TMDB connectivity failures on networks with broken IPv6 routing (notably Unraid).',
+      'On mobile, Immaculaterr now suggests adding itself to your home screen.',
     ],
     sections: [
       {

--- a/apps/web/src/pages/VersionHistoryPage.tsx
+++ b/apps/web/src/pages/VersionHistoryPage.tsx
@@ -17,7 +17,7 @@ export function VersionHistoryPage() {
   const titleIconGlowControls = useAnimation();
   const location = useLocation();
 
-  // Deep-link support: /version-history#v-1.7.10-beta-3 scrolls to that release.
+  // Deep-link support: /version-history#v-1.7.10 scrolls to that release.
   useEffect(() => {
     const hash = location.hash.replace(/^#/, '');
     if (!hash) return;

--- a/doc/Version_History.md
+++ b/doc/Version_History.md
@@ -2,9 +2,9 @@
 
 This file tracks notable changes by version.
 
-## 1.7.10-beta-5
+## 1.7.10
 
-- What's new since 1.7.10-beta-4:
+- What's new in 1.7.10:
 - On mobile, Immaculaterr now suggests adding it to your home screen: a small dismissible banner on Android offers a one-tap install, and on iOS Safari it shows the Share -> Add to Home Screen steps (only Safari can create a true standalone app from the manifest; other iOS browsers can't). It never interrupts — it waits a few seconds before appearing, never shows if you're already using the installed app, and stays away for about three weeks after you dismiss it once.
 - Retinted the dashboard chart's loading skeleton from a white shimmer to a warm amber one so it doesn't clash with the yellow-green backdrop.
 

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "10300",
+  "message": "10301",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "10298",
+  "message": "10300",
   "color": "blue"
 }

--- a/doc/assets/badges/ghcr-package-downloads.json
+++ b/doc/assets/badges/ghcr-package-downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "GHCR downloads",
-  "message": "10290",
+  "message": "10298",
   "color": "blue"
 }


### PR DESCRIPTION
## Summary

Rolls `develop` into `master`: promotes the 1.7.10 beta cycle to a final release. This is a non-beta version, so the publish workflow will move the `:latest` tag to this build.

## Changes

- `apps/api/src/version.ts`: drop the `-beta-5` suffix.
- `doc/Version_History.md`: rename the latest beta entry's heading to `1.7.10` (the granular `beta-1`..`beta-5` entries below stay as-is — same pattern as every prior beta-to-final promotion in this file).
- `apps/web/src/lib/version-history.ts`: rename the `beta-3` popup entry (the last one that had one — `beta-4`/`beta-5` were fix-only and skipped the in-app popup, matching the existing selective convention) to `1.7.10`, and fold in the `beta-4` TMDB/IPv6 connectivity fix and the `beta-5` mobile install suggestion so the What's New popup for anyone jumping straight from `1.7.9` doesn't silently omit them.
- Regenerated `openapi.json` and the web app's generated API types so their example version strings stop reading `1.7.10-beta-3`.
- Updated a stale deep-link comment in `VersionHistoryPage.tsx`.

## How to test

- `npm run lint`, `npm run build`, `npm run test` (503 tests), `npm run security:check:ajv`, `npm run security:audit:prod`, `npm run test:workflow:publish`, `npm run test:workflow:ci` all pass.
- Rebuilt and redeployed the local source container; `/api/updates` reports `currentVersion: "1.7.10"`, clean startup.

## UI screenshots (if applicable)

- n/a — version/changelog bump only.

## Checklist

- [x] I tested this change locally (or in Docker).
- [x] I added/updated docs where needed.
- [x] I kept this PR focused (no unrelated changes).